### PR TITLE
Return timing and cache hit info from toolkit Install and PrepareForStepRun

### DIFF
--- a/toolkits/bash.go
+++ b/toolkits/bash.go
@@ -41,16 +41,16 @@ func (toolkit BashToolkit) Bootstrap() error {
 	return nil
 }
 
-func (toolkit BashToolkit) Install() error {
-	return nil
+func (toolkit BashToolkit) Install() (InstallResult, error) {
+	return InstallResult{}, nil
 }
 
 func (toolkit BashToolkit) ToolkitName() string {
 	return "bash"
 }
 
-func (toolkit BashToolkit) PrepareForStepRun(_ models.StepModel, _ stepid.CanonicalID, _ string) error {
-	return nil
+func (toolkit BashToolkit) PrepareForStepRun(_ models.StepModel, _ stepid.CanonicalID, _ string) (PrepareForStepRunResult, error) {
+	return PrepareForStepRunResult{}, nil
 }
 
 func (toolkit BashToolkit) StepRunCommandArguments(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) ([]string, error) {

--- a/toolkits/golang.go
+++ b/toolkits/golang.go
@@ -298,23 +298,23 @@ func (toolkit GoToolkit) PrepareForStepRun(step models.StepModel, sIDData stepid
 
 	// it's not cached, so compile it
 	if step.Toolkit == nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, errors.New("no toolkit information specified in step")
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, errors.New("no toolkit information specified in step")
 	}
 	if step.Toolkit.Go == nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, errors.New("no toolkit.go information specified in step")
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, errors.New("no toolkit.go information specified in step")
 	}
 
 	isInstallRequired, _, goConfig, err := selectGoConfiguration(toolkit.logger)
 	if err != nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s", err)
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s", err)
 	}
 	if isInstallRequired {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s",
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s",
 			"found Go version is older than required. Please run 'bitrise setup' to check and install the required version")
 	}
 
 	if err := goBuildStep(toolkit.logger, newDefaultRunner(toolkit.logger), goConfig, step.Toolkit.Go.PackageName, stepAbsDirPath, fullStepBinPath); err != nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, err
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, err
 	}
 	return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, nil
 }

--- a/toolkits/golang.go
+++ b/toolkits/golang.go
@@ -193,7 +193,9 @@ func installGoTar(logger stepman.Logger, goTarGzPath string) error {
 	return nil
 }
 
