### PR TITLE
feat(steplibrary): on-disk HTTP cache for the V2 inventory reader

### DIFF
--- a/activator/steplib/activate_executable.go
+++ b/activator/steplib/activate_executable.go
@@ -1,8 +1,6 @@
 package steplib
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/stepman/internal/sri"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/hashicorp/go-retryablehttp"
 )
@@ -72,30 +71,31 @@ func activateStepExecutable(
 	return path, nil
 }
 
-func validateHash(filePath string, expectedHash string) error {
+func validateHash(filePath string, expectedHash string) (err error) {
 	if expectedHash == "" {
 		return fmt.Errorf("hash is empty")
 	}
 
-	if !strings.HasPrefix(expectedHash, "sha256-") {
+	if !strings.HasPrefix(expectedHash, sri.Prefix) {
 		return fmt.Errorf("only SHA256 hashes supported at this time, make sure to prefix the hash with `sha256-`. Found hash value: %s", expectedHash)
 	}
-
-	expectedHash = strings.TrimPrefix(expectedHash, "sha256-")
 
 	reader, err := os.Open(filePath)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if cerr := reader.Close(); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+	}()
 
-	h := sha256.New()
-	_, err = io.Copy(h, reader)
+	actualHash, err := sri.SHA256Reader(reader)
 	if err != nil {
 		return fmt.Errorf("calculate hash: %w", err)
 	}
-	actualHash := hex.EncodeToString(h.Sum(nil))
 	if actualHash != expectedHash {
-		return fmt.Errorf("hash mismatch: expected sha256-%s, got sha256-%s", expectedHash, actualHash)
+		return fmt.Errorf("hash mismatch: expected %s, got %s", expectedHash, actualHash)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/go-version v1.8.0
+	github.com/pquerna/cachecontrol v0.2.0
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli v1.22.14
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/cachecontrol v0.2.0 h1:vBXSNuE5MYP9IJ5kjsdo8uq+w41jSPgvba2DEnkRx9k=
+github.com/pquerna/cachecontrol v0.2.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQnrHV5K9mBcUI=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -46,6 +48,7 @@ github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/internal/httpcache/freshness.go
+++ b/internal/httpcache/freshness.go
@@ -11,16 +11,14 @@ import (
 // and whether it must not be stored at all.
 //
 //   - max-age=N  -> fresh for N seconds from fetchedAt.
-//   - no max-age -> expiresAt == fetchedAt (always revalidated; still storable
-//     so it can act as a stale fallback).
+//   - no max-age -> expiresAt == fetchedAt (revalidate before every reuse).
 //   - no-cache   -> same as no max-age: revalidate before every reuse.
 //   - immutable  -> never revalidate (isFresh short-circuits on it).
 //   - no-store   -> not cacheable.
 //
-// must-revalidate is intentionally NOT treated as "immediately stale": it only
-// governs the freshness window's edge, and stepman deliberately keeps stale
-// entries as a last-resort fallback even when the server asks not to (a CDN /
-// network outage must not break resolution).
+// must-revalidate needs no special handling: the cache already revalidates
+// every stale entry and surfaces revalidation failures as errors rather than
+// serving stale, so the directive's guarantee holds either way.
 func parseCacheControl(header string, fetchedAt time.Time) (expiresAt time.Time, immutable, noStore bool) {
 	if header == "" {
 		return fetchedAt, false, false

--- a/internal/httpcache/freshness.go
+++ b/internal/httpcache/freshness.go
@@ -1,0 +1,46 @@
+package httpcache
+
+import (
+	"time"
+
+	"github.com/pquerna/cachecontrol/cacheobject"
+)
+
+// parseCacheControl interprets a response Cache-Control header into the fields
+// the cache needs: when the entry stops being fresh, whether it is immutable,
+// and whether it must not be stored at all.
+//
+//   - max-age=N  -> fresh for N seconds from fetchedAt.
+//   - no max-age -> expiresAt == fetchedAt (always revalidated; still storable
+//     so it can act as a stale fallback).
+//   - no-cache   -> same as no max-age: revalidate before every reuse.
+//   - immutable  -> never revalidate (isFresh short-circuits on it).
+//   - no-store   -> not cacheable.
+//
+// must-revalidate is intentionally NOT treated as "immediately stale": it only
+// governs the freshness window's edge, and stepman deliberately keeps stale
+// entries as a last-resort fallback even when the server asks not to (a CDN /
+// network outage must not break resolution).
+func parseCacheControl(header string, fetchedAt time.Time) (expiresAt time.Time, immutable, noStore bool) {
+	if header == "" {
+		return fetchedAt, false, false
+	}
+
+	directives, err := cacheobject.ParseResponseCacheControl(header)
+	if err != nil {
+		// Unparseable directive: keep it storable but always revalidate.
+		return fetchedAt, false, false
+	}
+	if directives.NoStore {
+		return fetchedAt, false, true
+	}
+
+	expiresAt = fetchedAt
+	if directives.MaxAge >= 0 {
+		expiresAt = fetchedAt.Add(time.Duration(directives.MaxAge) * time.Second)
+	}
+	if directives.NoCachePresent {
+		expiresAt = fetchedAt
+	}
+	return expiresAt, directives.Immutable, false
+}

--- a/internal/httpcache/httpcache.go
+++ b/internal/httpcache/httpcache.go
@@ -1,0 +1,284 @@
+// Package httpcache provides a transparent on-disk HTTP cache as an
+// http.RoundTripper. It honors the server's Cache-Control/ETag, serves fresh
+// entries without touching the network, revalidates stale entries with
+// conditional requests, and — crucially for stepman — serves a stale entry as a
+// last resort when revalidation fails (network error or 5xx), so a CDN outage
+// degrades gracefully instead of breaking step resolution.
+//
+// Entries live one-directory-per-response under a hash+name layout (see Store),
+// keeping the cache both machine-addressable and human-browsable.
+package httpcache
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"time"
+)
+
+// Logger is the minimal logging surface the cache needs: Debugf for hit/miss
+// tracing and Warnf for the stale-fallback notice (a degraded-mode signal worth
+// surfacing). stepman.Logger satisfies it.
+type Logger interface {
+	Debugf(format string, v ...any)
+	Warnf(format string, v ...any)
+}
+
+// Transport is an http.RoundTripper that caches GET responses on disk via the
+// embedded Store and delegates the actual network fetch to base.
+type Transport struct {
+	base  http.RoundTripper
+	store *Store
+	log   Logger
+}
+
+// NewTransport returns a caching RoundTripper. base performs the real network
+// fetches (e.g. the default pooled transport); store holds the cached entries.
+func NewTransport(base http.RoundTripper, store *Store, log Logger) *Transport {
+	return &Transport{base: base, store: store, log: log}
+}
+
+// RoundTrip implements http.RoundTripper. Only GET is cached; every other
+// method is passed straight through to base.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method != http.MethodGet {
+		return t.base.RoundTrip(req)
+	}
+
+	key := cacheKey(req)
+	meta, hit, err := t.store.Lookup(key)
+	if err != nil {
+		t.log.Debugf("httpcache: lookup %s failed: %s", req.URL, err)
+		hit = false
+	}
+
+	if hit && isFresh(meta, time.Now()) {
+		resp, serr := t.serve(req, key, meta, false, "fresh")
+		if serr == nil {
+			return resp, nil
+		}
+		t.log.Debugf("httpcache: serving fresh %s failed: %s; refetching", req.URL, serr)
+		hit = false
+	}
+
+	if hit {
+		return t.revalidate(req, key, meta)
+	}
+	return t.fetchAndStore(req, key)
+}
+
+// revalidate is reached only when a stale entry exists. It issues a conditional
+// request and: serves the cached body on 304; replaces it on 2xx; falls back to
+// the stale body on a transport error or 5xx (the last-resort path).
+func (t *Transport) revalidate(req *http.Request, key string, meta Meta) (*http.Response, error) {
+	condReq := req.Clone(req.Context())
+	if meta.ETag != "" {
+		condReq.Header.Set("If-None-Match", meta.ETag)
+	}
+	if meta.LastModified != "" {
+		condReq.Header.Set("If-Modified-Since", meta.LastModified)
+	}
+
+	resp, err := t.base.RoundTrip(condReq)
+	if err != nil {
+		reason := "revalidation error: " + err.Error()
+		if served, serr := t.serve(req, key, meta, true, reason); serr == nil {
+			return served, nil
+		}
+		return nil, err
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusNotModified:
+		t.drain(req.URL.String(), resp.Body)
+		refreshed := meta
+		applyCacheHeaders(&refreshed, resp, time.Now())
+		if terr := t.store.Touch(key, refreshed); terr != nil {
+			t.log.Debugf("httpcache: touch %s failed: %s", req.URL, terr)
+		}
+		return t.serve(req, key, refreshed, false, "revalidated (304)")
+
+	case resp.StatusCode >= 500:
+		t.drain(req.URL.String(), resp.Body)
+		reason := fmt.Sprintf("revalidation status %d", resp.StatusCode)
+		if served, serr := t.serve(req, key, meta, true, reason); serr == nil {
+			return served, nil
+		}
+		return nil, fmt.Errorf("revalidate %s: status %d and cached body unusable", req.URL, resp.StatusCode)
+
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return t.store200(req, key, resp)
+
+	default:
+		// e.g. 404: the resource changed shape; pass through, leave the entry.
+		return resp, nil
+	}
+}
+
+// fetchAndStore handles a cache miss: fetch from base, store 2xx responses, pass
+// everything else (errors, non-2xx) through unchanged.
+func (t *Transport) fetchAndStore(req *http.Request, key string) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err // surfaced to retryablehttp, which retries
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return t.store200(req, key, resp)
+	}
+	return resp, nil
+}
+
+// store200 buffers a 2xx body, persists it (unless no-store), and returns a
+// response whose body replays the buffer. Inventory files are small by design,
+// so buffering in memory keeps the write atomic and the code simple.
+func (t *Transport) store200(req *http.Request, key string, resp *http.Response) (*http.Response, error) {
+	fetchedAt := time.Now()
+	meta := Meta{
+		URL:         req.URL.String(),
+		Method:      req.Method,
+		Status:      resp.StatusCode,
+		ContentType: resp.Header.Get("Content-Type"),
+		BodyFile:    bodyFilename(req),
+	}
+	noStore := applyCacheHeaders(&meta, resp, fetchedAt)
+
+	body, rerr := io.ReadAll(resp.Body)
+	cerr := resp.Body.Close()
+	if rerr != nil {
+		return nil, errors.Join(fmt.Errorf("read body %s: %w", req.URL, rerr), cerr)
+	}
+	if cerr != nil {
+		return nil, fmt.Errorf("close body %s: %w", req.URL, cerr)
+	}
+
+	if noStore {
+		t.log.Debugf("httpcache: not storing %s (no-store)", req.URL)
+	} else {
+		meta.BodySize = int64(len(body))
+		sum := sha256.Sum256(body)
+		meta.BodySHA256 = "sha256-" + hex.EncodeToString(sum[:])
+		if serr := t.store.Save(key, meta, body); serr != nil {
+			// A failed write must not fail the request: the caller still has a
+			// valid response; the cache just stays empty for this entry.
+			t.log.Warnf("httpcache: storing %s failed: %s", req.URL, serr)
+		} else {
+			t.log.Debugf("httpcache: stored %s (%d bytes)", req.URL, meta.BodySize)
+		}
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	return resp, nil
+}
+
+// serve builds a synthesized 200 response from the cached entry. When stale is
+// true the entry is being served as a last-resort fallback, which is logged at
+// Warn (a degraded-mode signal); otherwise it is a normal hit, logged at Debug.
+func (t *Transport) serve(req *http.Request, key string, meta Meta, stale bool, reason string) (*http.Response, error) {
+	body, err := t.store.Open(key, meta)
+	if err != nil {
+		return nil, err
+	}
+	if stale {
+		t.log.Warnf("httpcache: serving stale cache for %s (%s)", req.URL, reason)
+	} else {
+		t.log.Debugf("httpcache: serving %s cache for %s", reason, req.URL)
+	}
+
+	header := http.Header{}
+	setIfNotEmpty(header, "Content-Type", meta.ContentType)
+	setIfNotEmpty(header, "ETag", meta.ETag)
+	setIfNotEmpty(header, "Cache-Control", meta.CacheControl)
+	setIfNotEmpty(header, "Last-Modified", meta.LastModified)
+	header.Set("X-From-Cache", "1")
+
+	return &http.Response{
+		Status:        "200 OK",
+		StatusCode:    http.StatusOK,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        header,
+		Body:          body,
+		ContentLength: meta.BodySize,
+		Request:       req,
+	}, nil
+}
+
+// drain consumes and closes a response body we are discarding (e.g. a 304 or a
+// 5xx we fall back from), so the underlying connection can be reused.
+func (t *Transport) drain(url string, body io.ReadCloser) {
+	if body == nil {
+		return
+	}
+	_, copyErr := io.Copy(io.Discard, io.LimitReader(body, 64<<10))
+	closeErr := body.Close()
+	if err := errors.Join(copyErr, closeErr); err != nil {
+		t.log.Debugf("httpcache: draining response for %s: %s", url, err)
+	}
+}
+
+// applyCacheHeaders copies the validators and freshness directives from resp
+// into m and returns whether the response must not be stored.
+func applyCacheHeaders(m *Meta, resp *http.Response, now time.Time) (noStore bool) {
+	// A 304 (and some 200s) may omit headers that were present originally; per
+	// RFC 7234 §4.3.4 those must be preserved, not wiped. Validators already use
+	// preserve-if-absent; Cache-Control must too, otherwise the first 304 that
+	// drops the header collapses the entry's freshness window to zero and forces
+	// a revalidation on every later request.
+	cc := resp.Header.Get("Cache-Control")
+	if cc == "" {
+		cc = m.CacheControl
+	}
+	m.CacheControl = cc
+	setIfNotEmptyField(&m.ETag, resp.Header.Get("ETag"))
+	setIfNotEmptyField(&m.LastModified, resp.Header.Get("Last-Modified"))
+
+	expiresAt, immutable, ns := parseCacheControl(cc, now)
+	m.FetchedAt = now
+	m.ExpiresAt = expiresAt
+	m.Immutable = immutable
+	return ns
+}
+
+func isFresh(m Meta, now time.Time) bool {
+	if m.Immutable {
+		return true
+	}
+	return now.Before(m.ExpiresAt)
+}
+
+// cacheKey is both the lookup key and the entry directory name:
+// "<sha256(method+"\n"+url)>-<basename>". The hash guarantees uniqueness; the
+// basename suffix makes the directory recognizable when browsing the cache.
+func cacheKey(req *http.Request) string {
+	sum := sha256.Sum256([]byte(req.Method + "\n" + req.URL.String()))
+	return hex.EncodeToString(sum[:]) + "-" + bodyFilename(req)
+}
+
+// bodyFilename is the last path segment of the URL ("body" if there is none),
+// used as the on-disk body filename so cached files keep their real names.
+func bodyFilename(req *http.Request) string {
+	base := path.Base(req.URL.Path)
+	if base == "." || base == "/" || base == "" {
+		return "body"
+	}
+	return base
+}
+
+func setIfNotEmpty(h http.Header, key, value string) {
+	if value != "" {
+		h.Set(key, value)
+	}
+}
+
+func setIfNotEmptyField(dst *string, value string) {
+	if value != "" {
+		*dst = value
+	}
+}

--- a/internal/httpcache/httpcache.go
+++ b/internal/httpcache/httpcache.go
@@ -1,9 +1,12 @@
 // Package httpcache provides a transparent on-disk HTTP cache as an
 // http.RoundTripper. It honors the server's Cache-Control/ETag, serves fresh
-// entries without touching the network, revalidates stale entries with
-// conditional requests, and — crucially for stepman — serves a stale entry as a
-// last resort when revalidation fails (network error or 5xx), so a CDN outage
-// degrades gracefully instead of breaking step resolution.
+// entries without touching the network, and revalidates stale entries with
+// conditional requests.
+//
+// When revalidation fails (network error or 5xx) the failure is surfaced to the
+// caller rather than masked by serving a stale entry: a broken upstream should
+// fail loudly, not silently resolve against possibly-outdated inventory. A
+// deliberate offline mode that prefers stale entries is planned separately.
 //
 // Entries live one-directory-per-response under a hash+name layout (see Store),
 // keeping the cache both machine-addressable and human-browsable.
@@ -58,7 +61,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if hit && isFresh(meta, time.Now()) {
-		resp, serr := t.serve(req, key, meta, false, "fresh")
+		resp, serr := t.serve(req, key, meta, "fresh")
 		if serr == nil {
 			return resp, nil
 		}
@@ -73,8 +76,8 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // revalidate is reached only when a stale entry exists. It issues a conditional
-// request and: serves the cached body on 304; replaces it on 2xx; falls back to
-// the stale body on a transport error or 5xx (the last-resort path).
+// request and: serves the cached body on 304; replaces it on 2xx; surfaces the
+// failure on a transport error or 5xx (no stale fallback — see package doc).
 func (t *Transport) revalidate(req *http.Request, key string, meta Meta) (*http.Response, error) {
 	condReq := req.Clone(req.Context())
 	if meta.ETag != "" {
@@ -86,10 +89,7 @@ func (t *Transport) revalidate(req *http.Request, key string, meta Meta) (*http.
 
 	resp, err := t.base.RoundTrip(condReq)
 	if err != nil {
-		reason := "revalidation error: " + err.Error()
-		if served, serr := t.serve(req, key, meta, true, reason); serr == nil {
-			return served, nil
-		}
+		// Surface the error; retryablehttp retries it, then it reaches the caller.
 		return nil, err
 	}
 
@@ -101,21 +101,15 @@ func (t *Transport) revalidate(req *http.Request, key string, meta Meta) (*http.
 		if terr := t.store.Touch(key, refreshed); terr != nil {
 			t.log.Debugf("httpcache: touch %s failed: %s", req.URL, terr)
 		}
-		return t.serve(req, key, refreshed, false, "revalidated (304)")
-
-	case resp.StatusCode >= 500:
-		t.drain(req.URL.String(), resp.Body)
-		reason := fmt.Sprintf("revalidation status %d", resp.StatusCode)
-		if served, serr := t.serve(req, key, meta, true, reason); serr == nil {
-			return served, nil
-		}
-		return nil, fmt.Errorf("revalidate %s: status %d and cached body unusable", req.URL, resp.StatusCode)
+		return t.serve(req, key, refreshed, "revalidated (304)")
 
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
 		return t.store200(req, key, resp)
 
 	default:
-		// e.g. 404: the resource changed shape; pass through, leave the entry.
+		// 5xx and any other non-2xx (e.g. 404): pass through unchanged. The 5xx
+		// case is retried by retryablehttp and ultimately surfaced as an error;
+		// the stale entry is left in place for a future successful revalidation.
 		return resp, nil
 	}
 }
@@ -176,19 +170,14 @@ func (t *Transport) store200(req *http.Request, key string, resp *http.Response)
 	return resp, nil
 }
 
-// serve builds a synthesized 200 response from the cached entry. When stale is
-// true the entry is being served as a last-resort fallback, which is logged at
-// Warn (a degraded-mode signal); otherwise it is a normal hit, logged at Debug.
-func (t *Transport) serve(req *http.Request, key string, meta Meta, stale bool, reason string) (*http.Response, error) {
+// serve builds a synthesized 200 response from the cached entry. reason is a
+// human-readable cause ("fresh", "revalidated (304)") used only for logging.
+func (t *Transport) serve(req *http.Request, key string, meta Meta, reason string) (*http.Response, error) {
 	body, err := t.store.Open(key, meta)
 	if err != nil {
 		return nil, err
 	}
-	if stale {
-		t.log.Warnf("httpcache: serving stale cache for %s (%s)", req.URL, reason)
-	} else {
-		t.log.Debugf("httpcache: serving %s cache for %s", reason, req.URL)
-	}
+	t.log.Debugf("httpcache: serving %s cache for %s", reason, req.URL)
 
 	header := http.Header{}
 	setIfNotEmpty(header, "Content-Type", meta.ContentType)

--- a/internal/httpcache/httpcache.go
+++ b/internal/httpcache/httpcache.go
@@ -60,17 +60,22 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		hit = false
 	}
 
-	if hit && isFresh(meta, time.Now()) {
-		resp, serr := t.serve(req, key, meta, "fresh")
-		if serr == nil {
-			return resp, nil
+	var cachedBody []byte
+	if hit {
+		cachedBody, err = t.store.ReadBody(key, meta)
+		if err != nil {
+			// Body missing or corrupt: treat as a miss and refetch unconditionally
+			// (a stale validator would be useless without the body to back it).
+			t.log.Debugf("httpcache: cached body for %s unusable: %s; refetching", req.URL, err)
+			hit = false
 		}
-		t.log.Debugf("httpcache: serving fresh %s failed: %s; refetching", req.URL, serr)
-		hit = false
 	}
 
+	if hit && isFresh(meta, time.Now()) {
+		return t.serveBytes(req, meta, cachedBody, "fresh"), nil
+	}
 	if hit {
-		return t.revalidate(req, key, meta)
+		return t.revalidate(req, key, meta, cachedBody)
 	}
 	return t.fetchAndStore(req, key)
 }
@@ -78,7 +83,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 // revalidate is reached only when a stale entry exists. It issues a conditional
 // request and: serves the cached body on 304; replaces it on 2xx; surfaces the
 // failure on a transport error or 5xx (no stale fallback — see package doc).
-func (t *Transport) revalidate(req *http.Request, key string, meta Meta) (*http.Response, error) {
+func (t *Transport) revalidate(req *http.Request, key string, meta Meta, cachedBody []byte) (*http.Response, error) {
 	condReq := req.Clone(req.Context())
 	if meta.ETag != "" {
 		condReq.Header.Set("If-None-Match", meta.ETag)
@@ -101,7 +106,7 @@ func (t *Transport) revalidate(req *http.Request, key string, meta Meta) (*http.
 		if terr := t.store.Touch(key, refreshed); terr != nil {
 			t.log.Debugf("httpcache: touch %s failed: %s", req.URL, terr)
 		}
-		return t.serve(req, key, refreshed, "revalidated (304)")
+		return t.serveBytes(req, refreshed, cachedBody, "revalidated (304)"), nil
 
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
 		return t.store200(req, key, resp)
@@ -170,13 +175,11 @@ func (t *Transport) store200(req *http.Request, key string, resp *http.Response)
 	return resp, nil
 }
 
-// serve builds a synthesized 200 response from the cached entry. reason is a
-// human-readable cause ("fresh", "revalidated (304)") used only for logging.
-func (t *Transport) serve(req *http.Request, key string, meta Meta, reason string) (*http.Response, error) {
-	body, err := t.store.Open(key, meta)
-	if err != nil {
-		return nil, err
-	}
+// serveBytes builds a synthesized 200 response from an already-loaded (and
+// hash-verified) cached body. reason is a human-readable cause ("fresh",
+// "revalidated (304)") used only for logging. ContentLength reflects the actual
+// bytes served, not the stored metadata.
+func (t *Transport) serveBytes(req *http.Request, meta Meta, body []byte, reason string) *http.Response {
 	t.log.Debugf("httpcache: serving %s cache for %s", reason, req.URL)
 
 	header := http.Header{}
@@ -193,10 +196,10 @@ func (t *Transport) serve(req *http.Request, key string, meta Meta, reason strin
 		ProtoMajor:    1,
 		ProtoMinor:    1,
 		Header:        header,
-		Body:          body,
-		ContentLength: meta.BodySize,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
 		Request:       req,
-	}, nil
+	}
 }
 
 // drain consumes and closes a response body we are discarding (e.g. a 304 or a

--- a/internal/httpcache/httpcache.go
+++ b/internal/httpcache/httpcache.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 )
 
@@ -253,11 +254,21 @@ func cacheKey(req *http.Request) string {
 	return hex.EncodeToString(sum[:]) + "-" + bodyFilename(req)
 }
 
-// bodyFilename is the last path segment of the URL ("body" if there is none),
-// used as the on-disk body filename so cached files keep their real names.
+// maxBodyFilenameLen caps the human-readable suffix so the full entry dir name
+// ("<64 hex>-<basename>") stays well under the 255-byte NAME_MAX on common
+// filesystems.
+const maxBodyFilenameLen = 100
+
+// bodyFilename is the last path segment of the URL, used as the on-disk body
+// filename so cached files keep their real names. It falls back to "body" for
+// any segment that isn't safe as a single path component — empty, ".", "..",
+// containing a separator, or too long — since the segment is only a
+// human-readable convenience (the sha256 in the dir name guarantees
+// uniqueness), it never needs to round-trip back to the URL.
 func bodyFilename(req *http.Request) string {
 	base := path.Base(req.URL.Path)
-	if base == "." || base == "/" || base == "" {
+	if base == "." || base == ".." || base == "" ||
+		strings.ContainsAny(base, `/\`) || len(base) > maxBodyFilenameLen {
 		return "body"
 	}
 	return base

--- a/internal/httpcache/httpcache.go
+++ b/internal/httpcache/httpcache.go
@@ -140,6 +140,7 @@ func (t *Transport) fetchAndStore(req *http.Request, key string) (*http.Response
 // so buffering in memory keeps the write atomic and the code simple.
 func (t *Transport) store200(req *http.Request, key string, resp *http.Response) (*http.Response, error) {
 	fetchedAt := time.Now()
+	//nolint:exhaustruct // freshness/validator fields are filled by applyCacheHeaders; hash/size below
 	meta := Meta{
 		URL:         req.URL.String(),
 		Method:      req.Method,
@@ -191,6 +192,7 @@ func (t *Transport) serveBytes(req *http.Request, meta Meta, body []byte, reason
 	setIfNotEmpty(header, "Last-Modified", meta.LastModified)
 	header.Set("X-From-Cache", "1")
 
+	//nolint:exhaustruct // a synthesized response only needs status, headers, and body
 	return &http.Response{
 		Status:        "200 OK",
 		StatusCode:    http.StatusOK,

--- a/internal/httpcache/httpcache.go
+++ b/internal/httpcache/httpcache.go
@@ -23,6 +23,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/bitrise-io/stepman/internal/sri"
 )
 
 // Logger is the minimal logging surface the cache needs: Debugf for hit/miss
@@ -160,8 +162,7 @@ func (t *Transport) store200(req *http.Request, key string, resp *http.Response)
 		t.log.Debugf("httpcache: not storing %s (no-store)", req.URL)
 	} else {
 		meta.BodySize = int64(len(body))
-		sum := sha256.Sum256(body)
-		meta.BodySHA256 = "sha256-" + hex.EncodeToString(sum[:])
+		meta.BodySHA256 = sri.SHA256(body)
 		if serr := t.store.Save(key, meta, body); serr != nil {
 			// A failed write must not fail the request: the caller still has a
 			// valid response; the cache just stays empty for this entry.

--- a/internal/httpcache/httpcache_test.go
+++ b/internal/httpcache/httpcache_test.go
@@ -369,6 +369,26 @@ func TestNoStoreNotCached(t *testing.T) {
 	})
 }
 
+func TestBodyFilename(t *testing.T) {
+	cases := []struct {
+		url  string
+		want string
+	}{
+		{"https://h/spec/steps/git-clone/latest.json", "latest.json"},
+		{"https://h/steps/git-clone/8.5.0/step.json", "step.json"},
+		{"https://h/a/b/", "b"},                           // path.Base strips trailing slash
+		{"https://h/", "body"},                            // no segment
+		{"https://h", "body"},                             // empty path
+		{"https://h/a/..", "body"},                        // dot-dot segment
+		{"https://h/" + strings.Repeat("x", 200), "body"}, // over length cap
+	}
+	for _, c := range cases {
+		req, err := http.NewRequest(http.MethodGet, c.url, nil)
+		require.NoError(t, err, c.url)
+		assert.Equal(t, c.want, bodyFilename(req), c.url)
+	}
+}
+
 func TestNonGETPassThrough(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		h := newHarness(t, func(_ *http.Request, _ int) (*http.Response, error) {

--- a/internal/httpcache/httpcache_test.go
+++ b/internal/httpcache/httpcache_test.go
@@ -319,6 +319,35 @@ func TestRevalidation5xxPassedThrough(t *testing.T) {
 	})
 }
 
+// TestCorruptBodyRefetched verifies the on-read integrity check: if the cached
+// body is altered on disk so its bytes no longer match meta.BodySHA256, the
+// entry is treated as a miss and refetched rather than served as a valid 200.
+func TestCorruptBodyRefetched(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, _ int) (*http.Response, error) {
+			return makeResp(http.StatusOK, "GOOD", map[string]string{
+				"Cache-Control": "max-age=60",
+			}), nil
+		})
+
+		_, body := h.get(testURL)
+		require.Equal(t, "GOOD", body)
+		require.Equal(t, 1, h.base.calls)
+
+		// Corrupt the stored body in place (simulating bit-rot / a torn write).
+		entries, err := os.ReadDir(h.root)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		bodyPath := filepath.Join(h.root, entries[0].Name(), "latest.json")
+		require.NoError(t, os.WriteFile(bodyPath, []byte("CORRUPT"), 0o644))
+
+		// Still within max-age, but the checksum no longer matches -> refetch.
+		_, body = h.get(testURL)
+		assert.Equal(t, "GOOD", body, "corrupt entry must be refetched, not served")
+		assert.Equal(t, 2, h.base.calls, "checksum mismatch forces a network refetch")
+	})
+}
+
 func TestNoStoreNotCached(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		h := newHarness(t, func(_ *http.Request, _ int) (*http.Response, error) {

--- a/internal/httpcache/httpcache_test.go
+++ b/internal/httpcache/httpcache_test.go
@@ -268,7 +268,7 @@ func TestImmutableNeverRevalidates(t *testing.T) {
 	})
 }
 
-func TestStaleServedOnError(t *testing.T) {
+func TestRevalidationErrorSurfaced(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		h := newHarness(t, func(_ *http.Request, n int) (*http.Response, error) {
 			if n == 1 {
@@ -285,16 +285,17 @@ func TestStaleServedOnError(t *testing.T) {
 
 		time.Sleep(61 * time.Second)
 
-		status, body := h.get(testURL)
-		assert.Equal(t, http.StatusOK, status)
-		assert.Equal(t, "BODY-A", body, "stale body served when revalidation errors")
+		// No stale fallback: the transport error is surfaced to the caller.
+		req, err := http.NewRequest(http.MethodGet, testURL, nil)
+		require.NoError(t, err)
+		_, rtErr := h.tr.RoundTrip(req)
+		require.Error(t, rtErr, "revalidation transport error must be surfaced, not masked by stale")
+		assert.Contains(t, rtErr.Error(), "connection refused")
 		assert.Equal(t, 2, h.base.calls)
-		require.NotEmpty(t, h.log.warns, "stale fallback must be logged at Warn")
-		assert.Contains(t, h.log.warns[0], "serving stale cache")
 	})
 }
 
-func TestStaleServedOn5xx(t *testing.T) {
+func TestRevalidation5xxPassedThrough(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		h := newHarness(t, func(_ *http.Request, n int) (*http.Response, error) {
 			if n == 1 {
@@ -311,11 +312,10 @@ func TestStaleServedOn5xx(t *testing.T) {
 
 		time.Sleep(61 * time.Second)
 
-		status, body := h.get(testURL)
-		assert.Equal(t, http.StatusOK, status)
-		assert.Equal(t, "BODY-A", body, "stale body served on 5xx revalidation")
-		require.NotEmpty(t, h.log.warns)
-		assert.Contains(t, h.log.warns[0], "revalidation status 502")
+		// No stale fallback: the 5xx is passed through unchanged.
+		status, _ := h.get(testURL)
+		assert.Equal(t, http.StatusBadGateway, status, "5xx revalidation is passed through, not masked by stale")
+		assert.Equal(t, 2, h.base.calls)
 	})
 }
 

--- a/internal/httpcache/httpcache_test.go
+++ b/internal/httpcache/httpcache_test.go
@@ -1,6 +1,8 @@
 package httpcache
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -88,13 +91,28 @@ func (h *harness) get(url string) (int, string) {
 	return resp.StatusCode, string(body)
 }
 
+// entryNames lists real cache entry dirs under root, skipping the ".tmp"
+// staging dir (and any other dotfile).
+func entryNames(t *testing.T, root string) []string {
+	t.Helper()
+	dirEntries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	var names []string
+	for _, e := range dirEntries {
+		if strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	return names
+}
+
 // readMeta loads the single cache entry's meta.json (fails if not exactly one).
 func (h *harness) readMeta() Meta {
 	h.t.Helper()
-	entries, err := os.ReadDir(h.root)
-	require.NoError(h.t, err)
-	require.Len(h.t, entries, 1, "expected exactly one cache entry")
-	data, err := os.ReadFile(filepath.Join(h.root, entries[0].Name(), metaFilename))
+	names := entryNames(h.t, h.root)
+	require.Len(h.t, names, 1, "expected exactly one cache entry")
+	data, err := os.ReadFile(filepath.Join(h.root, names[0], metaFilename))
 	require.NoError(h.t, err)
 	var m Meta
 	require.NoError(h.t, json.Unmarshal(data, &m))
@@ -123,13 +141,12 @@ func TestMissThenHit(t *testing.T) {
 		assert.Equal(t, 1, h.base.calls, "fresh hit must not hit the network")
 
 		// Disk layout + metadata.
-		entries, err := os.ReadDir(h.root)
-		require.NoError(t, err)
-		require.Len(t, entries, 1)
-		assert.True(t, strings.HasSuffix(entries[0].Name(), "-latest.json"),
-			"entry dir keeps the human-readable basename: %s", entries[0].Name())
+		names := entryNames(t, h.root)
+		require.Len(t, names, 1)
+		assert.True(t, strings.HasSuffix(names[0], "-latest.json"),
+			"entry dir keeps the human-readable basename: %s", names[0])
 
-		bodyPath := filepath.Join(h.root, entries[0].Name(), "latest.json")
+		bodyPath := filepath.Join(h.root, names[0], "latest.json")
 		onDisk, err := os.ReadFile(bodyPath)
 		require.NoError(t, err)
 		assert.Equal(t, `{"latest":"8.5.0"}`, string(onDisk), "body stored under its real name")
@@ -335,10 +352,9 @@ func TestCorruptBodyRefetched(t *testing.T) {
 		require.Equal(t, 1, h.base.calls)
 
 		// Corrupt the stored body in place (simulating bit-rot / a torn write).
-		entries, err := os.ReadDir(h.root)
-		require.NoError(t, err)
-		require.Len(t, entries, 1)
-		bodyPath := filepath.Join(h.root, entries[0].Name(), "latest.json")
+		names := entryNames(t, h.root)
+		require.Len(t, names, 1)
+		bodyPath := filepath.Join(h.root, names[0], "latest.json")
 		require.NoError(t, os.WriteFile(bodyPath, []byte("CORRUPT"), 0o644))
 
 		// Still within max-age, but the checksum no longer matches -> refetch.
@@ -359,9 +375,7 @@ func TestNoStoreNotCached(t *testing.T) {
 		_, body := h.get(testURL)
 		assert.Equal(t, "SECRET", body)
 
-		entries, err := os.ReadDir(h.root)
-		require.NoError(t, err)
-		assert.Empty(t, entries, "no-store response must not be written to disk")
+		assert.Empty(t, entryNames(t, h.root), "no-store response must not be written to disk")
 
 		_, body = h.get(testURL)
 		assert.Equal(t, "SECRET", body)
@@ -389,6 +403,55 @@ func TestBodyFilename(t *testing.T) {
 	}
 }
 
+// TestConcurrentSaveConsistent hammers the same key with concurrent Saves of
+// different bodies and asserts the surviving entry is always internally
+// consistent — its body matches the checksum in its own meta.json. This is the
+// invariant the whole-entry atomic rename guarantees: an entry dir is only ever
+// a complete, single-writer pair, never a mix of one writer's body and
+// another's meta. Run with -race.
+func TestConcurrentSaveConsistent(t *testing.T) {
+	store := NewStore(t.TempDir())
+	const key = "deadbeef-latest.json"
+	const n = 16
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			body := fmt.Appendf(nil, "body-%02d-%s", i, strings.Repeat("x", i))
+			sum := sha256.Sum256(body)
+			//nolint:exhaustruct // only the body-integrity fields matter here
+			m := Meta{
+				URL:        "https://h/latest.json",
+				Method:     http.MethodGet,
+				Status:     http.StatusOK,
+				BodyFile:   "latest.json",
+				BodySHA256: "sha256-" + hex.EncodeToString(sum[:]),
+				BodySize:   int64(len(body)),
+			}
+			errCh <- store.Save(key, m, body)
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+
+	committed := 0
+	for err := range errCh {
+		if err == nil {
+			committed++
+		}
+	}
+	require.GreaterOrEqual(t, committed, 1, "at least one writer must commit the entry")
+
+	m, found, err := store.Lookup(key)
+	require.NoError(t, err)
+	require.True(t, found, "entry must exist after concurrent writes")
+	_, err = store.ReadBody(key, m)
+	require.NoError(t, err, "surviving entry's body must match its own meta checksum")
+}
+
 func TestNonGETPassThrough(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		h := newHarness(t, func(_ *http.Request, _ int) (*http.Response, error) {
@@ -403,9 +466,7 @@ func TestNonGETPassThrough(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, resp.Body.Close())
 
-		entries, err := os.ReadDir(h.root)
-		require.NoError(t, err)
-		assert.Empty(t, entries, "non-GET responses are not cached")
+		assert.Empty(t, entryNames(t, h.root), "non-GET responses are not cached")
 	})
 }
 
@@ -418,8 +479,6 @@ func TestNon2xxNotCached(t *testing.T) {
 		status, _ := h.get(testURL)
 		assert.Equal(t, http.StatusNotFound, status, "non-2xx passes through unchanged")
 
-		entries, err := os.ReadDir(h.root)
-		require.NoError(t, err)
-		assert.Empty(t, entries, "404 must not be cached")
+		assert.Empty(t, entryNames(t, h.root), "404 must not be cached")
 	})
 }

--- a/internal/httpcache/httpcache_test.go
+++ b/internal/httpcache/httpcache_test.go
@@ -1,0 +1,376 @@
+package httpcache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testURL = "https://steplib.example/spec/steps/git-clone/latest.json"
+
+// fakeRT is an in-memory http.RoundTripper. Keeping the network in-memory means
+// every goroutine stays inside the synctest bubble, so the fake clock and
+// quiescence behave (a real httptest.Server would spawn goroutines outside it).
+type fakeRT struct {
+	calls int
+	fn    func(req *http.Request, callNum int) (*http.Response, error)
+}
+
+func (f *fakeRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.calls++
+	return f.fn(req, f.calls)
+}
+
+func makeResp(status int, body string, header map[string]string) *http.Response {
+	h := http.Header{}
+	for k, v := range header {
+		h.Set(k, v)
+	}
+	return &http.Response{
+		StatusCode:    status,
+		Header:        h,
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}
+
+// recLogger records Warnf lines so tests can assert the stale-fallback notice.
+type recLogger struct{ warns []string }
+
+func (l *recLogger) Debugf(string, ...any) {}
+func (l *recLogger) Warnf(format string, v ...any) {
+	l.warns = append(l.warns, fmt.Sprintf(format, v...))
+}
+
+type harness struct {
+	t    *testing.T
+	tr   *Transport
+	base *fakeRT
+	log  *recLogger
+	root string
+}
+
+func newHarness(t *testing.T, fn func(req *http.Request, callNum int) (*http.Response, error)) *harness {
+	t.Helper()
+	root := t.TempDir()
+	base := &fakeRT{fn: fn}
+	log := &recLogger{}
+	return &harness{
+		t:    t,
+		tr:   NewTransport(base, NewStore(root), log),
+		base: base,
+		log:  log,
+		root: root,
+	}
+}
+
+// get issues a GET through the cache and returns the status and body.
+func (h *harness) get(url string) (int, string) {
+	h.t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(h.t, err)
+	resp, err := h.tr.RoundTrip(req)
+	require.NoError(h.t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(h.t, err)
+	require.NoError(h.t, resp.Body.Close())
+	return resp.StatusCode, string(body)
+}
+
+// readMeta loads the single cache entry's meta.json (fails if not exactly one).
+func (h *harness) readMeta() Meta {
+	h.t.Helper()
+	entries, err := os.ReadDir(h.root)
+	require.NoError(h.t, err)
+	require.Len(h.t, entries, 1, "expected exactly one cache entry")
+	data, err := os.ReadFile(filepath.Join(h.root, entries[0].Name(), metaFilename))
+	require.NoError(h.t, err)
+	var m Meta
+	require.NoError(h.t, json.Unmarshal(data, &m))
+	return m
+}
+
+func TestMissThenHit(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, _ int) (*http.Response, error) {
+			return makeResp(http.StatusOK, `{"latest":"8.5.0"}`, map[string]string{
+				"Content-Type":  "application/json",
+				"ETag":          `"v1"`,
+				"Cache-Control": "public, max-age=60, must-revalidate",
+			}), nil
+		})
+
+		status, body := h.get(testURL)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `{"latest":"8.5.0"}`, body)
+		assert.Equal(t, 1, h.base.calls, "first GET hits the network")
+
+		// Second GET while still fresh: served from disk, no network.
+		status, body = h.get(testURL)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `{"latest":"8.5.0"}`, body)
+		assert.Equal(t, 1, h.base.calls, "fresh hit must not hit the network")
+
+		// Disk layout + metadata.
+		entries, err := os.ReadDir(h.root)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.True(t, strings.HasSuffix(entries[0].Name(), "-latest.json"),
+			"entry dir keeps the human-readable basename: %s", entries[0].Name())
+
+		bodyPath := filepath.Join(h.root, entries[0].Name(), "latest.json")
+		onDisk, err := os.ReadFile(bodyPath)
+		require.NoError(t, err)
+		assert.Equal(t, `{"latest":"8.5.0"}`, string(onDisk), "body stored under its real name")
+
+		m := h.readMeta()
+		assert.Equal(t, testURL, m.URL)
+		assert.Equal(t, `"v1"`, m.ETag)
+		assert.Equal(t, "latest.json", m.BodyFile)
+		assert.Equal(t, int64(len(body)), m.BodySize)
+		assert.True(t, strings.HasPrefix(m.BodySHA256, "sha256-"), "SRI hash format: %s", m.BodySHA256)
+		assert.Equal(t, m.FetchedAt.Add(60*time.Second), m.ExpiresAt, "ExpiresAt = FetchedAt + max-age")
+	})
+}
+
+func TestRevalidation304(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(req *http.Request, n int) (*http.Response, error) {
+			if n == 1 {
+				return makeResp(http.StatusOK, "BODY-A", map[string]string{
+					"ETag":          `"v1"`,
+					"Cache-Control": "max-age=60",
+				}), nil
+			}
+			// Conditional request must carry the stored validator.
+			assert.Equal(t, `"v1"`, req.Header.Get("If-None-Match"))
+			return makeResp(http.StatusNotModified, "", map[string]string{
+				"Cache-Control": "max-age=60",
+			}), nil
+		})
+
+		_, body := h.get(testURL)
+		require.Equal(t, "BODY-A", body)
+		firstFetchedAt := h.readMeta().FetchedAt
+
+		time.Sleep(61 * time.Second) // entry goes stale (fake clock, instant)
+
+		status, body := h.get(testURL)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "BODY-A", body, "304 serves the cached body")
+		assert.Equal(t, 2, h.base.calls, "stale entry triggers one revalidation")
+
+		m := h.readMeta()
+		assert.True(t, m.FetchedAt.After(firstFetchedAt), "304 refreshes FetchedAt")
+		assert.Equal(t, m.FetchedAt.Add(60*time.Second), m.ExpiresAt)
+	})
+}
+
+// TestRevalidation304PreservesMaxAge guards against a 304 that omits
+// Cache-Control wiping the entry's original max-age. After revalidation the
+// entry must be fresh again for the original window (served from disk without a
+// further network call), not collapsed to revalidate-every-request.
+func TestRevalidation304PreservesMaxAge(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, n int) (*http.Response, error) {
+			if n == 1 {
+				return makeResp(http.StatusOK, "BODY-A", map[string]string{
+					"ETag":          `"v1"`,
+					"Cache-Control": "public, max-age=60, must-revalidate",
+				}), nil
+			}
+			// 304 deliberately carries NO Cache-Control header (common from CDNs).
+			return makeResp(http.StatusNotModified, "", nil), nil
+		})
+
+		_, body := h.get(testURL)
+		require.Equal(t, "BODY-A", body)
+
+		time.Sleep(61 * time.Second) // stale -> triggers revalidation
+		_, body = h.get(testURL)
+		require.Equal(t, "BODY-A", body)
+		require.Equal(t, 2, h.base.calls, "one revalidation after going stale")
+
+		m := h.readMeta()
+		assert.Equal(t, "public, max-age=60, must-revalidate", m.CacheControl,
+			"original Cache-Control preserved across a header-less 304")
+		assert.Equal(t, m.FetchedAt.Add(60*time.Second), m.ExpiresAt,
+			"freshness window restored to the original max-age")
+
+		// Within the restored window the entry is served from disk, no network.
+		time.Sleep(30 * time.Second)
+		_, body = h.get(testURL)
+		assert.Equal(t, "BODY-A", body)
+		assert.Equal(t, 2, h.base.calls, "must stay fresh for the original max-age, not revalidate every request")
+	})
+}
+
+func TestRevalidation200Replacement(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, n int) (*http.Response, error) {
+			if n == 1 {
+				return makeResp(http.StatusOK, "BODY-A", map[string]string{
+					"ETag":          `"v1"`,
+					"Cache-Control": "max-age=60",
+				}), nil
+			}
+			return makeResp(http.StatusOK, "BODY-B", map[string]string{
+				"ETag":          `"v2"`,
+				"Cache-Control": "max-age=60",
+			}), nil
+		})
+
+		_, body := h.get(testURL)
+		require.Equal(t, "BODY-A", body)
+
+		time.Sleep(61 * time.Second)
+
+		_, body = h.get(testURL)
+		assert.Equal(t, "BODY-B", body, "new 200 replaces the cached body")
+		assert.Equal(t, 2, h.base.calls)
+		assert.Equal(t, `"v2"`, h.readMeta().ETag, "metadata updated to new validator")
+
+		// Freshly stored entry is served from disk on the next call.
+		_, body = h.get(testURL)
+		assert.Equal(t, "BODY-B", body)
+		assert.Equal(t, 2, h.base.calls, "replacement entry is fresh again")
+	})
+}
+
+func TestImmutableNeverRevalidates(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, _ int) (*http.Response, error) {
+			return makeResp(http.StatusOK, "STEP-JSON", map[string]string{
+				"Cache-Control": "public, max-age=31536000, immutable",
+			}), nil
+		})
+
+		_, body := h.get(testURL)
+		require.Equal(t, "STEP-JSON", body)
+
+		time.Sleep(2 * 365 * 24 * time.Hour) // two years later
+
+		_, body = h.get(testURL)
+		assert.Equal(t, "STEP-JSON", body)
+		assert.Equal(t, 1, h.base.calls, "immutable entry is never revalidated")
+		assert.True(t, h.readMeta().Immutable)
+	})
+}
+
+func TestStaleServedOnError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, n int) (*http.Response, error) {
+			if n == 1 {
+				return makeResp(http.StatusOK, "BODY-A", map[string]string{
+					"ETag":          `"v1"`,
+					"Cache-Control": "max-age=60",
+				}), nil
+			}
+			return nil, errors.New("connection refused")
+		})
+
+		_, body := h.get(testURL)
+		require.Equal(t, "BODY-A", body)
+
+		time.Sleep(61 * time.Second)
+
+		status, body := h.get(testURL)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "BODY-A", body, "stale body served when revalidation errors")
+		assert.Equal(t, 2, h.base.calls)
+		require.NotEmpty(t, h.log.warns, "stale fallback must be logged at Warn")
+		assert.Contains(t, h.log.warns[0], "serving stale cache")
+	})
+}
+
+func TestStaleServedOn5xx(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, n int) (*http.Response, error) {
+			if n == 1 {
+				return makeResp(http.StatusOK, "BODY-A", map[string]string{
+					"ETag":          `"v1"`,
+					"Cache-Control": "max-age=60",
+				}), nil
+			}
+			return makeResp(http.StatusBadGateway, "upstream boom", nil), nil
+		})
+
+		_, body := h.get(testURL)
+		require.Equal(t, "BODY-A", body)
+
+		time.Sleep(61 * time.Second)
+
+		status, body := h.get(testURL)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "BODY-A", body, "stale body served on 5xx revalidation")
+		require.NotEmpty(t, h.log.warns)
+		assert.Contains(t, h.log.warns[0], "revalidation status 502")
+	})
+}
+
+func TestNoStoreNotCached(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, _ int) (*http.Response, error) {
+			return makeResp(http.StatusOK, "SECRET", map[string]string{
+				"Cache-Control": "no-store",
+			}), nil
+		})
+
+		_, body := h.get(testURL)
+		assert.Equal(t, "SECRET", body)
+
+		entries, err := os.ReadDir(h.root)
+		require.NoError(t, err)
+		assert.Empty(t, entries, "no-store response must not be written to disk")
+
+		_, body = h.get(testURL)
+		assert.Equal(t, "SECRET", body)
+		assert.Equal(t, 2, h.base.calls, "no-store is re-fetched every time")
+	})
+}
+
+func TestNonGETPassThrough(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, _ int) (*http.Response, error) {
+			return makeResp(http.StatusOK, "POSTED", map[string]string{
+				"Cache-Control": "max-age=60",
+			}), nil
+		})
+
+		req, err := http.NewRequest(http.MethodPost, testURL, strings.NewReader("x"))
+		require.NoError(t, err)
+		resp, err := h.tr.RoundTrip(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+
+		entries, err := os.ReadDir(h.root)
+		require.NoError(t, err)
+		assert.Empty(t, entries, "non-GET responses are not cached")
+	})
+}
+
+func TestNon2xxNotCached(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newHarness(t, func(_ *http.Request, _ int) (*http.Response, error) {
+			return makeResp(http.StatusNotFound, "nope", nil), nil
+		})
+
+		status, _ := h.get(testURL)
+		assert.Equal(t, http.StatusNotFound, status, "non-2xx passes through unchanged")
+
+		entries, err := os.ReadDir(h.root)
+		require.NoError(t, err)
+		assert.Empty(t, entries, "404 must not be cached")
+	})
+}

--- a/internal/httpcache/store.go
+++ b/internal/httpcache/store.go
@@ -38,8 +38,9 @@ type Meta struct {
 // Store is an on-disk HTTP cache laid out as one directory per entry, named
 // "<sha256(method+url)>-<basename>" (Nix-inspired: a machine-readable hash plus
 // a human-readable name). Each directory holds the body verbatim under its real
-// basename and a meta.json describing it. Entries are never auto-evicted, so a
-// stale entry stays available as a last-resort fallback when the network fails.
+// basename and a meta.json describing it. A single ".tmp" subdir holds
+// half-built entries before they are atomically renamed into place. Entries are
+// never auto-evicted.
 type Store struct {
 	root string
 }
@@ -53,6 +54,14 @@ func NewStore(dir string) *Store {
 func (s *Store) entryDir(key string) string { return filepath.Join(s.root, key) }
 
 func (s *Store) metaPath(key string) string { return filepath.Join(s.entryDir(key), metaFilename) }
+
+// stagingDir holds half-built entries before they are atomically renamed into
+// place. It lives under root so the rename stays on one filesystem (a
+// cross-filesystem rename would fail), keeps the root listing free of temp
+// dirs, and gives a GC a single place to sweep orphaned staging dirs. Its
+// leading dot keeps it from colliding with any entry key (keys start with a hex
+// hash).
+func (s *Store) stagingDir() string { return filepath.Join(s.root, ".tmp") }
 
 // Lookup reads the entry's meta.json. A missing entry or an unparseable
 // meta.json is reported as a miss (found == false) with no error, so a corrupt
@@ -94,33 +103,71 @@ func (s *Store) ReadBody(key string, m Meta) ([]byte, error) {
 	return data, nil
 }
 
-// Save writes the body and then meta.json into the entry directory, each via a
-// temp-file-plus-rename so a partially written entry is never observable. The
-// body is written before meta.json: a directory without a valid meta.json reads
-// back as a miss.
-func (s *Store) Save(key string, m Meta, body []byte) error {
-	dir := s.entryDir(key)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create cache dir %s: %w", dir, err)
+// Save writes the body and meta.json into a fresh staging directory and then
+// renames that directory into place as a single atomic step. Committing the
+// whole entry at once means a reader (or a concurrent writer) never observes a
+// directory whose meta.json and body came from different writes: an entry dir
+// is only ever created by an atomic rename of a fully-written staging dir, so
+// it is always complete (or absent). When the entry already exists it is
+// replaced; a concurrent writer of the same key may win the rename instead,
+// which is fine since both wrote the same resource.
+func (s *Store) Save(key string, m Meta, body []byte) (err error) {
+	staging := s.stagingDir()
+	if mkErr := os.MkdirAll(staging, 0o755); mkErr != nil {
+		return fmt.Errorf("create staging dir %s: %w", staging, mkErr)
 	}
-	if err := writeFileAtomic(filepath.Join(dir, m.BodyFile), body, 0o644); err != nil {
+	tmpDir, err := os.MkdirTemp(staging, "entry-*")
+	if err != nil {
+		return fmt.Errorf("create temp entry dir in %s: %w", staging, err)
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, os.RemoveAll(tmpDir))
+		}
+	}()
+
+	metaBytes, err := marshalMeta(m)
+	if err != nil {
 		return err
 	}
-	return s.writeMeta(key, m)
+	if werr := os.WriteFile(filepath.Join(tmpDir, m.BodyFile), body, 0o644); werr != nil {
+		return fmt.Errorf("write body in %s: %w", tmpDir, werr)
+	}
+	if werr := os.WriteFile(filepath.Join(tmpDir, metaFilename), metaBytes, 0o644); werr != nil {
+		return fmt.Errorf("write meta in %s: %w", tmpDir, werr)
+	}
+	if cherr := os.Chmod(tmpDir, 0o755); cherr != nil {
+		return fmt.Errorf("chmod %s: %w", tmpDir, cherr)
+	}
+
+	entryDir := s.entryDir(key)
+	if rmErr := os.RemoveAll(entryDir); rmErr != nil {
+		return fmt.Errorf("clear existing entry %s: %w", entryDir, rmErr)
+	}
+	if rnErr := os.Rename(tmpDir, entryDir); rnErr != nil {
+		return fmt.Errorf("commit entry %s: %w", entryDir, rnErr)
+	}
+	return nil
 }
 
 // Touch rewrites meta.json only, used to refresh timestamps/validators after a
-// 304 Not Modified without rewriting the unchanged body.
+// 304 Not Modified without rewriting the unchanged body. The body filename and
+// content are unchanged, so the in-place atomic meta rewrite keeps the entry
+// self-consistent.
 func (s *Store) Touch(key string, m Meta) error {
-	return s.writeMeta(key, m)
+	metaBytes, err := marshalMeta(m)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(s.metaPath(key), metaBytes, 0o644)
 }
 
-func (s *Store) writeMeta(key string, m Meta) error {
+func marshalMeta(m Meta) ([]byte, error) {
 	data, err := json.MarshalIndent(m, "", "\t")
 	if err != nil {
-		return fmt.Errorf("marshal cache meta %s: %w", key, err)
+		return nil, fmt.Errorf("marshal cache meta: %w", err)
 	}
-	return writeFileAtomic(s.metaPath(key), append(data, '\n'), 0o644)
+	return append(data, '\n'), nil
 }
 
 // writeFileAtomic writes data to a temp file in the destination directory and

--- a/internal/httpcache/store.go
+++ b/internal/httpcache/store.go
@@ -1,0 +1,146 @@
+package httpcache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const metaFilename = "meta.json"
+
+// Meta is the human-readable metadata stored beside each cached body in
+// meta.json. It records where the body came from, the validators needed for
+// conditional revalidation, and when the entry stops being fresh.
+type Meta struct {
+	URL          string    `json:"url"`
+	Method       string    `json:"method"`
+	Status       int       `json:"status"`
+	ETag         string    `json:"etag,omitempty"`
+	LastModified string    `json:"last_modified,omitempty"`
+	CacheControl string    `json:"cache_control,omitempty"`
+	ContentType  string    `json:"content_type,omitempty"`
+	FetchedAt    time.Time `json:"fetched_at"`
+	// ExpiresAt is FetchedAt+max-age; equal to FetchedAt when the response must
+	// be revalidated before every reuse. Ignored when Immutable is true.
+	ExpiresAt  time.Time `json:"expires_at"`
+	Immutable  bool      `json:"immutable"`
+	BodyFile   string    `json:"body_file"`   // basename of the body file in this entry dir
+	BodySHA256 string    `json:"body_sha256"` // "sha256-<hex>"
+	BodySize   int64     `json:"body_size"`
+}
+
+// Store is an on-disk HTTP cache laid out as one directory per entry, named
+// "<sha256(method+url)>-<basename>" (Nix-inspired: a machine-readable hash plus
+// a human-readable name). Each directory holds the body verbatim under its real
+// basename and a meta.json describing it. Entries are never auto-evicted, so a
+// stale entry stays available as a last-resort fallback when the network fails.
+type Store struct {
+	root string
+}
+
+// NewStore returns a Store rooted at dir. The directory is created lazily on
+// the first Save.
+func NewStore(dir string) *Store {
+	return &Store{root: dir}
+}
+
+func (s *Store) entryDir(key string) string { return filepath.Join(s.root, key) }
+
+func (s *Store) metaPath(key string) string { return filepath.Join(s.entryDir(key), metaFilename) }
+
+// Lookup reads the entry's meta.json. A missing entry, an unparseable meta.json,
+// or a meta.json whose body file is gone are all reported as a miss (found ==
+// false) with no error, so a corrupt entry simply triggers a refetch. A real
+// error is returned only for unexpected IO failures.
+func (s *Store) Lookup(key string) (meta Meta, found bool, err error) {
+	data, err := os.ReadFile(s.metaPath(key))
+	if errors.Is(err, fs.ErrNotExist) {
+		return Meta{}, false, nil
+	}
+	if err != nil {
+		return Meta{}, false, fmt.Errorf("read cache meta %s: %w", s.metaPath(key), err)
+	}
+
+	var m Meta
+	if uerr := json.Unmarshal(data, &m); uerr != nil {
+		return Meta{}, false, nil // corrupt metadata -> treat as miss
+	}
+	if _, serr := os.Stat(filepath.Join(s.entryDir(key), m.BodyFile)); serr != nil {
+		return Meta{}, false, nil // body gone -> treat as miss
+	}
+	return m, true, nil
+}
+
+// Open returns a reader over the cached body. The caller closes it.
+func (s *Store) Open(key string, m Meta) (io.ReadCloser, error) {
+	f, err := os.Open(filepath.Join(s.entryDir(key), m.BodyFile))
+	if err != nil {
+		return nil, fmt.Errorf("open cached body %s: %w", key, err)
+	}
+	return f, nil
+}
+
+// Save writes the body and then meta.json into the entry directory, each via a
+// temp-file-plus-rename so a partially written entry is never observable. The
+// body is written before meta.json: a directory without a valid meta.json reads
+// back as a miss.
+func (s *Store) Save(key string, m Meta, body []byte) error {
+	dir := s.entryDir(key)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create cache dir %s: %w", dir, err)
+	}
+	if err := writeFileAtomic(filepath.Join(dir, m.BodyFile), body, 0o644); err != nil {
+		return err
+	}
+	return s.writeMeta(key, m)
+}
+
+// Touch rewrites meta.json only, used to refresh timestamps/validators after a
+// 304 Not Modified without rewriting the unchanged body.
+func (s *Store) Touch(key string, m Meta) error {
+	return s.writeMeta(key, m)
+}
+
+func (s *Store) writeMeta(key string, m Meta) error {
+	data, err := json.MarshalIndent(m, "", "\t")
+	if err != nil {
+		return fmt.Errorf("marshal cache meta %s: %w", key, err)
+	}
+	return writeFileAtomic(s.metaPath(key), append(data, '\n'), 0o644)
+}
+
+// writeFileAtomic writes data to a temp file in the destination directory and
+// renames it into place, so readers never see a half-written file. The
+// destination directory must already exist.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) (err error) {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, os.Remove(tmpName))
+		}
+	}()
+
+	if _, werr := tmp.Write(data); werr != nil {
+		return errors.Join(fmt.Errorf("write %s: %w", tmpName, werr), tmp.Close())
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		return fmt.Errorf("close %s: %w", tmpName, cerr)
+	}
+	if cherr := os.Chmod(tmpName, perm); cherr != nil {
+		return fmt.Errorf("chmod %s: %w", tmpName, cherr)
+	}
+	if rerr := os.Rename(tmpName, path); rerr != nil {
+		return fmt.Errorf("rename %s to %s: %w", tmpName, path, rerr)
+	}
+	return nil
+}

--- a/internal/httpcache/store.go
+++ b/internal/httpcache/store.go
@@ -1,8 +1,6 @@
 package httpcache
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/bitrise-io/stepman/internal/sri"
 )
 
 const metaFilename = "meta.json"
@@ -95,8 +95,7 @@ func (s *Store) ReadBody(key string, m Meta) ([]byte, error) {
 		return nil, fmt.Errorf("read cached body %s: %w", key, err)
 	}
 	if m.BodySHA256 != "" {
-		sum := sha256.Sum256(data)
-		if got := "sha256-" + hex.EncodeToString(sum[:]); got != m.BodySHA256 {
+		if got := sri.SHA256(data); got != m.BodySHA256 {
 			return nil, fmt.Errorf("cached body %s checksum mismatch: have %s, want %s", key, got, m.BodySHA256)
 		}
 	}

--- a/internal/httpcache/store.go
+++ b/internal/httpcache/store.go
@@ -1,10 +1,11 @@
 package httpcache
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -53,10 +54,11 @@ func (s *Store) entryDir(key string) string { return filepath.Join(s.root, key) 
 
 func (s *Store) metaPath(key string) string { return filepath.Join(s.entryDir(key), metaFilename) }
 
-// Lookup reads the entry's meta.json. A missing entry, an unparseable meta.json,
-// or a meta.json whose body file is gone are all reported as a miss (found ==
-// false) with no error, so a corrupt entry simply triggers a refetch. A real
-// error is returned only for unexpected IO failures.
+// Lookup reads the entry's meta.json. A missing entry or an unparseable
+// meta.json is reported as a miss (found == false) with no error, so a corrupt
+// entry simply triggers a refetch. A real error is returned only for unexpected
+// IO failures. The body file's existence and integrity are checked separately
+// by ReadBody, so a hit here does not guarantee a usable body.
 func (s *Store) Lookup(key string) (meta Meta, found bool, err error) {
 	data, err := os.ReadFile(s.metaPath(key))
 	if errors.Is(err, fs.ErrNotExist) {
@@ -70,19 +72,26 @@ func (s *Store) Lookup(key string) (meta Meta, found bool, err error) {
 	if uerr := json.Unmarshal(data, &m); uerr != nil {
 		return Meta{}, false, nil // corrupt metadata -> treat as miss
 	}
-	if _, serr := os.Stat(filepath.Join(s.entryDir(key), m.BodyFile)); serr != nil {
-		return Meta{}, false, nil // body gone -> treat as miss
-	}
 	return m, true, nil
 }
 
-// Open returns a reader over the cached body. The caller closes it.
-func (s *Store) Open(key string, m Meta) (io.ReadCloser, error) {
-	f, err := os.Open(filepath.Join(s.entryDir(key), m.BodyFile))
+// ReadBody reads the cached body and verifies it against m.BodySHA256. A read
+// failure (body gone) or a checksum mismatch (corruption / a torn concurrent
+// write) is returned as an error so the caller treats the entry as unusable and
+// refetches. Loading the body here in one read also avoids a separate
+// existence-stat, closing the stat/open TOCTOU window.
+func (s *Store) ReadBody(key string, m Meta) ([]byte, error) {
+	data, err := os.ReadFile(filepath.Join(s.entryDir(key), m.BodyFile))
 	if err != nil {
-		return nil, fmt.Errorf("open cached body %s: %w", key, err)
+		return nil, fmt.Errorf("read cached body %s: %w", key, err)
 	}
-	return f, nil
+	if m.BodySHA256 != "" {
+		sum := sha256.Sum256(data)
+		if got := "sha256-" + hex.EncodeToString(sum[:]); got != m.BodySHA256 {
+			return nil, fmt.Errorf("cached body %s checksum mismatch: have %s, want %s", key, got, m.BodySHA256)
+		}
+	}
+	return data, nil
 }
 
 // Save writes the body and then meta.json into the entry directory, each via a

--- a/internal/httpfetch/httpfetch.go
+++ b/internal/httpfetch/httpfetch.go
@@ -7,7 +7,6 @@ package httpfetch
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +15,7 @@ import (
 	"path/filepath"
 
 	"github.com/bitrise-io/stepman/internal/httpcache"
+	"github.com/bitrise-io/stepman/internal/sri"
 	"github.com/hashicorp/go-retryablehttp"
 )
 
@@ -187,5 +187,5 @@ func (c *client) fetchToTemp(ctx context.Context, dir, url string) (path string,
 	if _, copyErr := io.Copy(io.MultiWriter(tmp, h), body); copyErr != nil {
 		return "", "", fmt.Errorf("write to %s: %w", tmp.Name(), copyErr)
 	}
-	return tmp.Name(), "sha256-" + hex.EncodeToString(h.Sum(nil)), nil
+	return tmp.Name(), sri.Format(h.Sum(nil)), nil
 }

--- a/internal/httpfetch/httpfetch.go
+++ b/internal/httpfetch/httpfetch.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/bitrise-io/stepman/internal/httpcache"
 	"github.com/hashicorp/go-retryablehttp"
 )
 
@@ -67,6 +68,30 @@ func NewClient(logger Logger) Client {
 // non-nil. Prefer NewClient unless you need a specific transport.
 func NewWithClient(httpClient *http.Client) Client {
 	return &client{httpClient: httpClient}
+}
+
+// NewCachingClient is like NewClient but routes requests through an on-disk
+// HTTP cache rooted at cacheDir. The cache honors the server's
+// Cache-Control/ETag, serves fresh entries without hitting the network, and
+// falls back to a stale entry when revalidation fails — so callers get
+// graceful degradation during a CDN/network outage. Retries layer above the
+// cache: a cache hit returns immediately, and only a genuine miss-and-failure
+// is retried.
+//
+// logger must satisfy httpcache.Logger (Debugf+Warnf); stepman.Logger does.
+func NewCachingClient(logger httpcache.Logger, cacheDir string) Client {
+	rc := retryablehttp.NewClient()
+	rc.Logger = &retryhttpLogger{l: logger}
+	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+
+	base := rc.HTTPClient.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	store := httpcache.NewStore(cacheDir)
+	rc.HTTPClient.Transport = httpcache.NewTransport(base, store, logger)
+
+	return &client{httpClient: rc.StandardClient()}
 }
 
 func (c *client) Get(ctx context.Context, url string) (io.ReadCloser, error) {

--- a/internal/sri/sri.go
+++ b/internal/sri/sri.go
@@ -1,0 +1,33 @@
+// Package sri produces and formats Subresource-Integrity-style content
+// digests of the form "sha256-<hex>", the single hash format stepman uses for
+// precompiled binaries, V2 step manifests, and cached HTTP bodies.
+package sri
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+)
+
+// Prefix is the algorithm label on every digest this package produces.
+const Prefix = "sha256-"
+
+// Format renders a raw digest as "sha256-<hex>".
+func Format(sum []byte) string {
+	return Prefix + hex.EncodeToString(sum)
+}
+
+// SHA256 returns the "sha256-<hex>" digest of data.
+func SHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return Format(sum[:])
+}
+
+// SHA256Reader returns the "sha256-<hex>" digest of everything read from r.
+func SHA256Reader(r io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", err
+	}
+	return Format(h.Sum(nil)), nil
+}

--- a/internal/sri/sri_test.go
+++ b/internal/sri/sri_test.go
@@ -1,0 +1,31 @@
+package sri
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// knownHash is the SHA-256 of "hello world", in this package's "sha256-<hex>"
+// format.
+const knownHash = "sha256-b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+
+func TestSHA256(t *testing.T) {
+	assert.Equal(t, knownHash, SHA256([]byte("hello world")))
+}
+
+func TestSHA256Reader(t *testing.T) {
+	got, err := SHA256Reader(strings.NewReader("hello world"))
+	require.NoError(t, err)
+	assert.Equal(t, knownHash, got)
+}
+
+func TestSHA256AndReaderAgree(t *testing.T) {
+	data := []byte("the quick brown fox")
+	fromReader, err := SHA256Reader(strings.NewReader(string(data)))
+	require.NoError(t, err)
+	assert.Equal(t, SHA256(data), fromReader)
+	assert.True(t, strings.HasPrefix(SHA256(data), Prefix))
+}

--- a/steplibrary/http_api_cache_integration_test.go
+++ b/steplibrary/http_api_cache_integration_test.go
@@ -1,0 +1,51 @@
+package steplibrary
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bitrise-io/stepman/internal/httpfetch"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type nopLogger struct{}
+
+func (nopLogger) Debugf(string, ...any) {}
+func (nopLogger) Warnf(string, ...any)  {}
+
+// TestHTTPAPI_cachingClient_reusesFreshEntry verifies the end-to-end wiring:
+// an HTTPAPI backed by httpfetch.NewCachingClient serves a second identical
+// request from disk while the entry is fresh, so the origin is hit only once.
+func TestHTTPAPI_cachingClient_reusesFreshEntry(t *testing.T) {
+	var hits atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/spec/steps/hello-step/latest.json", func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", `"v1"`)
+		w.Header().Set("Cache-Control", "public, max-age=60, must-revalidate")
+		_, err := w.Write([]byte(`{"step_id":"hello-step","latest":"2.0.0","latest_by_major":{"2":"2.0.0"}}`))
+		require.NoError(t, err)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	api := NewHTTPAPI(srv.URL, httpfetch.NewCachingClient(nopLogger{}, t.TempDir()))
+	ctx := context.Background()
+
+	first, err := api.GetLatestStepVersions(ctx, "hello-step")
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", first.Latest)
+
+	second, err := api.GetLatestStepVersions(ctx, "hello-step")
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", second.Latest)
+
+	assert.Equal(t, int32(1), hits.Load(), "fresh cache entry must be reused without re-hitting the origin")
+}

--- a/steplibrary/steplib.go
+++ b/steplibrary/steplib.go
@@ -29,9 +29,13 @@ type ActivateOutputPaths struct {
 // official steplib, whose git identity is rewritten to a compiled-in V2 host.
 func New(log stepman.Logger, steplibURI, inventoryURL string, isOfflineMode bool, fileManager fileutil.FileManager) *Steplib {
 	return &Steplib{
-		log:         log,
-		steplibURI:  steplibURI,
-		api:         NewHTTPAPI(inventoryURL, httpfetch.NewClient(log)),
+		log:        log,
+		steplibURI: steplibURI,
+		// The inventory API goes through the on-disk HTTP cache (Cache-Control /
+		// ETag aware, stale-on-error fallback). Binary downloads stay uncached:
+		// they are large, immutable, hash-verified, and already land at a
+		// content-addressed install path.
+		api:         NewHTTPAPI(inventoryURL, httpfetch.NewCachingClient(log, stepman.GetHTTPCacheDirPath())),
 		fileManager: fileManager,
 		fetcher:     httpfetch.NewClient(log),
 		source:      v1Source{steplibURI: steplibURI, isOfflineMode: isOfflineMode, log: log},

--- a/stepman/paths.go
+++ b/stepman/paths.go
@@ -20,6 +20,10 @@ const (
 	RoutingFilename = "routing.json"
 	// CollectionsDirname ...
 	CollectionsDirname = "step_collections"
+	// HTTPCacheDirname is the directory under ~/.stepman holding the V2
+	// inventory HTTP cache. It is global (shared across steplibs): cache keys
+	// are full URLs, which already encode the inventory identity.
+	HTTPCacheDirname = "http_cache"
 )
 
 // SteplibRoute ...
@@ -230,6 +234,12 @@ func GetStepmanDirPath() string {
 // GetCollectionsDirPath ...
 func GetCollectionsDirPath() string {
 	return filepath.Join(GetStepmanDirPath(), CollectionsDirname)
+}
+
+// GetHTTPCacheDirPath returns ~/.stepman/http_cache, the root of the V2
+// inventory HTTP cache.
+func GetHTTPCacheDirPath() string {
+	return filepath.Join(GetStepmanDirPath(), HTTPCacheDirname)
 }
 
 func getRoutingFilePath() string {

--- a/vendor/github.com/pquerna/cachecontrol/LICENSE
+++ b/vendor/github.com/pquerna/cachecontrol/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/pquerna/cachecontrol/cacheobject/directive.go
+++ b/vendor/github.com/pquerna/cachecontrol/cacheobject/directive.go
@@ -1,0 +1,554 @@
+/**
+ *  Copyright 2015 Paul Querna
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package cacheobject
+
+import (
+	"errors"
+	"math"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"strings"
+)
+
+// TODO(pquerna): add extensions from here: http://www.iana.org/assignments/http-cache-directives/http-cache-directives.xhtml
+
+var (
+	ErrQuoteMismatch         = errors.New("Missing closing quote")
+	ErrMaxAgeDeltaSeconds    = errors.New("Failed to parse delta-seconds in `max-age`")
+	ErrSMaxAgeDeltaSeconds   = errors.New("Failed to parse delta-seconds in `s-maxage`")
+	ErrMaxStaleDeltaSeconds  = errors.New("Failed to parse delta-seconds in `max-stale`")
+	ErrMinFreshDeltaSeconds  = errors.New("Failed to parse delta-seconds in `min-fresh`")
+	ErrNoCacheNoArgs         = errors.New("Unexpected argument to `no-cache`")
+	ErrNoStoreNoArgs         = errors.New("Unexpected argument to `no-store`")
+	ErrNoTransformNoArgs     = errors.New("Unexpected argument to `no-transform`")
+	ErrOnlyIfCachedNoArgs    = errors.New("Unexpected argument to `only-if-cached`")
+	ErrMustRevalidateNoArgs  = errors.New("Unexpected argument to `must-revalidate`")
+	ErrPublicNoArgs          = errors.New("Unexpected argument to `public`")
+	ErrProxyRevalidateNoArgs = errors.New("Unexpected argument to `proxy-revalidate`")
+	// Experimental
+	ErrImmutableNoArgs                  = errors.New("Unexpected argument to `immutable`")
+	ErrStaleIfErrorDeltaSeconds         = errors.New("Failed to parse delta-seconds in `stale-if-error`")
+	ErrStaleWhileRevalidateDeltaSeconds = errors.New("Failed to parse delta-seconds in `stale-while-revalidate`")
+)
+
+func whitespace(b byte) bool {
+	if b == '\t' || b == ' ' {
+		return true
+	}
+	return false
+}
+
+func parse(value string, cd cacheDirective) error {
+	var err error = nil
+	i := 0
+
+	for i < len(value) && err == nil {
+		// eat leading whitespace or commas
+		if whitespace(value[i]) || value[i] == ',' {
+			i++
+			continue
+		}
+
+		j := i + 1
+
+		for j < len(value) {
+			if !isToken(value[j]) {
+				break
+			}
+			j++
+		}
+
+		token := strings.ToLower(value[i:j])
+		tokenHasFields := hasFieldNames(token)
+		/*
+			println("GOT TOKEN:")
+			println("	i -> ", i)
+			println("	j -> ", j)
+			println("	token -> ", token)
+		*/
+
+		if j+1 < len(value) && value[j] == '=' {
+			k := j + 1
+			// minimum size two bytes of "", but we let httpUnquote handle it.
+			if k < len(value) && value[k] == '"' {
+				eaten, result := httpUnquote(value[k:])
+				if eaten == -1 {
+					return ErrQuoteMismatch
+				}
+				i = k + eaten
+
+				err = cd.addPair(token, result)
+			} else {
+				z := k
+				for z < len(value) {
+					if tokenHasFields {
+						if whitespace(value[z]) {
+							break
+						}
+					} else {
+						if whitespace(value[z]) || value[z] == ',' {
+							break
+						}
+					}
+					z++
+				}
+				i = z
+
+				result := value[k:z]
+				if result != "" && result[len(result)-1] == ',' {
+					result = result[:len(result)-1]
+				}
+
+				err = cd.addPair(token, result)
+			}
+		} else {
+			if token != "," {
+				err = cd.addToken(token)
+			}
+			i = j
+		}
+	}
+
+	return err
+}
+
+// DeltaSeconds specifies a non-negative integer, representing
+// time in seconds: http://tools.ietf.org/html/rfc7234#section-1.2.1
+//
+// When set to -1, this means unset.
+type DeltaSeconds int32
+
+// Parser for delta-seconds, a uint31, more or less:
+// http://tools.ietf.org/html/rfc7234#section-1.2.1
+func parseDeltaSeconds(v string) (DeltaSeconds, error) {
+	n, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		if numError, ok := err.(*strconv.NumError); ok {
+			if numError.Err == strconv.ErrRange {
+				return DeltaSeconds(math.MaxInt32), nil
+			}
+		}
+		return DeltaSeconds(-1), err
+	} else {
+		if n > math.MaxInt32 {
+			return DeltaSeconds(math.MaxInt32), nil
+		} else {
+			return DeltaSeconds(n), nil
+		}
+	}
+}
+
+// Fields present in a header.
+type FieldNames map[string]bool
+
+// internal interface for shared methods of RequestCacheDirectives and ResponseCacheDirectives
+type cacheDirective interface {
+	addToken(s string) error
+	addPair(s string, v string) error
+}
+
+// LOW LEVEL API: Representation of possible request directives in a `Cache-Control` header: http://tools.ietf.org/html/rfc7234#section-5.2.1
+//
+// Note: Many fields will be `nil` in practice.
+type RequestCacheDirectives struct {
+
+	// max-age(delta seconds): http://tools.ietf.org/html/rfc7234#section-5.2.1.1
+	//
+	// The "max-age" request directive indicates that the client is
+	// unwilling to accept a response whose age is greater than the
+	// specified number of seconds.  Unless the max-stale request directive
+	// is also present, the client is not willing to accept a stale
+	// response.
+	MaxAge DeltaSeconds
+
+	// max-stale(delta seconds): http://tools.ietf.org/html/rfc7234#section-5.2.1.2
+	//
+	// The "max-stale" request directive indicates that the client is
+	// willing to accept a response that has exceeded its freshness
+	// lifetime.  If max-stale is assigned a value, then the client is
+	// willing to accept a response that has exceeded its freshness lifetime
+	// by no more than the specified number of seconds.  If no value is
+	// assigned to max-stale, then the client is willing to accept a stale
+	// response of any age.
+	MaxStale    DeltaSeconds
+	MaxStaleSet bool
+
+	// min-fresh(delta seconds): http://tools.ietf.org/html/rfc7234#section-5.2.1.3
+	//
+	// The "min-fresh" request directive indicates that the client is
+	// willing to accept a response whose freshness lifetime is no less than
+	// its current age plus the specified time in seconds.  That is, the
+	// client wants a response that will still be fresh for at least the
+	// specified number of seconds.
+	MinFresh DeltaSeconds
+
+	// no-cache(bool): http://tools.ietf.org/html/rfc7234#section-5.2.1.4
+	//
+	// The "no-cache" request directive indicates that a cache MUST NOT use
+	// a stored response to satisfy the request without successful
+	// validation on the origin server.
+	NoCache bool
+
+	// no-store(bool): http://tools.ietf.org/html/rfc7234#section-5.2.1.5
+	//
+	// The "no-store" request directive indicates that a cache MUST NOT
+	// store any part of either this request or any response to it.  This
+	// directive applies to both private and shared caches.
+	NoStore bool
+
+	// no-transform(bool): http://tools.ietf.org/html/rfc7234#section-5.2.1.6
+	//
+	// The "no-transform" request directive indicates that an intermediary
+	// (whether or not it implements a cache) MUST NOT transform the
+	// payload, as defined in Section 5.7.2 of RFC7230.
+	NoTransform bool
+
+	// only-if-cached(bool): http://tools.ietf.org/html/rfc7234#section-5.2.1.7
+	//
+	// The "only-if-cached" request directive indicates that the client only
+	// wishes to obtain a stored response.
+	OnlyIfCached bool
+
+	// stale-if-error(delta seconds): https://datatracker.ietf.org/doc/html/rfc5861#section-4
+	StaleIfError DeltaSeconds
+
+	// Extensions: http://tools.ietf.org/html/rfc7234#section-5.2.3
+	//
+	// The Cache-Control header field can be extended through the use of one
+	// or more cache-extension tokens, each with an optional value.  A cache
+	// MUST ignore unrecognized cache directives.
+	Extensions []string
+}
+
+func (cd *RequestCacheDirectives) addToken(token string) error {
+	var err error = nil
+
+	switch token {
+	case "max-age":
+		err = ErrMaxAgeDeltaSeconds
+	case "min-fresh":
+		err = ErrMinFreshDeltaSeconds
+	case "max-stale":
+		cd.MaxStaleSet = true
+	case "no-cache":
+		cd.NoCache = true
+	case "no-store":
+		cd.NoStore = true
+	case "no-transform":
+		cd.NoTransform = true
+	case "only-if-cached":
+		cd.OnlyIfCached = true
+	case "stale-if-error":
+		err = ErrMaxAgeDeltaSeconds
+	default:
+		cd.Extensions = append(cd.Extensions, token)
+	}
+	return err
+}
+
+func (cd *RequestCacheDirectives) addPair(token string, v string) error {
+	var err error = nil
+
+	switch token {
+	case "max-age":
+		cd.MaxAge, err = parseDeltaSeconds(v)
+		if err != nil {
+			err = ErrMaxAgeDeltaSeconds
+		}
+	case "max-stale":
+		cd.MaxStale, err = parseDeltaSeconds(v)
+		if err != nil {
+			err = ErrMaxStaleDeltaSeconds
+		}
+	case "min-fresh":
+		cd.MinFresh, err = parseDeltaSeconds(v)
+		if err != nil {
+			err = ErrMinFreshDeltaSeconds
+		}
+	case "no-cache":
+		err = ErrNoCacheNoArgs
+	case "no-store":
+		err = ErrNoStoreNoArgs
+	case "no-transform":
+		err = ErrNoTransformNoArgs
+	case "only-if-cached":
+		err = ErrOnlyIfCachedNoArgs
+	case "stale-if-error":
+		cd.StaleIfError, err = parseDeltaSeconds(v)
+		if err != nil {
+			err = ErrStaleIfErrorDeltaSeconds
+		}
+	default:
+		// TODO(pquerna): this sucks, making user re-parse
+		cd.Extensions = append(cd.Extensions, token+"="+v)
+	}
+
+	return err
+}
+
+// LOW LEVEL API: Parses a Cache Control Header from a Request into a set of directives.
+func ParseRequestCacheControl(value string) (*RequestCacheDirectives, error) {
+	cd := &RequestCacheDirectives{
+		MaxAge:   -1,
+		MaxStale: -1,
+		MinFresh: -1,
+	}
+
+	err := parse(value, cd)
+	if err != nil {
+		return nil, err
+	}
+	return cd, nil
+}
+
+// LOW LEVEL API: Repersentation of possible response directives in a `Cache-Control` header: http://tools.ietf.org/html/rfc7234#section-5.2.2
+//
+// Note: Many fields will be `nil` in practice.
+type ResponseCacheDirectives struct {
+
+	// must-revalidate(bool): http://tools.ietf.org/html/rfc7234#section-5.2.2.1
+	//
+	// The "must-revalidate" response directive indicates that once it has
+	// become stale, a cache MUST NOT use the response to satisfy subsequent
+	// requests without successful validation on the origin server.
+	MustRevalidate bool
+
+	// no-cache(FieldName): http://tools.ietf.org/html/rfc7234#section-5.2.2.2
+	//
+	// The "no-cache" response directive indicates that the response MUST
+	// NOT be used to satisfy a subsequent request without successful
+	// validation on the origin server.
+	//
+	// If the no-cache response directive specifies one or more field-names,
+	// then a cache MAY use the response to satisfy a subsequent request,
+	// subject to any other restrictions on caching.  However, any header
+	// fields in the response that have the field-name(s) listed MUST NOT be
+	// sent in the response to a subsequent request without successful
+	// revalidation with the origin server.
+	NoCache FieldNames
+
+	// no-cache(cast-to-bool): http://tools.ietf.org/html/rfc7234#section-5.2.2.2
+	//
+	// While the RFC defines optional field-names on a no-cache directive,
+	// many applications only want to know if any no-cache directives were
+	// present at all.
+	NoCachePresent bool
+
+	// no-store(bool): http://tools.ietf.org/html/rfc7234#section-5.2.2.3
+	//
+	// The "no-store" request directive indicates that a cache MUST NOT
+	// store any part of either this request or any response to it.  This
+	// directive applies to both private and shared caches.
+	NoStore bool
+
+	// no-transform(bool): http://tools.ietf.org/html/rfc7234#section-5.2.2.4
+	//
+	// The "no-transform" response directive indicates that an intermediary
+	// (regardless of whether it implements a cache) MUST NOT transform the
+	// payload, as defined in Section 5.7.2 of RFC7230.
+	NoTransform bool
+
+	// public(bool): http://tools.ietf.org/html/rfc7234#section-5.2.2.5
+	//
+	// The "public" response directive indicates that any cache MAY store
+	// the response, even if the response would normally be non-cacheable or
+	// cacheable only within a private cache.
+	Public bool
+
+	// private(FieldName): http://tools.ietf.org/html/rfc7234#section-5.2.2.6
+	//
+	// The "private" response directive indicates that the response message
+	// is intended for a single user and MUST NOT be stored by a shared
+	// cache.  A private cache MAY store the response and reuse it for later
+	// requests, even if the response would normally be non-cacheable.
+	//
+	// If the private response directive specifies one or more field-names,
+	// this requirement is limited to the field-values associated with the
+	// listed response header fields.  That is, a shared cache MUST NOT
+	// store the specified field-names(s), whereas it MAY store the
+	// remainder of the response message.
+	Private FieldNames
+
+	// private(cast-to-bool): http://tools.ietf.org/html/rfc7234#section-5.2.2.6
+	//
+	// While the RFC defines optional field-names on a private directive,
+	// many applications only want to know if any private directives were
+	// present at all.
+	PrivatePresent bool
+
+	// proxy-revalidate(bool): http://tools.ietf.org/html/rfc7234#section-5.2.2.7
+	//
+	// The "proxy-revalidate" response directive has the same meaning as the
+	// must-revalidate response directive, except that it does not apply to
+	// private caches.
+	ProxyRevalidate bool
+
+	// max-age(delta seconds): http://tools.ietf.org/html/rfc7234#section-5.2.2.8
+	//
+	// The "max-age" response directive indicates that the response is to be
+	// considered stale after its age is greater than the specified number
+	// of seconds.
+	MaxAge DeltaSeconds
+
+	// s-maxage(delta seconds): http://tools.ietf.org/html/rfc7234#section-5.2.2.9
+	//
+	// The "s-maxage" response directive indicates that, in shared caches,
+	// the maximum age specified by this directive overrides the maximum age
+	// specified by either the max-age directive or the Expires header
+	// field.  The s-maxage directive also implies the semantics of the
+	// proxy-revalidate response directive.
+	SMaxAge DeltaSeconds
+
+	////
+	// Experimental features
+	// - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Extension_Cache-Control_directives
+	// - https://www.fastly.com/blog/stale-while-revalidate-stale-if-error-available-today
+	////
+
+	// immutable(cast-to-bool): experimental feature
+	Immutable bool
+
+	// stale-if-error(delta seconds): experimental feature
+	StaleIfError DeltaSeconds
+
+	// stale-while-revalidate(delta seconds): experimental feature
+	StaleWhileRevalidate DeltaSeconds
+
+	// Extensions: http://tools.ietf.org/html/rfc7234#section-5.2.3
+	//
+	// The Cache-Control header field can be extended through the use of one
+	// or more cache-extension tokens, each with an optional value.  A cache
+	// MUST ignore unrecognized cache directives.
+	Extensions []string
+}
+
+// LOW LEVEL API: Parses a Cache Control Header from a Response into a set of directives.
+func ParseResponseCacheControl(value string) (*ResponseCacheDirectives, error) {
+	cd := &ResponseCacheDirectives{
+		MaxAge:  -1,
+		SMaxAge: -1,
+		// Exerimantal stale timeouts
+		StaleIfError:         -1,
+		StaleWhileRevalidate: -1,
+	}
+
+	err := parse(value, cd)
+	if err != nil {
+		return nil, err
+	}
+	return cd, nil
+}
+
+func (cd *ResponseCacheDirectives) addToken(token string) error {
+	var err error = nil
+	switch token {
+	case "must-revalidate":
+		cd.MustRevalidate = true
+	case "no-cache":
+		cd.NoCachePresent = true
+	case "no-store":
+		cd.NoStore = true
+	case "no-transform":
+		cd.NoTransform = true
+	case "public":
+		cd.Public = true
+	case "private":
+		cd.PrivatePresent = true
+	case "proxy-revalidate":
+		cd.ProxyRevalidate = true
+	case "max-age":
+		err = ErrMaxAgeDeltaSeconds
+	case "s-maxage":
+		err = ErrSMaxAgeDeltaSeconds
+	// Experimental
+	case "immutable":
+		cd.Immutable = true
+	case "stale-if-error":
+		err = ErrMaxAgeDeltaSeconds
+	case "stale-while-revalidate":
+		err = ErrMaxAgeDeltaSeconds
+	default:
+		cd.Extensions = append(cd.Extensions, token)
+	}
+	return err
+}
+
+func hasFieldNames(token string) bool {
+	switch token {
+	case "no-cache":
+		return true
+	case "private":
+		return true
+	}
+	return false
+}
+
+func (cd *ResponseCacheDirectives) addPair(token string, v string) error {
+	var err error = nil
+
+	switch token {
+	case "must-revalidate":
+		err = ErrMustRevalidateNoArgs
+	case "no-cache":
+		cd.NoCachePresent = true
+		tokens := strings.Split(v, ",")
+		if cd.NoCache == nil {
+			cd.NoCache = make(FieldNames)
+		}
+		for _, t := range tokens {
+			k := http.CanonicalHeaderKey(textproto.TrimString(t))
+			cd.NoCache[k] = true
+		}
+	case "no-store":
+		err = ErrNoStoreNoArgs
+	case "no-transform":
+		err = ErrNoTransformNoArgs
+	case "public":
+		err = ErrPublicNoArgs
+	case "private":
+		cd.PrivatePresent = true
+		tokens := strings.Split(v, ",")
+		if cd.Private == nil {
+			cd.Private = make(FieldNames)
+		}
+		for _, t := range tokens {
+			k := http.CanonicalHeaderKey(textproto.TrimString(t))
+			cd.Private[k] = true
+		}
+	case "proxy-revalidate":
+		err = ErrProxyRevalidateNoArgs
+	case "max-age":
+		cd.MaxAge, err = parseDeltaSeconds(v)
+	case "s-maxage":
+		cd.SMaxAge, err = parseDeltaSeconds(v)
+	// Experimental
+	case "immutable":
+		err = ErrImmutableNoArgs
+	case "stale-if-error":
+		cd.StaleIfError, err = parseDeltaSeconds(v)
+	case "stale-while-revalidate":
+		cd.StaleWhileRevalidate, err = parseDeltaSeconds(v)
+	default:
+		// TODO(pquerna): this sucks, making user re-parse, and its technically not 'quoted' like the original,
+		// but this is still easier, just a SplitN on "="
+		cd.Extensions = append(cd.Extensions, token+"="+v)
+	}
+
+	return err
+}

--- a/vendor/github.com/pquerna/cachecontrol/cacheobject/lex.go
+++ b/vendor/github.com/pquerna/cachecontrol/cacheobject/lex.go
@@ -1,0 +1,93 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cacheobject
+
+// This file deals with lexical matters of HTTP
+
+func isSeparator(c byte) bool {
+	switch c {
+	case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}', ' ', '\t':
+		return true
+	}
+	return false
+}
+
+func isCtl(c byte) bool { return (0 <= c && c <= 31) || c == 127 }
+
+func isChar(c byte) bool { return 0 <= c && c <= 127 }
+
+func isAnyText(c byte) bool { return !isCtl(c) }
+
+func isQdText(c byte) bool { return isAnyText(c) && c != '"' }
+
+func isToken(c byte) bool { return isChar(c) && !isCtl(c) && !isSeparator(c) }
+
+// Valid escaped sequences are not specified in RFC 2616, so for now, we assume
+// that they coincide with the common sense ones used by GO. Malformed
+// characters should probably not be treated as errors by a robust (forgiving)
+// parser, so we replace them with the '?' character.
+func httpUnquotePair(b byte) byte {
+	// skip the first byte, which should always be '\'
+	switch b {
+	case 'a':
+		return '\a'
+	case 'b':
+		return '\b'
+	case 'f':
+		return '\f'
+	case 'n':
+		return '\n'
+	case 'r':
+		return '\r'
+	case 't':
+		return '\t'
+	case 'v':
+		return '\v'
+	case '\\':
+		return '\\'
+	case '\'':
+		return '\''
+	case '"':
+		return '"'
+	}
+	return '?'
+}
+
+// raw must begin with a valid quoted string. Only the first quoted string is
+// parsed and is unquoted in result. eaten is the number of bytes parsed, or -1
+// upon failure.
+func httpUnquote(raw string) (eaten int, result string) {
+	buf := make([]byte, len(raw))
+	if raw[0] != '"' {
+		return -1, ""
+	}
+	eaten = 1
+	j := 0 // # of bytes written in buf
+	for i := 1; i < len(raw); i++ {
+		switch b := raw[i]; b {
+		case '"':
+			eaten++
+			buf = buf[0:j]
+			return i + 1, string(buf)
+		case '\\':
+			if len(raw) < i+2 {
+				return -1, ""
+			}
+			buf[j] = httpUnquotePair(raw[i+1])
+			eaten += 2
+			j++
+			i++
+		default:
+			if isQdText(b) {
+				buf[j] = b
+			} else {
+				buf[j] = '?'
+			}
+			eaten++
+			j++
+		}
+	}
+	return -1, ""
+}

--- a/vendor/github.com/pquerna/cachecontrol/cacheobject/object.go
+++ b/vendor/github.com/pquerna/cachecontrol/cacheobject/object.go
@@ -1,0 +1,398 @@
+/**
+ *  Copyright 2015 Paul Querna
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package cacheobject
+
+import (
+	"net/http"
+	"time"
+)
+
+// LOW LEVEL API: Represents a potentially cachable HTTP object.
+//
+// This struct is designed to be serialized efficiently, so in a high
+// performance caching server, things like Date-Strings don't need to be
+// parsed for every use of a cached object.
+type Object struct {
+	CacheIsPrivate bool
+
+	RespDirectives         *ResponseCacheDirectives
+	RespHeaders            http.Header
+	RespStatusCode         int
+	RespExpiresHeader      time.Time
+	RespDateHeader         time.Time
+	RespLastModifiedHeader time.Time
+
+	ReqDirectives *RequestCacheDirectives
+	ReqHeaders    http.Header
+	ReqMethod     string
+
+	NowUTC time.Time
+}
+
+// LOW LEVEL API: Represents the results of examining an Object with
+// CachableObject and ExpirationObject.
+//
+// TODO(pquerna): decide if this is a good idea or bad
+type ObjectResults struct {
+	OutReasons        []Reason
+	OutWarnings       []Warning
+	OutExpirationTime time.Time
+	OutErr            error
+}
+
+// LOW LEVEL API: Check if a request is cacheable.
+// This function doesn't reset the passed ObjectResults.
+func CachableRequestObject(obj *Object, rv *ObjectResults) {
+	switch obj.ReqMethod {
+	case "GET":
+		break
+	case "HEAD":
+		break
+	case "POST":
+		// Responses to POST requests can be cacheable if they include explicit freshness information
+		break
+
+	case "PUT":
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodPUT)
+
+	case "DELETE":
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodDELETE)
+
+	case "CONNECT":
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodCONNECT)
+
+	case "OPTIONS":
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodOPTIONS)
+
+	case "TRACE":
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodTRACE)
+
+	// HTTP Extension Methods: http://www.iana.org/assignments/http-methods/http-methods.xhtml
+	//
+	// To my knowledge, none of them are cachable. Please open a ticket if this is not the case!
+	//
+	default:
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodUnknown)
+	}
+
+	if obj.ReqDirectives != nil && obj.ReqDirectives.NoStore {
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestNoStore)
+	}
+}
+
+// LOW LEVEL API: Check if a response is cacheable.
+// This function doesn't reset the passed ObjectResults.
+func CachableResponseObject(obj *Object, rv *ObjectResults) {
+	/**
+	  POST: http://tools.ietf.org/html/rfc7231#section-4.3.3
+
+	  Responses to POST requests are only cacheable when they include
+	  explicit freshness information (see Section 4.2.1 of [RFC7234]).
+	  However, POST caching is not widely implemented.  For cases where an
+	  origin server wishes the client to be able to cache the result of a
+	  POST in a way that can be reused by a later GET, the origin server
+	  MAY send a 200 (OK) response containing the result and a
+	  Content-Location header field that has the same value as the POST's
+	  effective request URI (Section 3.1.4.2).
+	*/
+	if obj.ReqMethod == http.MethodPost && !hasFreshness(obj.RespDirectives, obj.RespHeaders, obj.RespExpiresHeader, obj.CacheIsPrivate) {
+		rv.OutReasons = append(rv.OutReasons, ReasonRequestMethodPOST)
+	}
+
+	// Storing Responses to Authenticated Requests: http://tools.ietf.org/html/rfc7234#section-3.2
+	if obj.ReqHeaders.Get("Authorization") != "" {
+		if obj.RespDirectives.MustRevalidate ||
+			obj.RespDirectives.Public ||
+			obj.RespDirectives.SMaxAge != -1 {
+			// Expires of some kind present, this is potentially OK.
+		} else {
+			rv.OutReasons = append(rv.OutReasons, ReasonRequestAuthorizationHeader)
+		}
+	}
+
+	if obj.RespDirectives.PrivatePresent && !obj.CacheIsPrivate {
+		rv.OutReasons = append(rv.OutReasons, ReasonResponsePrivate)
+	}
+
+	if obj.RespDirectives.NoStore {
+		rv.OutReasons = append(rv.OutReasons, ReasonResponseNoStore)
+	}
+
+	/*
+	   the response either:
+
+	     *  contains an Expires header field (see Section 5.3), or
+
+	     *  contains a max-age response directive (see Section 5.2.2.8), or
+
+	     *  contains a s-maxage response directive (see Section 5.2.2.9)
+	        and the cache is shared, or
+
+	     *  contains a Cache Control Extension (see Section 5.2.3) that
+	        allows it to be cached, or
+
+	     *  has a status code that is defined as cacheable by default (see
+	        Section 4.2.2), or
+
+	     *  contains a public response directive (see Section 5.2.2.5).
+	*/
+
+	if obj.RespHeaders.Get("Expires") != "" ||
+		obj.RespDirectives.MaxAge != -1 ||
+		(obj.RespDirectives.SMaxAge != -1 && !obj.CacheIsPrivate) ||
+		cachableStatusCode(obj.RespStatusCode) ||
+		obj.RespDirectives.Public {
+		/* cachable by default, at least one of the above conditions was true */
+		return
+	}
+
+	rv.OutReasons = append(rv.OutReasons, ReasonResponseUncachableByDefault)
+}
+
+// LOW LEVEL API: Check if a object is cachable.
+func CachableObject(obj *Object, rv *ObjectResults) {
+	rv.OutReasons = nil
+	rv.OutWarnings = nil
+	rv.OutErr = nil
+
+	CachableRequestObject(obj, rv)
+	CachableResponseObject(obj, rv)
+}
+
+var twentyFourHours = time.Duration(24 * time.Hour)
+
+const debug = false
+
+// LOW LEVEL API: Update an objects expiration time.
+func ExpirationObject(obj *Object, rv *ObjectResults) {
+	/**
+	 * Okay, lets calculate Freshness/Expiration now. woo:
+	 *  http://tools.ietf.org/html/rfc7234#section-4.2
+	 */
+
+	/*
+	   o  If the cache is shared and the s-maxage response directive
+	      (Section 5.2.2.9) is present, use its value, or
+
+	   o  If the max-age response directive (Section 5.2.2.8) is present,
+	      use its value, or
+
+	   o  If the Expires response header field (Section 5.3) is present, use
+	      its value minus the value of the Date response header field, or
+
+	   o  Otherwise, no explicit expiration time is present in the response.
+	      A heuristic freshness lifetime might be applicable; see
+	      Section 4.2.2.
+	*/
+
+	var expiresTime time.Time
+
+	if obj.RespDirectives.SMaxAge != -1 && !obj.CacheIsPrivate {
+		expiresTime = obj.NowUTC.Add(time.Second * time.Duration(obj.RespDirectives.SMaxAge))
+	} else if obj.RespDirectives.MaxAge != -1 {
+		expiresTime = obj.NowUTC.UTC().Add(time.Second * time.Duration(obj.RespDirectives.MaxAge))
+	} else if !obj.RespExpiresHeader.IsZero() {
+		serverDate := obj.RespDateHeader
+		if serverDate.IsZero() {
+			// common enough case when a Date: header has not yet been added to an
+			// active response.
+			serverDate = obj.NowUTC
+		}
+		expiresTime = obj.NowUTC.Add(obj.RespExpiresHeader.Sub(serverDate))
+	} else if !obj.RespLastModifiedHeader.IsZero() {
+		// heuristic freshness lifetime
+		rv.OutWarnings = append(rv.OutWarnings, WarningHeuristicExpiration)
+
+		// http://httpd.apache.org/docs/2.4/mod/mod_cache.html#cachelastmodifiedfactor
+		// CacheMaxExpire defaults to 24 hours
+		// CacheLastModifiedFactor: is 0.1
+		//
+		// expiry-period = MIN(time-since-last-modified-date * factor, 24 hours)
+		//
+		// obj.NowUTC
+
+		since := obj.RespLastModifiedHeader.Sub(obj.NowUTC)
+		since = time.Duration(float64(since) * -0.1)
+
+		if since > twentyFourHours {
+			expiresTime = obj.NowUTC.Add(twentyFourHours)
+		} else {
+			expiresTime = obj.NowUTC.Add(since)
+		}
+
+		if debug {
+			println("Now UTC: ", obj.NowUTC.String())
+			println("Last-Modified: ", obj.RespLastModifiedHeader.String())
+			println("Since: ", since.String())
+			println("TwentyFourHours: ", twentyFourHours.String())
+			println("Expiration: ", expiresTime.String())
+		}
+	} else {
+		// TODO(pquerna): what should the default behavior be for expiration time?
+	}
+
+	rv.OutExpirationTime = expiresTime
+}
+
+// Evaluate cachability based on an HTTP request, and parts of the response.
+func UsingRequestResponse(req *http.Request,
+	statusCode int,
+	respHeaders http.Header,
+	privateCache bool) ([]Reason, time.Time, error) {
+	reasons, time, _, _, err := UsingRequestResponseWithObject(req, statusCode, respHeaders, privateCache)
+	return reasons, time, err
+}
+
+// Evaluate cachability based on an HTTP request, and parts of the response.
+// Returns the parsed Object as well.
+func UsingRequestResponseWithObject(req *http.Request,
+	statusCode int,
+	respHeaders http.Header,
+	privateCache bool) ([]Reason, time.Time, []Warning, *Object, error) {
+	var reqHeaders http.Header
+	var reqMethod string
+
+	var reqDir *RequestCacheDirectives = nil
+	respDir, err := ParseResponseCacheControl(respHeaders.Get("Cache-Control"))
+	if err != nil {
+		return nil, time.Time{}, nil, nil, err
+	}
+
+	if req != nil {
+		reqDir, err = ParseRequestCacheControl(req.Header.Get("Cache-Control"))
+		if err != nil {
+			return nil, time.Time{}, nil, nil, err
+		}
+		reqHeaders = req.Header
+		reqMethod = req.Method
+	}
+
+	var expiresHeader time.Time
+	var dateHeader time.Time
+	var lastModifiedHeader time.Time
+
+	if respHeaders.Get("Expires") != "" {
+		expiresHeader, err = http.ParseTime(respHeaders.Get("Expires"))
+		if err != nil {
+			// sometimes servers will return `Expires: 0` or `Expires: -1` to
+			// indicate expired content
+			expiresHeader = time.Time{}
+		}
+		expiresHeader = expiresHeader.UTC()
+	}
+
+	if respHeaders.Get("Date") != "" {
+		dateHeader, err = http.ParseTime(respHeaders.Get("Date"))
+		if err != nil {
+			return nil, time.Time{}, nil, nil, err
+		}
+		dateHeader = dateHeader.UTC()
+	}
+
+	if respHeaders.Get("Last-Modified") != "" {
+		lastModifiedHeader, err = http.ParseTime(respHeaders.Get("Last-Modified"))
+		if err != nil {
+			return nil, time.Time{}, nil, nil, err
+		}
+		lastModifiedHeader = lastModifiedHeader.UTC()
+	}
+
+	obj := Object{
+		CacheIsPrivate: privateCache,
+
+		RespDirectives:         respDir,
+		RespHeaders:            respHeaders,
+		RespStatusCode:         statusCode,
+		RespExpiresHeader:      expiresHeader,
+		RespDateHeader:         dateHeader,
+		RespLastModifiedHeader: lastModifiedHeader,
+
+		ReqDirectives: reqDir,
+		ReqHeaders:    reqHeaders,
+		ReqMethod:     reqMethod,
+
+		NowUTC: time.Now().UTC(),
+	}
+	rv := ObjectResults{}
+
+	CachableObject(&obj, &rv)
+	if rv.OutErr != nil {
+		return nil, time.Time{}, nil, nil, rv.OutErr
+	}
+
+	ExpirationObject(&obj, &rv)
+	if rv.OutErr != nil {
+		return nil, time.Time{}, nil, nil, rv.OutErr
+	}
+
+	return rv.OutReasons, rv.OutExpirationTime, rv.OutWarnings, &obj, nil
+}
+
+// calculate if a freshness directive is present: http://tools.ietf.org/html/rfc7234#section-4.2.1
+func hasFreshness(respDir *ResponseCacheDirectives, respHeaders http.Header, respExpires time.Time, privateCache bool) bool {
+	if !privateCache && respDir.SMaxAge != -1 {
+		return true
+	}
+
+	if respDir.MaxAge != -1 {
+		return true
+	}
+
+	if !respExpires.IsZero() || respHeaders.Get("Expires") != "" {
+		return true
+	}
+
+	return false
+}
+
+func cachableStatusCode(statusCode int) bool {
+	/*
+		Responses with status codes that are defined as cacheable by default
+		(e.g., 200, 203, 204, 206, 300, 301, 404, 405, 410, 414, and 501 in
+		this specification) can be reused by a cache with heuristic
+		expiration unless otherwise indicated by the method definition or
+		explicit cache controls [RFC7234]; all other status codes are not
+		cacheable by default.
+	*/
+	switch statusCode {
+	case 200:
+		return true
+	case 203:
+		return true
+	case 204:
+		return true
+	case 206:
+		return true
+	case 300:
+		return true
+	case 301:
+		return true
+	case 404:
+		return true
+	case 405:
+		return true
+	case 410:
+		return true
+	case 414:
+		return true
+	case 501:
+		return true
+	default:
+		return false
+	}
+}

--- a/vendor/github.com/pquerna/cachecontrol/cacheobject/reasons.go
+++ b/vendor/github.com/pquerna/cachecontrol/cacheobject/reasons.go
@@ -1,0 +1,95 @@
+/**
+ *  Copyright 2015 Paul Querna
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package cacheobject
+
+// Repersents a potential Reason to not cache an object.
+//
+// Applications may wish to ignore specific reasons, which will make them non-RFC
+// compliant, but this type gives them specific cases they can choose to ignore,
+// making them compliant in as many cases as they can.
+type Reason int
+
+const (
+
+	// The request method was POST and an Expiration header was not supplied.
+	ReasonRequestMethodPOST Reason = iota
+
+	// The request method was PUT and PUTs are not cachable.
+	ReasonRequestMethodPUT
+
+	// The request method was DELETE and DELETEs are not cachable.
+	ReasonRequestMethodDELETE
+
+	// The request method was CONNECT and CONNECTs are not cachable.
+	ReasonRequestMethodCONNECT
+
+	// The request method was OPTIONS and OPTIONS are not cachable.
+	ReasonRequestMethodOPTIONS
+
+	// The request method was TRACE and TRACEs are not cachable.
+	ReasonRequestMethodTRACE
+
+	// The request method was not recognized by cachecontrol, and should not be cached.
+	ReasonRequestMethodUnknown
+
+	// The request included an Cache-Control: no-store header
+	ReasonRequestNoStore
+
+	// The request included an Authorization header without an explicit Public or Expiration time: http://tools.ietf.org/html/rfc7234#section-3.2
+	ReasonRequestAuthorizationHeader
+
+	// The response included an Cache-Control: no-store header
+	ReasonResponseNoStore
+
+	// The response included an Cache-Control: private header and this is not a Private cache
+	ReasonResponsePrivate
+
+	// The response failed to meet at least one of the conditions specified in RFC 7234 section 3: http://tools.ietf.org/html/rfc7234#section-3
+	ReasonResponseUncachableByDefault
+)
+
+func (r Reason) String() string {
+	switch r {
+	case ReasonRequestMethodPOST:
+		return "ReasonRequestMethodPOST"
+	case ReasonRequestMethodPUT:
+		return "ReasonRequestMethodPUT"
+	case ReasonRequestMethodDELETE:
+		return "ReasonRequestMethodDELETE"
+	case ReasonRequestMethodCONNECT:
+		return "ReasonRequestMethodCONNECT"
+	case ReasonRequestMethodOPTIONS:
+		return "ReasonRequestMethodOPTIONS"
+	case ReasonRequestMethodTRACE:
+		return "ReasonRequestMethodTRACE"
+	case ReasonRequestMethodUnknown:
+		return "ReasonRequestMethodUnkown"
+	case ReasonRequestNoStore:
+		return "ReasonRequestNoStore"
+	case ReasonRequestAuthorizationHeader:
+		return "ReasonRequestAuthorizationHeader"
+	case ReasonResponseNoStore:
+		return "ReasonResponseNoStore"
+	case ReasonResponsePrivate:
+		return "ReasonResponsePrivate"
+	case ReasonResponseUncachableByDefault:
+		return "ReasonResponseUncachableByDefault"
+	}
+
+	panic(r)
+}

--- a/vendor/github.com/pquerna/cachecontrol/cacheobject/warning.go
+++ b/vendor/github.com/pquerna/cachecontrol/cacheobject/warning.go
@@ -1,0 +1,107 @@
+/**
+ *  Copyright 2015 Paul Querna
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package cacheobject
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Repersents an HTTP Warning: http://tools.ietf.org/html/rfc7234#section-5.5
+type Warning int
+
+const (
+	// Response is Stale
+	// A cache SHOULD generate this whenever the sent response is stale.
+	WarningResponseIsStale Warning = 110
+
+	// Revalidation Failed
+	// A cache SHOULD generate this when sending a stale
+	// response because an attempt to validate the response failed, due to an
+	// inability to reach the server.
+	WarningRevalidationFailed Warning = 111
+
+	// Disconnected Operation
+	// A cache SHOULD generate this if it is intentionally disconnected from
+	// the rest of the network for a period of time.
+	WarningDisconnectedOperation Warning = 112
+
+	// Heuristic Expiration
+	//
+	// A cache SHOULD generate this if it heuristically chose a freshness
+	// lifetime greater than 24 hours and the response's age is greater than
+	// 24 hours.
+	WarningHeuristicExpiration Warning = 113
+
+	// Miscellaneous Warning
+	//
+	// The warning text can include arbitrary information to be presented to
+	// a human user or logged.  A system receiving this warning MUST NOT
+	// take any automated action, besides presenting the warning to the
+	// user.
+	WarningMiscellaneousWarning Warning = 199
+
+	// Transformation Applied
+	//
+	// This Warning code MUST be added by a proxy if it applies any
+	// transformation to the representation, such as changing the
+	// content-coding, media-type, or modifying the representation data,
+	// unless this Warning code already appears in the response.
+	WarningTransformationApplied Warning = 214
+
+	// Miscellaneous Persistent Warning
+	//
+	// The warning text can include arbitrary information to be presented to
+	// a human user or logged.  A system receiving this warning MUST NOT
+	// take any automated action.
+	WarningMiscellaneousPersistentWarning Warning = 299
+)
+
+func (w Warning) HeaderString(agent string, date time.Time) string {
+	if agent == "" {
+		agent = "-"
+	} else {
+		// TODO(pquerna): this doesn't escape agent if it contains bad things.
+		agent = `"` + agent + `"`
+	}
+	return fmt.Sprintf(`%d %s "%s" %s`, w, agent, w.String(), date.Format(http.TimeFormat))
+}
+
+func (w Warning) String() string {
+	switch w {
+	case WarningResponseIsStale:
+		return "Response is Stale"
+	case WarningRevalidationFailed:
+		return "Revalidation Failed"
+	case WarningDisconnectedOperation:
+		return "Disconnected Operation"
+	case WarningHeuristicExpiration:
+		return "Heuristic Expiration"
+	case WarningMiscellaneousWarning:
+		// TODO(pquerna): ideally had a better way to override this one code.
+		return "Miscellaneous Warning"
+	case WarningTransformationApplied:
+		return "Transformation Applied"
+	case WarningMiscellaneousPersistentWarning:
+		// TODO(pquerna): same as WarningMiscellaneousWarning
+		return "Miscellaneous Persistent Warning"
+	}
+
+	panic(w)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -49,6 +49,9 @@ github.com/hashicorp/go-version
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib
+# github.com/pquerna/cachecontrol v0.2.0
+## explicit; go 1.16
+github.com/pquerna/cachecontrol/cacheobject
 # github.com/russross/blackfriday/v2 v2.1.0
 ## explicit
 github.com/russross/blackfriday/v2


### PR DESCRIPTION
## What & why

PR #5 of the V2 steplib series. The V2 reader fetches a sharded inventory of small JSON files over HTTP (see STEP-2374). Until now every fetch hit the network: `httpfetch.Client.Get` returned only the response body and threw away all headers, so the per-prefix caching contract the hosting layer sets was ignored, and every build re-downloaded every inventory file.

This adds a transparent on-disk HTTP cache so clients honor that contract:

| Pattern | `Cache-Control` |
|---|---|
| `/spec/*` | `public, max-age=60, must-revalidate` + `ETag` |
| `/steps/*/step-info.json` | `public, max-age=300, must-revalidate` + `ETag` |
| `/steps/*` (`step.json`) | `public, max-age=31536000, immutable` |

## How

A new `internal/httpcache` package provides an `http.RoundTripper` that:

- serves **fresh** entries with **zero network**;
- **revalidates** stale entries with a conditional request (`If-None-Match` / `If-Modified-Since`) — a `304` reuses the local body;
- **verifies** each cached body against a stored `sha256-<hex>` on read — a mismatch (corruption / torn write) is treated as a miss and refetched;
- **surfaces** revalidation failures (transport error or `5xx`) as errors rather than serving stale — a broken upstream fails loudly. (A deliberate offline/prefer-stale mode is planned separately.)

It's wired in as the transport **below** retryablehttp (a hit returns immediately; only a genuine miss-and-failure is retried), so `HTTPAPI.fetchJSON` and `httpfetch.Client.Get` are unchanged. Only the inventory **API** client is cached; binary downloads stay uncached (large, immutable, hash-verified, already content-addressed at the install path).

### On-disk layout

Nix-inspired, machine-addressable + human-browsable, under `~/.stepman/http_cache/`:

```
<sha256(method+url)>-<basename>/
    meta.json     # url, etag, cache-control, fetched/expires, sha256, size
    <basename>    # the body verbatim, e.g. latest.json / step.json
.tmp/             # staging dir for atomic commits
```

Each entry is committed by writing into `.tmp/` and renaming the whole directory into place, so `meta.json` and the body are never observed mismatched, even under concurrent writers.

### Cache-Control parsing

`github.com/pquerna/cachecontrol` (vendored). `max-age`, `immutable`, `no-store` honored; `must-revalidate` needs no special handling since stale entries are always revalidated.

## Notable decisions

- **RoundTripper, not a Client wrapper** — cleanest access to ETag/Cache-Control; fully transparent to callers.
- **Global cache dir** — keys are full URLs (which encode the inventory identity), so steplibs never collide and entries are reused across routes.
- **No eviction yet** — entries are never auto-evicted; a GC/size-bound sweep (the `.tmp/` dir and orphaned entries) is deferred follow-up.

## Tests

`internal/httpcache` is tested with `testing/synctest` (stable in this `go 1.25` module) driving an in-memory fake transport, so production code keeps real `time.Now()` and freshness boundaries are crossed instantly. Coverage: miss→hit, 304 revalidation (incl. a 304 that omits `Cache-Control` must preserve `max-age`), 200 replacement, immutable-never-revalidates, revalidation-error/5xx surfaced, corrupt-body refetch, no-store, non-GET/non-2xx passthrough, filename sanitization, and a `-race` concurrent-save consistency test. Plus a `steplibrary` integration test against a real `httptest.Server` (fresh-reuse → one origin hit), and a new `internal/sri` package test.

## Review notes

The commits are reviewable one-by-one — the feature commit, then five fixes from a `/code-review` pass (revalidation error surfacing, read-time checksum verification, filename sanitization, atomic entry commit, and extracting the duplicated `sha256-<hex>` format into `internal/sri`).

> [!NOTE]
> Stacked on `step-2374-v2-pr4-activator-wiring`; review/merge that first. Diff against the wrong base will show PR1–4's changes too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)