### PR TITLE
Log - path ref fix

### DIFF
--- a/cli/step_info.go
+++ b/cli/step_info.go
@@ -258,7 +258,7 @@ func stepInfo(c *cli.Context) error {
 		if globalStepInfoPth != "" {
 			globalInfo, found, err := stepman.ParseGlobalStepInfoYML(globalStepInfoPth)
 			if err != nil {
-				return fmt.Errorf("Failed to get step (path:%s) output infos, err: %s", YMLPath, err)
+				return fmt.Errorf("Failed to get step (path:%s) output infos, err: %s", globalStepInfoPth, err)
 			}
 
 			if found {


### PR DESCRIPTION
I guess there's no point in printing `YMLPath` in the `else` case, when we know that it's empty ;)