### PR TITLE
Fix/validate collection aliases

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -144,20 +144,6 @@ workflows:
       Used fot bitrise-io.
       Git clone stepman, cd to stepman GOPATH, install testing tools, install envman.
     steps:
-    - git-clone:
-        title: Git Clone bitrise
-        inputs:
-        - clone_into_dir: $STEPMAN_PATH
-    - script:
-        title: cd to stepman go path
-        run_if: .IsCI
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -e
-            set -v
-
-            envman add --key BITRISE_SOURCE_DIR --value $STEPMAN_PATH
     - script:
         title: Install required testing tools
         run_if: .IsCI
@@ -167,8 +153,6 @@ workflows:
             set -e
             set -v
 
-            brew update
-
             # Install dependencies
             go get -u github.com/tools/godep
 
@@ -177,17 +161,6 @@ workflows:
 
             # Go lint
             go get -u github.com/golang/lint/golint
-    - script:
-        title: Install envman
-        run_if: .IsCI
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -e
-            set -v
-
-            curl -fL https://github.com/bitrise-io/envman/releases/download/0.9.9/envman-$(uname -s)-$(uname -m) > /usr/local/bin/envman
-            chmod +x /usr/local/bin/envman
 
   test_and_install:
     description: |-
@@ -383,4 +356,4 @@ workflows:
             #!/bin/bash
             set -v
             set -e
-            stepman steup -c ${DEFAULT_STEPLIB_GIT}
+            stepman setup -c ${DEFAULT_STEPLIB_GIT}

--- a/cli/delete_collection.go
+++ b/cli/delete_collection.go
@@ -17,7 +17,11 @@ func deleteCollection(c *cli.Context) {
 
 	route, found := stepman.ReadRoute(collectionURI)
 	if !found {
-		log.Warn("No route found for lib: " + collectionURI)
+		log.Warnf("No route found for collection: %s, cleaning up routing..", collectionURI)
+		if err := stepman.CleanupDanglingLib(collectionURI); err != nil {
+			log.Errorf("Error cleaning up lib: %s", collectionURI)
+		}
+		log.Infof("Call 'stepman setup -c %s' for a clean setup", collectionURI)
 		return
 	}
 

--- a/cli/update.go
+++ b/cli/update.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/bitrise-io/go-utils/cmdex"
@@ -14,7 +15,8 @@ import (
 func updateCollection(steplibSource string) (models.StepCollectionModel, error) {
 	route, found := stepman.ReadRoute(steplibSource)
 	if !found {
-		return models.StepCollectionModel{}, errors.New("No route found for lib: " + steplibSource)
+		return models.StepCollectionModel{},
+			fmt.Errorf("No collection found for lib, call 'stepman delete -c %s' for cleanup", steplibSource)
 	}
 
 	pth := stepman.GetCollectionBaseDirPath(route)

--- a/stepman/paths.go
+++ b/stepman/paths.go
@@ -36,6 +36,15 @@ type SteplibRoutes []SteplibRoute
 func (routes SteplibRoutes) GetRoute(URI string) (route SteplibRoute, found bool) {
 	for _, route := range routes {
 		if route.SteplibURI == URI {
+			pth := path.Join(GetCollectionsDirPath(), route.FolderAlias)
+			exist, err := pathutil.IsPathExists(pth)
+			if err != nil {
+				log.Warnf("Failed to read path %s", pth)
+				return SteplibRoute{}, false
+			} else if !exist {
+				log.Warnf("Failed to read path %s", pth)
+				return SteplibRoute{}, false
+			}
 			return route, true
 		}
 	}
@@ -74,6 +83,15 @@ func CleanupRoute(route SteplibRoute) error {
 		return err
 	}
 	return nil
+}
+
+// CleanupDanglingLib ...
+func CleanupDanglingLib(URI string) error {
+	route := SteplibRoute{
+		SteplibURI:  URI,
+		FolderAlias: "",
+	}
+	return RemoveRoute(route)
 }
 
 // RootExistForCollection ...


### PR DESCRIPTION
Shows a more descriptive error message for the scenario when a user manually clears the local `step_collection` but misses to wipe the related registry from `routing.json`