-func (toolkit GoToolkit) Install() error {
+func (toolkit GoToolkit) Install() (InstallResult, error) {
+	start := time.Now()
+
 	versionStr := minGoVersionForToolkit
 	osStr := runtime.GOOS
 	archStr := runtime.GOARCH
@@ -205,35 +207,33 @@ func (toolkit GoToolkit) Install() error {
 
 	goTmpDirPath := goToolkitTmpDirPath()
 	if err := pathutil.EnsureDirExist(goTmpDirPath); err != nil {
-		return fmt.Errorf("create Toolkits TMP directory: %s", err)
+		return InstallResult{InstallDuration: time.Since(start)}, fmt.Errorf("create Toolkits TMP directory: %s", err)
 	}
 
 	localFileName := "go." + extentionStr
 	goArchiveDownloadPath := filepath.Join(goTmpDirPath, localFileName)
 
-	var downloadErr error
-
 	toolkit.logger.Infof("=> Downloading ...")
-	downloadErr = retry.Times(2).Wait(5 * time.Second).Try(func(attempt uint) error {
+	downloadErr := retry.Times(2).Wait(5 * time.Second).Try(func(attempt uint) error {
 		if attempt > 0 {
 			toolkit.logger.Warnf("==> Download failed, retrying ...")
 		}
 		return downloadFile(downloadURL, goArchiveDownloadPath)
 	})
 	if downloadErr != nil {
-		return fmt.Errorf("download Go toolkit: %s", downloadErr)
+		return InstallResult{InstallDuration: time.Since(start)}, fmt.Errorf("download Go toolkit: %s", downloadErr)
 	}
 
 	toolkit.logger.Infof("=> Installing ...")
 	if err := installGoTar(toolkit.logger, goArchiveDownloadPath); err != nil {
-		return fmt.Errorf("install Go toolkit: %s", err)
+		return InstallResult{InstallDuration: time.Since(start)}, fmt.Errorf("install Go toolkit: %s", err)
 	}
 	if err := os.Remove(goArchiveDownloadPath); err != nil {
-		return fmt.Errorf("remove the downloaded Go archive at %s: %s", goArchiveDownloadPath, err)
+		return InstallResult{InstallDuration: time.Since(start)}, fmt.Errorf("remove the downloaded Go archive at %s: %s", goArchiveDownloadPath, err)
 	}
 	toolkit.logger.Infof("=> Installing DONE")
 
-	return nil
+	return InstallResult{InstallDuration: time.Since(start)}, nil
 }
 
 func goBuildStep(logger stepman.Logger, cmdRunner commandRunner, goConfig GoConfigurationModel, packageName, stepAbsDirPath, outputBinPath string) error {
@@ -283,7 +283,8 @@ func stepBinaryCacheFullPath(sIDData stepid.CanonicalID) string {
 }
 
 // PrepareForStepRun ...
-func (toolkit GoToolkit) PrepareForStepRun(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) error {
+func (toolkit GoToolkit) PrepareForStepRun(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) (PrepareForStepRunResult, error) {
+	start := time.Now()
 	fullStepBinPath := stepBinaryCacheFullPath(sIDData)
 
 	// try to use cached binary, if possible
@@ -291,28 +292,31 @@ func (toolkit GoToolkit) PrepareForStepRun(step models.StepModel, sIDData stepid
 		if exists, err := pathutil.IsPathExists(fullStepBinPath); err != nil {
 			toolkit.logger.Warnf("Failed to check cached binary for step, error: %s", err)
 		} else if exists {
-			return nil
+			return PrepareForStepRunResult{CacheHit: true, PrepareDuration: time.Since(start)}, nil
 		}
 	}
 
 	// it's not cached, so compile it
 	if step.Toolkit == nil {
-		return errors.New("no toolkit information specified in step")
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, errors.New("no toolkit information specified in step")
 	}
 	if step.Toolkit.Go == nil {
-		return errors.New("no toolkit.go information specified in step")
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, errors.New("no toolkit.go information specified in step")
 	}
 
 	isInstallRequired, _, goConfig, err := selectGoConfiguration(toolkit.logger)
 	if err != nil {
-		return fmt.Errorf("select an appropriate Go installation for compiling the Step: %s", err)
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s", err)
 	}
 	if isInstallRequired {
-		return fmt.Errorf("select an appropriate Go installation for compiling the Step: %s",
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s",
 			"found Go version is older than required. Please run 'bitrise setup' to check and install the required version")
 	}
 
-	return goBuildStep(toolkit.logger, newDefaultRunner(toolkit.logger), goConfig, step.Toolkit.Go.PackageName, stepAbsDirPath, fullStepBinPath)
+	if err := goBuildStep(toolkit.logger, newDefaultRunner(toolkit.logger), goConfig, step.Toolkit.Go.PackageName, stepAbsDirPath, fullStepBinPath); err != nil {
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, err
+	}
+	return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, nil
 }
 
 // === Toolkit: Step Run ===

--- a/toolkits/golang_test.go
+++ b/toolkits/golang_test.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/stepman/activator/steplib"
+	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/stretchr/testify/require"
 )
@@ -294,6 +296,49 @@ func (l testLogger) Infof(format string, v ...interface{}) {
 	l.t.Logf(format, v...)
 }
 
+func TestGoToolkit_PrepareForStepRun(t *testing.T) {
+	logger := testLogger{t: t}
+
+	t.Run("cache hit", func(t *testing.T) {
+		toolkit := NewGoToolkit(logger)
+		sIDData := stepid.CanonicalID{
+			SteplibSource: "https://github.com/bitrise-io/bitrise-steplib.git",
+			IDorURI:       "script",
+			Version:       "0.0.0-test",
+		}
+
+		binPath := stepBinaryCacheFullPath(sIDData)
+		require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0755))
+		require.NoError(t, os.WriteFile(binPath, []byte{}, 0755))
+		t.Cleanup(func() { _ = os.Remove(binPath) })
+
+		result, err := toolkit.PrepareForStepRun(models.StepModel{}, sIDData, t.TempDir())
+
+		require.NoError(t, err)
+		require.True(t, result.CacheHit)
+		
+		// It's a weak check since durations are never negative, but it serves as documentation that the field is intentionally populated on every path
+		require.GreaterOrEqual(t, result.PrepareDuration, time.Duration(0))
+	})
+
+	t.Run("error path returns duration", func(t *testing.T) {
+		toolkit := NewGoToolkit(logger)
+		sIDData := stepid.CanonicalID{
+			SteplibSource: "git",
+			IDorURI:       "https://github.com/bitrise-steplib/my-step.git",
+			Version:       "main",
+		}
+		
+		// git step IDs are never unique resources, so the cache check is skipped
+		// and the nil Toolkit field triggers an immediate error
+		result, err := toolkit.PrepareForStepRun(models.StepModel{Toolkit: nil}, sIDData, t.TempDir())
+
+		require.Error(t, err)
+		require.False(t, result.CacheHit)
+		require.Greater(t, result.PrepareDuration, time.Duration(0))
+	})
+}
+
 func TestGoToolkit_Install(t *testing.T) {
 	logger := testLogger{t: t}
 	tests := []struct {
@@ -306,7 +351,7 @@ func TestGoToolkit_Install(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			toolkit := NewGoToolkit(logger)
-			gotErr := toolkit.Install()
+			_, gotErr := toolkit.Install()
 			require.NoError(t, gotErr)
 		})
 	}

--- a/toolkits/swift.go
+++ b/toolkits/swift.go
@@ -49,15 +49,15 @@ func (toolkit SwiftToolkit) PrepareForStepRun(step models.StepModel, _ stepid.Ca
 	start := time.Now()
 	err := downloadFile(binaryLocation, executablePath)
 	if err != nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("download precompiled step binary: %s", err)
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, fmt.Errorf("download precompiled step binary: %s", err)
 	}
 
 	err = os.Chmod(executablePath, 0755)
 	if err != nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, err
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, err
 	}
 
-	return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, nil
+	return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, nil
 }
 
 func (toolkit SwiftToolkit) StepRunCommandArguments(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) ([]string, error) {

--- a/toolkits/swift.go
+++ b/toolkits/swift.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
@@ -17,8 +18,8 @@ func (toolkit SwiftToolkit) Bootstrap() error {
 	return nil
 }
 
-func (toolkit SwiftToolkit) Install() error {
-	return nil
+func (toolkit SwiftToolkit) Install() (InstallResult, error) {
+	return InstallResult{}, nil
 }
 
 func (toolkit SwiftToolkit) ToolkitName() string {
@@ -37,25 +38,26 @@ func (toolkit SwiftToolkit) IsToolAvailableInPATH() bool {
 	return len(binPath) > 0
 }
 
-func (toolkit SwiftToolkit) PrepareForStepRun(step models.StepModel, _ stepid.CanonicalID, stepAbsDirPath string) error {
+func (toolkit SwiftToolkit) PrepareForStepRun(step models.StepModel, _ stepid.CanonicalID, stepAbsDirPath string) (PrepareForStepRunResult, error) {
 	binaryLocation := step.Toolkit.Swift.BinaryLocation
 	if binaryLocation == "" {
-		return nil
+		return PrepareForStepRunResult{}, nil
 	}
 
 	executablePath := filepath.Join(stepAbsDirPath, step.Toolkit.Swift.ExecutableName)
-	
+
+	start := time.Now()
 	err := downloadFile(binaryLocation, executablePath)
 	if err != nil {
-		return fmt.Errorf("download precompiled step binary: %s", err)
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("download precompiled step binary: %s", err)
 	}
 
 	err = os.Chmod(executablePath, 0755)
 	if err != nil {
-		return err
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, err
 	}
 
-	return nil
+	return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, nil
 }
 
 func (toolkit SwiftToolkit) StepRunCommandArguments(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) ([]string, error) {

--- a/toolkits/toolkit.go
+++ b/toolkits/toolkit.go
@@ -6,11 +6,23 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/stepman"
 )
+
+type InstallResult struct {
+	InstallDuration time.Duration
+}
+
+type PrepareForStepRunResult struct {
+	PrepareDuration time.Duration
+
+	// CacheHit should indicate if PrepareDuration was shorter because of a cache hit or similar optimizations.
+	CacheHit        bool
+}
 
 type ToolkitCheckResult struct {
 	Path    string
@@ -28,7 +40,7 @@ type Toolkit interface {
 	Check() (bool, ToolkitCheckResult, error)
 
 	// Install the toolkit
-	Install() error
+	Install() (InstallResult, error)
 
 	// Check whether the toolkit's tool (e.g. Go, Ruby, Bash, ...) is available
 	// and "usable"" without any bootstrapping.
@@ -57,7 +69,7 @@ type Toolkit interface {
 	// the toolkit should/can be "enforced" here (e.g. during the compilation),
 	// BUT ONLY for this function! E.g. don't call `os.Setenv` or something similar
 	// which would affect other functions, just pass the required envs to the compilation command!
-	PrepareForStepRun(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) error
+	PrepareForStepRun(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) (PrepareForStepRunResult, error)
 
 	// StepRunCommandArguments ...
 	StepRunCommandArguments(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) ([]string, error)


### PR DESCRIPTION
## Summary

- Adds `InstallResult` (with `InstallDuration`) and `PrepareForStepRunResult` (with `PrepareDuration` and `CacheHit`) to the `Toolkit` interface
- `GoToolkit` populates real timings: `Install` covers download+extract, `PrepareForStepRun` covers the full prepare path including cache lookup
- Duration is returned on **all** paths including errors, so callers can correlate latency with operation outcome independently
- `SwiftToolkit` times its binary download; `BashToolkit` returns zero-value structs (no meaningful work to measure)
- Adds unit tests for the cache hit and error-path measurement behaviour in `GoToolkit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)