### PR TITLE
Bump min Go toolkit version

### DIFF
--- a/toolkits/golang_min_version.go
+++ b/toolkits/golang_min_version.go
@@ -1,5 +1,5 @@
 package toolkits
 
 const (
-	minGoVersionForToolkit = "1.21.10"
+	minGoVersionForToolkit = "1.22.12"
 )


### PR DESCRIPTION
The deploy step already requires Go 1.22: https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io/blob/7b3d0d262fe12a140844bbc8288f8af4fb41e9ff/go.mod#L3