### PR TITLE
[PLAT-92] Generate step-info.yml for new steps

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -58,8 +58,8 @@ const (
 	GitKey      = "git"
 	gitKeyShort = "g"
 
-	// StepIDKEy ...
-	StepIDKEy      = "stepid"
+	// StepIDKey ...
+	StepIDKey      = "stepid"
 	stepIDKeyShort = "s"
 
 	// ShortKey ...
@@ -126,7 +126,7 @@ var (
 		Usage: "Git clone url of the step repository.",
 	}
 	flStepID = cli.StringFlag{
-		Name:  StepIDKEy + ", " + stepIDKeyShort,
+		Name:  StepIDKey + ", " + stepIDKeyShort,
 		Usage: "ID of the step.",
 	}
 	flFormat = cli.StringFlag{

--- a/cli/share.go
+++ b/cli/share.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/bitrise-io/colorstring"
 	"github.com/bitrise-io/go-utils/command"
@@ -184,5 +184,5 @@ func share(c *cli.Context) {
 }
 
 func getShareFilePath() string {
-	return path.Join(stepman.GetStepmanDirPath(), ShareFilename)
+	return filepath.Join(stepman.GetStepmanDirPath(), ShareFilename)
 }

--- a/cli/share_create.go
+++ b/cli/share_create.go
@@ -54,7 +54,7 @@ func validateTag(tag string) error {
 	return nil
 }
 
-func createDefaultStepGroupSpec(stepDirInSteplib string) error {
+func createDefaultStepGroupSpec(route stepman.SteplibRoute, id string) error {
 	model := models.StepGroupInfoModel{}
 	model.Maintainer = "community"
 
@@ -63,7 +63,7 @@ func createDefaultStepGroupSpec(stepDirInSteplib string) error {
 		return err
 	}
 
-	pth := path.Join(stepDirInSteplib, "step-info.yml")
+	pth := stepman.GetStepGlobalInfoPath(route, id)
 	return fileutil.WriteBytesToFile(pth, marshalled)
 }
 
@@ -128,11 +128,6 @@ func create(c *cli.Context) error {
 	collection, err := stepman.ParseStepCollection(collectionSpecPath)
 	if err != nil {
 		fail("Failed to read step spec, error: %s", err)
-	}
-	if !collection.IsAnyStepVersionExist(stepID) {
-		if err := createDefaultStepGroupSpec(stepDirInSteplib); err != nil {
-			fail("Failed to create step group spec for new step: %s", err)
-		}
 	}
 
 	// Clone Step to tmp dir
@@ -244,6 +239,12 @@ func create(c *cli.Context) error {
 	}
 	if err := fileutil.WriteBytesToFile(stepYMLPathInSteplib, stepBytes); err != nil {
 		fail("Failed to write Step to file, err: %s", err)
+	}
+
+	if !collection.IsAnyStepVersionExist(stepID) {
+		if err := createDefaultStepGroupSpec(route, stepID); err != nil {
+			fail("Failed to create step group spec for new step: %s", err)
+		}
 	}
 
 	log.Printf("your Step (%s@%s) has been added to the local StepLib (%s).", share.StepID, share.StepTag, stepDirInSteplib)

--- a/cli/share_create.go
+++ b/cli/share_create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -55,9 +56,9 @@ func validateTag(tag string) error {
 }
 
 func getDefaultStepGroupSpec() models.StepGroupInfoModel {
-	model := models.StepGroupInfoModel{}
-	model.Maintainer = "community"
-	return model
+	return models.StepGroupInfoModel{
+		Maintainer: "community",
+	}
 }
 
 func createDefaultStepGroupSpec(route stepman.SteplibRoute, id string) error {
@@ -87,7 +88,7 @@ func create(c *cli.Context) error {
 	share, err := ReadShareSteplibFromFile()
 	if err != nil {
 		log.Errorf(err.Error())
-		fail("You have to start sharing with `stepman share start`, or you can read instructions with `stepman share`")
+		fail("You need to start sharing with `stepman share start`, you can read instructions with `stepman share`")
 	}
 
 	// Input validation
@@ -119,7 +120,7 @@ func create(c *cli.Context) error {
 	}
 
 	stepDirInSteplib := stepman.GetStepCollectionDirPath(route, stepID, tag)
-	stepYMLPathInSteplib := path.Join(stepDirInSteplib, "step.yml")
+	stepYMLPathInSteplib := filepath.Join(stepDirInSteplib, "step.yml")
 	if exist, err := pathutil.IsPathExists(stepYMLPathInSteplib); err != nil {
 		fail("Failed to check step.yml path in steplib, err: %s", err)
 	} else if exist {
@@ -160,7 +161,7 @@ func create(c *cli.Context) error {
 	}
 
 	// Update step.yml
-	tmpStepYMLPath := path.Join(tmp, "step.yml")
+	tmpStepYMLPath := filepath.Join(tmp, "step.yml")
 	bytes, err := fileutil.ReadBytesFromFile(tmpStepYMLPath)
 	if err != nil {
 		fail("Failed to read Step from file, err: %s", err)

--- a/cli/share_create.go
+++ b/cli/share_create.go
@@ -54,11 +54,14 @@ func validateTag(tag string) error {
 	return nil
 }
 
-func createDefaultStepGroupSpec(route stepman.SteplibRoute, id string) error {
+func getDefaultStepGroupSpec() models.StepGroupInfoModel {
 	model := models.StepGroupInfoModel{}
 	model.Maintainer = "community"
+	return model
+}
 
-	marshalled, err := yaml.Marshal(model)
+func createDefaultStepGroupSpec(route stepman.SteplibRoute, id string) error {
+	marshalled, err := yaml.Marshal(getDefaultStepGroupSpec())
 	if err != nil {
 		return err
 	}

--- a/cli/share_create_test.go
+++ b/cli/share_create_test.go
@@ -1,6 +1,11 @@
 package cli
 
-import "testing"
+import (
+	"github.com/bitrise-io/stepman/models"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestValidateTag(t *testing.T) {
 	cases := []struct {
@@ -15,9 +20,19 @@ func TestValidateTag(t *testing.T) {
 	for _, tc := range cases {
 		got := validateTag(tc.tag)
 		valid := got == nil
-
-		if valid != tc.valid {
-			t.Errorf("validateTag(%s) == nil should be %t but got %s", tc.tag, tc.valid, got)
-		}
+		assert.Equal(t, tc.valid, valid, "validateTag(%s) == nil should be %t but got %s", tc.tag, tc.valid, got)
 	}
+}
+
+func TestGetDefaultStepGroupSpec(t *testing.T) {
+	// Given
+	expected := models.StepGroupInfoModel{
+		Maintainer: "community",
+	}
+
+	// When
+	actual := getDefaultStepGroupSpec()
+
+	// Then
+	assert.Equal(t, expected, actual)
 }

--- a/cli/share_finish.go
+++ b/cli/share_finish.go
@@ -68,7 +68,7 @@ func finish(c *cli.Context) error {
 	if exists, err := pathutil.IsPathExists(stepInfoYMLPathInSteplib); err == nil {
 		if exists && strings.Contains(gitstatus, path.Base(stepInfoYMLPathInSteplib)) {
 			log.Printf("new step-info.yml: %s", stepInfoYMLPathInSteplib)
-			if err := repo.Add(stepYMLPathInSteplib).Run(); err != nil {
+			if err := repo.Add(stepInfoYMLPathInSteplib).Run(); err != nil {
 				fail(err.Error())
 			}
 		}

--- a/cli/share_finish.go
+++ b/cli/share_finish.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/bitrise-io/colorstring"
@@ -58,7 +59,7 @@ func finish(c *cli.Context) error {
 	}
 
 	stepDirInSteplib := stepman.GetStepCollectionDirPath(route, share.StepID, share.StepTag)
-	stepYMLPathInSteplib := path.Join(stepDirInSteplib, "step.yml")
+	stepYMLPathInSteplib := filepath.Join(stepDirInSteplib, "step.yml")
 	log.Printf("new step.yml: %s", stepYMLPathInSteplib)
 	if err := repo.Add(stepYMLPathInSteplib).Run(); err != nil {
 		fail(err.Error())

--- a/cli/share_finish.go
+++ b/cli/share_finish.go
@@ -58,7 +58,7 @@ func finish(c *cli.Context) error {
 	}
 
 	stepDirInSteplib := stepman.GetStepCollectionDirPath(route, share.StepID, share.StepTag)
-	stepYMLPathInSteplib := path.Join(stepDirInSteplib, "/step.yml")
+	stepYMLPathInSteplib := path.Join(stepDirInSteplib, "step.yml")
 	log.Printf("new step.yml: %s", stepYMLPathInSteplib)
 	if err := repo.Add(stepYMLPathInSteplib).Run(); err != nil {
 		fail(err.Error())

--- a/cli/share_finish.go
+++ b/cli/share_finish.go
@@ -46,7 +46,7 @@ func finish(c *cli.Context) error {
 		fail(err.Error())
 	}
 
-	gitstatus, err := repo.Status("--porcelain").RunAndReturnTrimmedCombinedOutput()
+	gitstatus, err := repo.Status("-u", "--porcelain").RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		fail(err.Error())
 	}

--- a/cli/share_start.go
+++ b/cli/share_start.go
@@ -95,7 +95,7 @@ func start(c *cli.Context) error {
 		fail("Failed to setup step spec (url: %s) version (%s), error: %s", collectionURI, pth, err)
 	}
 
-	specPth := pth + "/steplib.yml"
+	specPth := stepman.GetStepCollectionSpecPath(route)
 	collection, err := stepman.ParseStepCollection(specPth)
 	if err != nil {
 		fail("Failed to read step spec, error: %s", err)

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -252,6 +252,12 @@ func (collection StepCollectionModel) IsStepExist(id, version string) bool {
 	return (stepFound && versionFound)
 }
 
+func (collection StepCollectionModel) IsAnyStepVersionExist(id string) bool {
+	stepHash := collection.Steps
+	_, found := stepHash[id]
+	return found
+}
+
 // GetStep ...
 func (collection StepCollectionModel) GetStep(id, version string) (StepModel, bool, bool) {
 	stepVer, isStepFound, isVersionFound := collection.GetStepVersion(id, version)

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -252,12 +252,6 @@ func (collection StepCollectionModel) IsStepExist(id, version string) bool {
 	return (stepFound && versionFound)
 }
 
-func (collection StepCollectionModel) IsAnyStepVersionExist(id string) bool {
-	stepHash := collection.Steps
-	_, found := stepHash[id]
-	return found
-}
-
 // GetStep ...
 func (collection StepCollectionModel) GetStep(id, version string) (StepModel, bool, bool) {
 	stepVer, isStepFound, isVersionFound := collection.GetStepVersion(id, version)

--- a/stepman/paths.go
+++ b/stepman/paths.go
@@ -200,6 +200,8 @@ func GetLibraryBaseDirPath(route SteplibRoute) string {
 	return path.Join(GetCollectionsDirPath(), route.FolderAlias, "collection")
 }
 
+// GetStepCollectionSpecPath ...
+// Location of steplib.yml of the collection marked by this route
 func GetStepCollectionSpecPath(route SteplibRoute) string {
 	return path.Join(GetLibraryBaseDirPath(route), "steplib.yml")
 }

--- a/stepman/paths.go
+++ b/stepman/paths.go
@@ -200,6 +200,10 @@ func GetLibraryBaseDirPath(route SteplibRoute) string {
 	return path.Join(GetCollectionsDirPath(), route.FolderAlias, "collection")
 }
 
+func GetStepCollectionSpecPath(route SteplibRoute) string {
+	return path.Join(GetLibraryBaseDirPath(route), "steplib.yml")
+}
+
 // GetAllStepCollectionPath ...
 func GetAllStepCollectionPath() []string {
 	routes, err := readRouteMap()

--- a/stepman/paths.go
+++ b/stepman/paths.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -36,7 +36,7 @@ type SteplibRoutes []SteplibRoute
 func (routes SteplibRoutes) GetRoute(URI string) (route SteplibRoute, found bool) {
 	for _, route := range routes {
 		if route.SteplibURI == URI {
-			pth := path.Join(GetCollectionsDirPath(), route.FolderAlias)
+			pth := filepath.Join(GetCollectionsDirPath(), route.FolderAlias)
 			exist, err := pathutil.IsPathExists(pth)
 			if err != nil {
 				log.Warnf("Failed to read path %s", pth)
@@ -75,7 +75,7 @@ func (routes SteplibRoutes) writeToFile() error {
 
 // CleanupRoute ...
 func CleanupRoute(route SteplibRoute) error {
-	pth := path.Join(GetCollectionsDirPath(), route.FolderAlias)
+	pth := filepath.Join(GetCollectionsDirPath(), route.FolderAlias)
 	if err := command.RemoveDir(pth); err != nil {
 		return err
 	}
@@ -182,28 +182,28 @@ func CreateStepManDirIfNeeded() error {
 
 // GetStepSpecPath ...
 func GetStepSpecPath(route SteplibRoute) string {
-	return path.Join(GetCollectionsDirPath(), route.FolderAlias, "spec", "spec.json")
+	return filepath.Join(GetCollectionsDirPath(), route.FolderAlias, "spec", "spec.json")
 }
 
 // GetSlimStepSpecPath ...
 func GetSlimStepSpecPath(route SteplibRoute) string {
-	return path.Join(GetCollectionsDirPath(), route.FolderAlias, "spec", "slim-spec.json")
+	return filepath.Join(GetCollectionsDirPath(), route.FolderAlias, "spec", "slim-spec.json")
 }
 
 // GetCacheBaseDir ...
 func GetCacheBaseDir(route SteplibRoute) string {
-	return path.Join(GetCollectionsDirPath(), route.FolderAlias, "cache")
+	return filepath.Join(GetCollectionsDirPath(), route.FolderAlias, "cache")
 }
 
 // GetLibraryBaseDirPath ...
 func GetLibraryBaseDirPath(route SteplibRoute) string {
-	return path.Join(GetCollectionsDirPath(), route.FolderAlias, "collection")
+	return filepath.Join(GetCollectionsDirPath(), route.FolderAlias, "collection")
 }
 
 // GetStepCollectionSpecPath ...
 // Location of steplib.yml of the collection marked by this route
 func GetStepCollectionSpecPath(route SteplibRoute) string {
-	return path.Join(GetLibraryBaseDirPath(route), "steplib.yml")
+	return filepath.Join(GetLibraryBaseDirPath(route), "steplib.yml")
 }
 
 // GetAllStepCollectionPath ...
@@ -225,30 +225,30 @@ func GetAllStepCollectionPath() []string {
 // GetStepCacheDirPath ...
 // Step's Cache dir path, where it's code lives.
 func GetStepCacheDirPath(route SteplibRoute, id, version string) string {
-	return path.Join(GetCacheBaseDir(route), id, version)
+	return filepath.Join(GetCacheBaseDir(route), id, version)
 }
 
 // GetStepGlobalInfoPath ...
 func GetStepGlobalInfoPath(route SteplibRoute, id string) string {
-	return path.Join(GetLibraryBaseDirPath(route), "steps", id, "step-info.yml")
+	return filepath.Join(GetLibraryBaseDirPath(route), "steps", id, "step-info.yml")
 }
 
 // GetStepCollectionDirPath ...
 // Step's Collection dir path, where it's spec (step.yml) lives.
 func GetStepCollectionDirPath(route SteplibRoute, id, version string) string {
-	return path.Join(GetLibraryBaseDirPath(route), "steps", id, version)
+	return filepath.Join(GetLibraryBaseDirPath(route), "steps", id, version)
 }
 
 // GetStepmanDirPath ...
 func GetStepmanDirPath() string {
-	return path.Join(pathutil.UserHomeDir(), StepmanDirname)
+	return filepath.Join(pathutil.UserHomeDir(), StepmanDirname)
 }
 
 // GetCollectionsDirPath ...
 func GetCollectionsDirPath() string {
-	return path.Join(GetStepmanDirPath(), CollectionsDirname)
+	return filepath.Join(GetStepmanDirPath(), CollectionsDirname)
 }
 
 func getRoutingFilePath() string {
-	return path.Join(GetStepmanDirPath(), RoutingFilename)
+	return filepath.Join(GetStepmanDirPath(), RoutingFilename)
 }

--- a/stepman/paths.go
+++ b/stepman/paths.go
@@ -200,8 +200,7 @@ func GetLibraryBaseDirPath(route SteplibRoute) string {
 	return filepath.Join(GetCollectionsDirPath(), route.FolderAlias, "collection")
 }
 
-// GetStepCollectionSpecPath ...
-// Location of steplib.yml of the collection marked by this route
+// GetStepCollectionSpecPath Location of steplib.yml of the collection marked by this route
 func GetStepCollectionSpecPath(route SteplibRoute) string {
 	return filepath.Join(GetLibraryBaseDirPath(route), "steplib.yml")
 }

--- a/stepman/paths_test.go
+++ b/stepman/paths_test.go
@@ -36,7 +36,7 @@ func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testi
 	actual := GetStepmanDirPath()
 
 	// Then
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func Test_GivenStepmanDir_WhenGetCollectionDirPathCalled_ThenGoodPathReturned(t *testing.T) {
@@ -52,7 +52,7 @@ func Test_GivenStepmanDir_WhenGetCollectionDirPathCalled_ThenGoodPathReturned(t 
 	actual := GetCollectionsDirPath()
 
 	// Then
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func Test_GivenRoute_WhenGetLibraryBaseDirPathCalled_ThenGoodPathReturned(t *testing.T) {

--- a/stepman/paths_test.go
+++ b/stepman/paths_test.go
@@ -2,6 +2,7 @@ package stepman
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"path"
 	"testing"
@@ -24,7 +25,8 @@ func GivenRoute() SteplibRoute {
 
 func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
-	os.Setenv("HOME", GivenHomePath)
+	err := os.Setenv("HOME", GivenHomePath)
+	require.NoError(t, err)
 	expected := path.Join(GivenHomePath, ".stepman")
 
 	// When
@@ -36,7 +38,8 @@ func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testi
 
 func Test_GivenStepmanDir_WhenGetCollectionDirPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
-	os.Setenv("HOME", GivenHomePath)
+	err := os.Setenv("HOME", GivenHomePath)
+	require.NoError(t, err)
 	expected := path.Join(GetStepmanDirPath(), "step_collections")
 
 	// When

--- a/stepman/paths_test.go
+++ b/stepman/paths_test.go
@@ -9,25 +9,25 @@ import (
 )
 
 const (
-	GivenSteplibURI  = "https://github.com/bitrise-io/steplib"
-	GivenFolderAlias = "12334556"
-	GivenHomePath    = "/usr/testeruser/"
-	GivenStepID      = "test-custom-step"
-	GivenStepVersion = "0.5.6"
+	givenSteplibURI  = "https://github.com/bitrise-io/steplib"
+	givenFolderAlias = "12334556"
+	givenHomePath    = "/usr/testeruser/"
+	givenStepID      = "test-custom-step"
+	givenStepVersion = "0.5.6"
 )
 
 func GivenRoute() SteplibRoute {
 	return SteplibRoute{
-		SteplibURI:  GivenSteplibURI,
-		FolderAlias: GivenFolderAlias,
+		SteplibURI:  givenSteplibURI,
+		FolderAlias: givenFolderAlias,
 	}
 }
 
 func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
-	err := os.Setenv("HOME", GivenHomePath)
+	err := os.Setenv("HOME", givenHomePath)
 	require.NoError(t, err)
-	expected := filepath.Join(GivenHomePath, ".stepman")
+	expected := filepath.Join(givenHomePath, ".stepman")
 
 	// When
 	actual := GetStepmanDirPath()
@@ -38,7 +38,7 @@ func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testi
 
 func Test_GivenStepmanDir_WhenGetCollectionDirPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
-	os.Setenv("HOME", GivenHomePath)
+	os.Setenv("HOME", givenHomePath)
 	// require.NoError(t, err)
 	expected := filepath.Join(GetStepmanDirPath(), "step_collections")
 
@@ -64,8 +64,8 @@ func Test_GivenRoute_WhenGetLibraryBaseDirPathCalled_ThenGoodPathReturned(t *tes
 func Test_GivenRouteAndStepId_WhenGetStepCollectionDirPath_ThenGoodPathReturned(t *testing.T) {
 	// Given
 	route := GivenRoute()
-	step := GivenStepID
-	version := GivenStepVersion
+	step := givenStepID
+	version := givenStepVersion
 	expected := filepath.Join(GetLibraryBaseDirPath(route), "steps", step, version)
 
 	// When
@@ -78,7 +78,7 @@ func Test_GivenRouteAndStepId_WhenGetStepCollectionDirPath_ThenGoodPathReturned(
 func Test_GivenRouteAndStepId_WhenGetStepGlobalInfoPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
 	route := GivenRoute()
-	step := GivenStepID
+	step := givenStepID
 	expected := filepath.Join(GetLibraryBaseDirPath(route), "steps", step, "step-info.yml")
 
 	// When

--- a/stepman/paths_test.go
+++ b/stepman/paths_test.go
@@ -1,0 +1,86 @@
+package stepman
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path"
+	"testing"
+)
+
+const (
+	GivenSteplibUri  = "https://github.com/bitrise-io/steplib"
+	GivenFolderAlias = "12334556"
+	GivenHomePath    = "/usr/testeruser/"
+	GivenStepId      = "test-custom-step"
+	GivenStepVersion = "0.5.6"
+)
+
+func GivenRoute() SteplibRoute {
+	return SteplibRoute{
+		SteplibURI:  GivenSteplibUri,
+		FolderAlias: GivenFolderAlias,
+	}
+}
+
+func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testing.T) {
+	// Given
+	os.Setenv("HOME", GivenHomePath)
+	expected := path.Join(GivenHomePath, ".stepman")
+
+	// When
+	actual := GetStepmanDirPath()
+
+	// Then
+	assert.Equal(t, actual, expected)
+}
+
+func Test_GivenStepmanDir_WhenGetCollectionDirPathCalled_ThenGoodPathReturned(t *testing.T) {
+	// Given
+	os.Setenv("HOME", GivenHomePath)
+	expected := path.Join(GetStepmanDirPath(), "step_collections")
+
+	// When
+	actual := GetCollectionsDirPath()
+
+	// Then
+	assert.Equal(t, actual, expected)
+}
+
+func Test_GivenRoute_WhenGetLibraryBaseDirPathCalled_ThenGoodPathReturned(t *testing.T) {
+	// Given
+	route := GivenRoute()
+	expected := path.Join(GetCollectionsDirPath(), route.FolderAlias, "collection")
+
+	// When
+	actual := GetLibraryBaseDirPath(route)
+
+	// Then
+	assert.Equal(t, expected, actual)
+}
+
+func Test_GivenRouteAndStepId_WhenGetStepCollectionDirPath_ThenGoodPathReturned(t *testing.T) {
+	// Given
+	route := GivenRoute()
+	step := GivenStepId
+	version := GivenStepVersion
+	expected := path.Join(GetLibraryBaseDirPath(route), "steps", step, version)
+
+	// When
+	actual := GetStepCollectionDirPath(route, step, version)
+
+	// Then
+	assert.Equal(t, expected, actual)
+}
+
+func Test_GivenRouteAndStepId_WhenGetStepGlobalInfoPathCalled_ThenGoodPathReturned(t *testing.T) {
+	// Given
+	route := GivenRoute()
+	step := GivenStepId
+	expected := path.Join(GetLibraryBaseDirPath(route), "steps", step, "step-info.yml")
+
+	// When
+	actual := GetStepGlobalInfoPath(route, step)
+
+	// Then
+	assert.Equal(t, expected, actual)
+}

--- a/stepman/paths_test.go
+++ b/stepman/paths_test.go
@@ -27,7 +27,10 @@ func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testi
 	// Given
 	oldhome := os.Getenv("HOME")
 	err := os.Setenv("HOME", givenHomePath)
-	defer os.Setenv("HOME", oldhome)
+	defer func() {
+		err := os.Setenv("HOME", oldhome)
+		require.NoError(t, err)
+	}()
 	require.NoError(t, err)
 
 	expected := filepath.Join(givenHomePath, ".stepman")
@@ -43,7 +46,10 @@ func Test_GivenStepmanDir_WhenGetCollectionDirPathCalled_ThenGoodPathReturned(t 
 	// Given
 	oldhome := os.Getenv("HOME")
 	err := os.Setenv("HOME", givenHomePath)
-	defer os.Setenv("HOME", oldhome)
+	defer func() {
+		err := os.Setenv("HOME", oldhome)
+		require.NoError(t, err)
+	}()
 	require.NoError(t, err)
 
 	expected := filepath.Join(GetStepmanDirPath(), "step_collections")

--- a/stepman/paths_test.go
+++ b/stepman/paths_test.go
@@ -25,8 +25,11 @@ func GivenRoute() SteplibRoute {
 
 func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
+	oldhome := os.Getenv("HOME")
 	err := os.Setenv("HOME", givenHomePath)
+	defer os.Setenv("HOME", oldhome)
 	require.NoError(t, err)
+
 	expected := filepath.Join(givenHomePath, ".stepman")
 
 	// When
@@ -38,8 +41,11 @@ func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testi
 
 func Test_GivenStepmanDir_WhenGetCollectionDirPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
-	os.Setenv("HOME", givenHomePath)
-	// require.NoError(t, err)
+	oldhome := os.Getenv("HOME")
+	err := os.Setenv("HOME", givenHomePath)
+	defer os.Setenv("HOME", oldhome)
+	require.NoError(t, err)
+
 	expected := filepath.Join(GetStepmanDirPath(), "step_collections")
 
 	// When

--- a/stepman/paths_test.go
+++ b/stepman/paths_test.go
@@ -8,16 +8,16 @@ import (
 )
 
 const (
-	GivenSteplibUri  = "https://github.com/bitrise-io/steplib"
+	GivenSteplibURI  = "https://github.com/bitrise-io/steplib"
 	GivenFolderAlias = "12334556"
 	GivenHomePath    = "/usr/testeruser/"
-	GivenStepId      = "test-custom-step"
+	GivenStepID      = "test-custom-step"
 	GivenStepVersion = "0.5.6"
 )
 
 func GivenRoute() SteplibRoute {
 	return SteplibRoute{
-		SteplibURI:  GivenSteplibUri,
+		SteplibURI:  GivenSteplibURI,
 		FolderAlias: GivenFolderAlias,
 	}
 }
@@ -61,7 +61,7 @@ func Test_GivenRoute_WhenGetLibraryBaseDirPathCalled_ThenGoodPathReturned(t *tes
 func Test_GivenRouteAndStepId_WhenGetStepCollectionDirPath_ThenGoodPathReturned(t *testing.T) {
 	// Given
 	route := GivenRoute()
-	step := GivenStepId
+	step := GivenStepID
 	version := GivenStepVersion
 	expected := path.Join(GetLibraryBaseDirPath(route), "steps", step, version)
 
@@ -75,7 +75,7 @@ func Test_GivenRouteAndStepId_WhenGetStepCollectionDirPath_ThenGoodPathReturned(
 func Test_GivenRouteAndStepId_WhenGetStepGlobalInfoPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
 	route := GivenRoute()
-	step := GivenStepId
+	step := GivenStepID
 	expected := path.Join(GetLibraryBaseDirPath(route), "steps", step, "step-info.yml")
 
 	// When

--- a/stepman/paths_test.go
+++ b/stepman/paths_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -27,7 +27,7 @@ func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testi
 	// Given
 	err := os.Setenv("HOME", GivenHomePath)
 	require.NoError(t, err)
-	expected := path.Join(GivenHomePath, ".stepman")
+	expected := filepath.Join(GivenHomePath, ".stepman")
 
 	// When
 	actual := GetStepmanDirPath()
@@ -38,9 +38,9 @@ func Test_GivenHomeDir_WhenGetStepmanDirPathCalled_ThenGoodPathReturned(t *testi
 
 func Test_GivenStepmanDir_WhenGetCollectionDirPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
-	err := os.Setenv("HOME", GivenHomePath)
-	require.NoError(t, err)
-	expected := path.Join(GetStepmanDirPath(), "step_collections")
+	os.Setenv("HOME", GivenHomePath)
+	// require.NoError(t, err)
+	expected := filepath.Join(GetStepmanDirPath(), "step_collections")
 
 	// When
 	actual := GetCollectionsDirPath()
@@ -52,7 +52,7 @@ func Test_GivenStepmanDir_WhenGetCollectionDirPathCalled_ThenGoodPathReturned(t 
 func Test_GivenRoute_WhenGetLibraryBaseDirPathCalled_ThenGoodPathReturned(t *testing.T) {
 	// Given
 	route := GivenRoute()
-	expected := path.Join(GetCollectionsDirPath(), route.FolderAlias, "collection")
+	expected := filepath.Join(GetCollectionsDirPath(), route.FolderAlias, "collection")
 
 	// When
 	actual := GetLibraryBaseDirPath(route)
@@ -66,7 +66,7 @@ func Test_GivenRouteAndStepId_WhenGetStepCollectionDirPath_ThenGoodPathReturned(
 	route := GivenRoute()
 	step := GivenStepID
 	version := GivenStepVersion
-	expected := path.Join(GetLibraryBaseDirPath(route), "steps", step, version)
+	expected := filepath.Join(GetLibraryBaseDirPath(route), "steps", step, version)
 
 	// When
 	actual := GetStepCollectionDirPath(route, step, version)
@@ -79,7 +79,7 @@ func Test_GivenRouteAndStepId_WhenGetStepGlobalInfoPathCalled_ThenGoodPathReturn
 	// Given
 	route := GivenRoute()
 	step := GivenStepID
-	expected := path.Join(GetLibraryBaseDirPath(route), "steps", step, "step-info.yml")
+	expected := filepath.Join(GetLibraryBaseDirPath(route), "steps", step, "step-info.yml")
 
 	// When
 	actual := GetStepGlobalInfoPath(route, step)

--- a/stepman/util.go
+++ b/stepman/util.go
@@ -244,7 +244,7 @@ func parseStepCollection(route SteplibRoute, templateCollection models.StepColle
 
 				// Check for assets - STEP_SPEC_DIR/steps/step-id/assets
 				if collection.AssetsDownloadBaseURI != "" {
-					assetsFolderPth := path.Join(stepsCollectionDirPth, stepsDirName, stepID, "assets")
+					assetsFolderPth := filepath.Join(stepsCollectionDirPth, stepsDirName, stepID, "assets")
 					exist, err := pathutil.IsPathExists(assetsFolderPth)
 					if err != nil {
 						return err

--- a/stepman/util.go
+++ b/stepman/util.go
@@ -194,7 +194,7 @@ func addStepVersionToStepGroup(step models.StepModel, version string, stepGroup 
 	return stepGroup, nil
 }
 
-func generateStepLibCollection(route SteplibRoute, templateCollection models.StepCollectionModel) (models.StepCollectionModel, error) {
+func parseStepCollection(route SteplibRoute, templateCollection models.StepCollectionModel) (models.StepCollectionModel, error) {
 	collection := models.StepCollectionModel{
 		FormatVersion:         templateCollection.FormatVersion,
 		GeneratedAtTimeStamp:  time.Now().Unix(),
@@ -301,7 +301,7 @@ func generateStepLibCollection(route SteplibRoute, templateCollection models.Ste
 	return collection, nil
 }
 
-func generateSlimStepLibModel(collection models.StepCollectionModel) models.StepCollectionModel {
+func generateSlimStepModel(collection models.StepCollectionModel) models.StepCollectionModel {
 
 	slimCollection := models.StepCollectionModel{
 		FormatVersion:         collection.FormatVersion,
@@ -343,7 +343,7 @@ func WriteStepSpecToFile(templateCollection models.StepCollectionModel, route St
 		}
 	}
 
-	collection, err := generateStepLibCollection(route, templateCollection)
+	collection, err := parseStepCollection(route, templateCollection)
 	if err != nil {
 		return err
 	}
@@ -358,7 +358,7 @@ func WriteStepSpecToFile(templateCollection models.StepCollectionModel, route St
 	}
 
 	pth = GetSlimStepSpecPath(route)
-	slimCollection := generateSlimStepLibModel(collection)
+	slimCollection := generateSlimStepModel(collection)
 	if err != nil {
 		return err
 	}

--- a/stepman/util.go
+++ b/stepman/util.go
@@ -422,7 +422,7 @@ func ReGenerateLibrarySpec(route SteplibRoute) error {
 		return errors.New("Not initialized")
 	}
 
-	specPth := pth + "/steplib.yml"
+	specPth := GetStepCollectionSpecPath(route)
 	collection, err := ParseStepCollection(specPth)
 	if err != nil {
 		return err

--- a/stepman/util.go
+++ b/stepman/util.go
@@ -194,7 +194,7 @@ func addStepVersionToStepGroup(step models.StepModel, version string, stepGroup 
 	return stepGroup, nil
 }
 
-func generateStepLib(route SteplibRoute, templateCollection models.StepCollectionModel) (models.StepCollectionModel, error) {
+func generateStepLibCollection(route SteplibRoute, templateCollection models.StepCollectionModel) (models.StepCollectionModel, error) {
 	collection := models.StepCollectionModel{
 		FormatVersion:         templateCollection.FormatVersion,
 		GeneratedAtTimeStamp:  time.Now().Unix(),
@@ -205,9 +205,9 @@ func generateStepLib(route SteplibRoute, templateCollection models.StepCollectio
 
 	stepHash := models.StepHash{}
 
-	stepsSpecDirPth := GetLibraryBaseDirPath(route)
-	if err := filepath.Walk(stepsSpecDirPth, func(pth string, f os.FileInfo, err error) error {
-		truncatedPath := strings.Replace(pth, stepsSpecDirPth+"/", "", -1)
+	stepsCollectionDirPth := GetLibraryBaseDirPath(route)
+	if err := filepath.Walk(stepsCollectionDirPth, func(pth string, f os.FileInfo, err error) error {
+		truncatedPath := strings.Replace(pth, stepsCollectionDirPth+"/", "", -1)
 		match, matchErr := regexp.MatchString("([a-z]+).yml", truncatedPath)
 		if matchErr != nil {
 			return matchErr
@@ -228,7 +228,7 @@ func generateStepLib(route SteplibRoute, templateCollection models.StepCollectio
 				stepGroupInfo := models.StepGroupInfoModel{}
 
 				// Check for step-info.yml - STEP_SPEC_DIR/steps/step-id/step-info.yml
-				stepGroupInfoPth := filepath.Join(stepsSpecDirPth, stepsDirName, stepID, "step-info.yml")
+				stepGroupInfoPth := filepath.Join(stepsCollectionDirPth, stepsDirName, stepID, "step-info.yml")
 				if exist, err := pathutil.IsPathExists(stepGroupInfoPth); err != nil {
 					return err
 				} else if exist {
@@ -244,7 +244,7 @@ func generateStepLib(route SteplibRoute, templateCollection models.StepCollectio
 
 				// Check for assets - STEP_SPEC_DIR/steps/step-id/assets
 				if collection.AssetsDownloadBaseURI != "" {
-					assetsFolderPth := path.Join(stepsSpecDirPth, stepsDirName, stepID, "assets")
+					assetsFolderPth := path.Join(stepsCollectionDirPth, stepsDirName, stepID, "assets")
 					exist, err := pathutil.IsPathExists(assetsFolderPth)
 					if err != nil {
 						return err
@@ -301,7 +301,7 @@ func generateStepLib(route SteplibRoute, templateCollection models.StepCollectio
 	return collection, nil
 }
 
-func generateSlimStepLib(collection models.StepCollectionModel) models.StepCollectionModel {
+func generateSlimStepLibModel(collection models.StepCollectionModel) models.StepCollectionModel {
 
 	slimCollection := models.StepCollectionModel{
 		FormatVersion:         collection.FormatVersion,
@@ -343,7 +343,7 @@ func WriteStepSpecToFile(templateCollection models.StepCollectionModel, route St
 		}
 	}
 
-	collection, err := generateStepLib(route, templateCollection)
+	collection, err := generateStepLibCollection(route, templateCollection)
 	if err != nil {
 		return err
 	}
@@ -358,7 +358,7 @@ func WriteStepSpecToFile(templateCollection models.StepCollectionModel, route St
 	}
 
 	pth = GetSlimStepSpecPath(route)
-	slimCollection := generateSlimStepLib(collection)
+	slimCollection := generateSlimStepLibModel(collection)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Context

Jira: https://bitrise.atlassian.net/browse/PLAT-92

We want to generate a `step-info.yml` automatically during sharing to avoid issues and manual work needed.

## Changes

### General

- Renamed some variables/methods in `util.go` to better convey their purpose
- Added tests for `paths.go`

### In create stage

- Fixed grammatical and phrasing issues in logs / status reports
- New method for getting the `step-info.yml` path: `GetStepGlobalInfoPath`
- Check if the step is new by checking the step root (a.k.a. step group) directory
- Create the default `step-info.yml` if the step is new

### In finish stage
- When checking the git status, we should use `-u` to list all changes
- If the `step-info.yml` is added, add it to the commit as well