### PR TITLE
[ACI-2272] set go 1.20 as minimum

### DIFF
--- a/toolkits/golang_min_version.go
+++ b/toolkits/golang_min_version.go
@@ -1,5 +1,5 @@
 package toolkits
 
 const (
-	minGoVersionForToolkit = "1.16.15"
+	minGoVersionForToolkit = "1.20.8"
 )


### PR DESCRIPTION
Based on https://stacks.bitrise.io/ 1.20.14 is available in the latest update. Used 1.20.8 so previous images are covered too.