### PR TITLE
Add logger

### DIFF
--- a/toolkits/command_runner.go
+++ b/toolkits/command_runner.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
-	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/stepman/stepman"
 )
 
 type commandRunner interface {
@@ -13,10 +13,15 @@ type commandRunner interface {
 }
 
 type defaultRunner struct {
+	logger stepman.Logger
+}
+
+func newDefaultRunner(logger stepman.Logger) *defaultRunner {
+	return &defaultRunner{logger: logger}
 }
 
 func (r *defaultRunner) runForOutput(c *command.Model) (string, error) {
-	log.Debugf("$ %s", c.PrintableCommandArgs())
+	r.logger.Debugf("$ %s", c.PrintableCommandArgs())
 
 	out, err := c.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {

--- a/toolkits/toolkit.go
+++ b/toolkits/toolkit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
+	"github.com/bitrise-io/stepman/stepman"
 )
 
 type ToolkitCheckResult struct {
@@ -65,7 +66,7 @@ type Toolkit interface {
 //
 // === Utils ===
 
-func ToolkitForStep(step models.StepModel) Toolkit {
+func ToolkitForStep(step models.StepModel, logger stepman.Logger) Toolkit {
 	var toolkit Toolkit = BashToolkit{}
 	if step.Toolkit != nil {
 		stepToolkit := step.Toolkit
@@ -78,7 +79,7 @@ func ToolkitForStep(step models.StepModel) Toolkit {
 	return toolkit
 }
 
-func AllSupportedToolkits() []Toolkit {
+func AllSupportedToolkits(logger stepman.Logger) []Toolkit {
 	return []Toolkit{GoToolkit{}, BashToolkit{}, SwiftToolkit{}}
 }
 


### PR DESCRIPTION
In a rare case, malformed logs were generated:

```[33;1mInstalled go found (path: /usr/local/go/bin/go), but not a supported version: 1.20.5[0m,```