### PR TITLE
Enable paths with environment variables for local steps in the offline workflow editor

### DIFF
--- a/_tests/integration/step_info_test.go
+++ b/_tests/integration/step_info_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"strings"
 	"testing"
+	"os"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/stretchr/testify/require"
@@ -43,6 +44,14 @@ func TestStepInfo(t *testing.T) {
 	t.Log("local step --format json")
 	{
 		out, err := command.New(binPath(), "step-info", "--collection", "path", "--id", "./test-step", "--format", "json").RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+		require.Equal(t, localTestStepDefinitionJSON, out)
+	}
+
+	t.Log("local step - environment variable path --format json")
+	{
+		os.Setenv("STEP", ".")
+		out, err := command.New(binPath(), "step-info", "--collection", "path", "--id", "$STEP/test-step", "--format", "json").RunAndReturnTrimmedCombinedOutput()
 		require.NoError(t, err, out)
 		require.Equal(t, localTestStepDefinitionJSON, out)
 	}

--- a/cli/step_info.go
+++ b/cli/step_info.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -162,7 +163,8 @@ func QueryStepInfoFromGit(gitURL, tagOrBranch string) (models.StepInfoModel, err
 }
 
 // QueryStepInfoFromPath returns step info from a local path source
-func QueryStepInfoFromPath(dir string) (models.StepInfoModel, error) {
+func QueryStepInfoFromPath(envdir string) (models.StepInfoModel, error) {
+	dir := os.ExpandEnv(envdir)
 	stepDefinitionPth := filepath.Join(dir, "step.yml")
 	if exist, err := pathutil.IsPathExists(stepDefinitionPth); err != nil {
 		return models.StepInfoModel{}, fmt.Errorf("query local step info: check if step.yml exist: %s", err)


### PR DESCRIPTION
When editing workflows with the offline workflow editor, local steps with paths that have environment variables cannot be found by the stepman tool. The workflow editor fails to load the workflow in that case and displays an error instead.

The workflow editor supports both absolute and relative paths. However, it doesn't support environment variables because the library that executes the stepman command doesn't support them by design. However, when the use case is narrowed down to local Steps that use the `path::` prefix, it makes sense for environment variables to be supported.

This change adds a productivity boost for large teams that use their own Bitrise Steps locally.