### PR TITLE
Build For Apple Silicon

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,7 +39,7 @@ workflows:
     title: creates binary for specified platform
     steps:
     - script:
-        title: Create D binary
+        title: Create binary
         inputs:
         - content: |
             #!/bin/bash
@@ -61,7 +61,7 @@ workflows:
             echo "  Copy binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
 
   create-x86-darwin-binary:
-    before_run:
+    after_run:
     - _create-binary
     envs:
     - DESCRIPTION: "x86 Darwin"
@@ -71,7 +71,7 @@ workflows:
     - GOOS: "darwin"
 
   create-arm-darwin-binary:
-    before_run:
+    after_run:
     - _create-binary
     envs:
     - DESCRIPTION: "ARM Darwin"
@@ -81,7 +81,7 @@ workflows:
     - GOOS: "darwin"
 
   create-x86-linux-binary:
-    before_run:
+    after_run:
     - _create-binary
     envs:
     - DESCRIPTION: "x86 Linux"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -35,29 +35,21 @@ workflows:
             export INTEGRATION_TEST_BINARY_PATH="$current_stepman"
             go test -v ./_tests/integration/...
 
-  create-binaries:
-    title: Create binaries
+  _create-binary:
+    title: creates binary for specified platform
     steps:
     - script:
-        title: Create binaries
+        title: Create D binary
         inputs:
         - content: |
             #!/bin/bash
             set -ex
 
-            echo
-            echo "Create final binaries"
+            echo "  Create binary for $DESCRIPTION"
             echo "  Build number: $BITRISE_BUILD_NUMBER"
 
-            export ARCH=x86_64
-            export GOARCH=amd64
-
-            # Create Darwin bin
-            export OS=Darwin
-            export GOOS=darwin
-
             DEPLOY_PATH="_bin/$BIN_NAME-$OS-$ARCH"
-            echo "  Create final Darwin binary at: $DEPLOY_PATH"
+            echo "  Create at: $DEPLOY_PATH"
 
             version_package="github.com/bitrise-io/stepman/version"
 
@@ -65,26 +57,46 @@ workflows:
               -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
               -o "$DEPLOY_PATH"
 
-            envman add --key OSX_DEPLOY_PATH --value $DEPLOY_PATH
             cp $DEPLOY_PATH $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH
-            echo "  Copy final Darwin binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
+            echo "  Copy binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
 
+  create-x86-darwin-binary:
+    before_run:
+    - _create-binary
+    envs:
+    - DESCRIPTION: "x86 Darwin"
+    - ARCH: "x86_64"
+    - GOARCH: "amd64"
+    - OS: "Darwin"
+    - GOOS: "darwin"
 
-            # Create Linux binary
-            export OS=Linux
-            export GOOS=linux
+  create-arm-darwin-binary:
+    before_run:
+    - _create-binary
+    envs:
+    - DESCRIPTION: "ARM Darwin"
+    - ARCH: "arm64"
+    - GOARCH: "amd64"
+    - OS: "Darwin"
+    - GOOS: "darwin"
 
-            DEPLOY_PATH="_bin/$BIN_NAME-$OS-$ARCH"
-            echo "  Create final Linux binary at: $DEPLOY_PATH"
+  create-x86-linux-binary:
+    before_run:
+    - _create-binary
+    envs:
+    - DESCRIPTION: "x86 Linux"
+    - ARCH: "x86_64"
+    - GOARCH: "amd64"
+    - OS: "Linux"
+    - GOOS: "linux"
 
-            go build \
-              -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
-              -o "$DEPLOY_PATH"
-
-            envman add --key LINUX_DEPLOY_PATH --value $DEPLOY_PATH
-            cp $DEPLOY_PATH $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH
-            echo "  Copy final Linux binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
-
+  create-binaries:
+    title: Create binaries
+    before_run:
+    - create-arm-darwin-binary
+    - create-x86-darwin-binary
+    - create-x86-linux-binary
+  
   dep-update:
     title: Dep update
     steps:


### PR DESCRIPTION
Building Stepman and Envman for ARM on Mac are prerequisites to the bitrise cli supporting the new M1 machines.

This PR contains some re-organization of the bitrise.yml to reduce copy-paste, but the actual change is quite small. It simply adds an ARM/Darwin build target to the `create-binaries` workflow.

Please let me know if my changes are not consistent with how `stepman` is typically built and deployed. I had trouble running the bitrise.yml as written. My other branch, [m1_testing](https://github.com/benbitrise/stepman/compare/master...benbitrise:m1_testing?expand=1), includes additional steps (like cloning the repo) that I had to add to get this running in my bitrise account.