### PR TITLE
Update steplib if step version not found

### DIFF
--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -86,7 +86,7 @@ func prepareStepLibForActivation(
 			return stepInfo, didUpdate, err
 		}
 
-		log.Infof("Failed to query step info from library, trying to update StepLib...")
+		log.Infof("Step not found in local StepLib cache, trying to update StepLib...")
 		_, err = stepman.UpdateLibrary(id.SteplibSource, log)
 		if err != nil {
 			return stepInfo, didUpdate, err

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -82,7 +82,22 @@ func prepareStepLibForActivation(
 
 	stepInfo, err = cli.QueryStepInfoFromLibrary(id.SteplibSource, id.IDorURI, id.Version, log)
 	if err != nil {
-		return stepInfo, didUpdate, err
+		if !canUpdateStepLib(isOfflineMode, didStepLibUpdateInWorkflow) {
+			return stepInfo, didUpdate, err
+		}
+
+		log.Infof("Failed to query step info from library, trying to update StepLib...")
+		_, err = stepman.UpdateLibrary(id.SteplibSource, log)
+		if err != nil {
+			return stepInfo, didUpdate, err
+		} else {
+			didUpdate = true
+		}
+
+		stepInfo, err = cli.QueryStepInfoFromLibrary(id.SteplibSource, id.IDorURI, id.Version, log)
+		if err != nil {
+			return stepInfo, didUpdate, err
+		}
 	}
 
 	if stepInfo.Step.Title == nil || *stepInfo.Step.Title == "" {
@@ -94,6 +109,16 @@ func prepareStepLibForActivation(
 }
 
 func shouldUpdateStepLibForStep(constraint models.VersionConstraint, isOfflineMode bool, didStepLibUpdateInWorkflow bool) bool {
+	if !canUpdateStepLib(isOfflineMode, didStepLibUpdateInWorkflow) {
+		return false
+	}
+
+	return (constraint.VersionLockType == models.Latest) ||
+		(constraint.VersionLockType == models.MinorLocked) ||
+		(constraint.VersionLockType == models.MajorLocked)
+}
+
+func canUpdateStepLib(isOfflineMode bool, didStepLibUpdateInWorkflow bool) bool {
 	if isOfflineMode {
 		return false
 	}
@@ -102,7 +127,5 @@ func shouldUpdateStepLibForStep(constraint models.VersionConstraint, isOfflineMo
 		return false
 	}
 
-	return (constraint.VersionLockType == models.Latest) ||
-		(constraint.VersionLockType == models.MinorLocked) ||
-		(constraint.VersionLockType == models.MajorLocked)
+	return true
 }


### PR DESCRIPTION
This PR restores the functionality of updating the steplib if a given step version is not found in the local collection.
This is the related original Bitrise CLI code: https://github.com/bitrise-io/bitrise/blob/e444d8e43ac7908cc5eb5bcc3c5c343007d76d4c/cli/step_activator.go#L169-L187