### PR TITLE
Update version number

### DIFF
--- a/_tests/integration/version_test.go
+++ b/_tests/integration/version_test.go
@@ -14,7 +14,7 @@ func Test_VersionOutput(t *testing.T) {
 	{
 		out, err := command.RunCommandAndReturnCombinedStdoutAndStderr(binPath(), "version")
 		require.NoError(t, err, out)
-		require.Equal(t, "0.0.0-development", out)
+		require.Equal(t, "0.16.3", out)
 	}
 
 	t.Log("Version --full")

--- a/_tests/integration/version_test.go
+++ b/_tests/integration/version_test.go
@@ -23,7 +23,7 @@ func Test_VersionOutput(t *testing.T) {
 		require.NoError(t, err, out)
 
 		expectedOSVersion := fmt.Sprintf("%s (%s)", runtime.GOOS, runtime.GOARCH)
-		expectedVersionOut := fmt.Sprintf(`version: 0.0.0-development
+		expectedVersionOut := fmt.Sprintf(`version: 0.16.3
 os: %s
 go: %s
 build_number: 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the stepman version number. It's defined at build time using -ldflags
-var Version = "0.0.0-development"
+var Version = "0.16.3"


### PR DESCRIPTION
This PR updates the version number to the current release version, to fix the `stepman -version`, when the tool is installed via `go install github.com/bitrise-io/stepman@latest`.