### PR TITLE
new options in 'setup' action : use a local path as source of the col…

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,6 +9,16 @@ app:
     opts:
       is_expand: false
 workflows:
+  delete-stepman-dir:
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -v
+            set -e
+            rm -rf ~/.stepman
+
   create-release:
     steps:
     - script:

--- a/cli/activate.go
+++ b/cli/activate.go
@@ -93,7 +93,7 @@ func activate(c *cli.Context) {
 		}
 	}
 
-	if err = stepman.RunCopyDir(srcFolder+"/", destFolder); err != nil {
+	if err = stepman.RunCopyDir(srcFolder+"/", destFolder, true); err != nil {
 		log.Fatalln("[STEPMAN] - Failed to copy step:", err)
 	}
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -11,6 +11,8 @@ var (
 			Action:    setup,
 			Flags: []cli.Flag{
 				flCollection,
+				flLocalCollection,
+				flCopySpecJSON,
 			},
 		},
 		{

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -16,6 +16,10 @@ const (
 	// CollectionKey ...
 	CollectionKey      string = "collection"
 	collectionKeyShort string = "c"
+	// LocalCollectionKey ...
+	LocalCollectionKey string = "local"
+	// CopySpecJSONKey ...
+	CopySpecJSONKey string = "copy-spec-json"
 
 	// DebugEnvKey ...
 	DebugEnvKey string = "STEPMAN_DEBUG"
@@ -68,6 +72,14 @@ var (
 		Name:   CollectionKey + ", " + collectionKeyShort,
 		Usage:  "Collection of step.",
 		EnvVar: CollectionPathEnvKey,
+	}
+	flLocalCollection = cli.BoolFlag{
+		Name:  LocalCollectionKey,
+		Usage: "Allow the --collection to be a local path.",
+	}
+	flCopySpecJSON = cli.StringFlag{
+		Name:  CopySpecJSONKey,
+		Usage: "If setup succeeds copy the generates spec.json to this path.",
 	}
 	flID = cli.StringFlag{
 		Name:  IDKey + ", " + idKeyShort,

--- a/stepman/run.go
+++ b/stepman/run.go
@@ -3,6 +3,7 @@ package stepman
 import (
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // RunCopyFile ...
@@ -12,9 +13,12 @@ func RunCopyFile(src, dst string) error {
 }
 
 // RunCopyDir ...
-func RunCopyDir(src, dst string) error {
+func RunCopyDir(src, dst string, isOnlyContent bool) error {
+	if isOnlyContent && !strings.HasSuffix(src, "/") {
+		src = src + "/"
+	}
 	args := []string{"-r", src, dst}
-	return RunCommand("cp", args...)
+	return RunCommand("rsync", args...)
 }
 
 // RunCommand ...


### PR DESCRIPTION
…lection + optionally specify a spec.json path, to copy the successfully generated spec.json to