### PR TITLE
test(indexgen): V2 inventory validator + wire-format / determinism guarantees

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -55,6 +55,9 @@ workflows:
             export INTEGRATION_TEST_BINARY_PATH="$current_stepman"
             go test -v ./_tests/integration/...
 
+            # Generator round-trip against a real steplib (build-tag gated, needs network).
+            go test -tags integration -v ./steplibrary/indexgen/...
+
   create-release:
     description: Creates Linux and Darwin binaries, then publishes a GitHub release
     envs:

--- a/steplibrary/indexgen/collect_test.go
+++ b/steplibrary/indexgen/collect_test.go
@@ -29,18 +29,17 @@ func minimalStepYAML(title string) []byte {
 }
 
 func TestCollect_step_info_and_asset_copy(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	var info steplibindex.StepInfo
-	readJSON(t, filepath.Join(out, "steps/hello-step/step-info.json"), &info)
+	readJSON(t, filepath.Join(root, mustFS(steplibindex.StepInfoPath("hello-step"))), &info)
 
 	assert.Equal(t, "bitrise", info.Maintainer, "Maintainer")
 	assert.Nil(t, info.Deprecation, "Deprecation")
 	assert.Equal(t, []string{"assets/icon.svg"}, info.AssetURLs, "AssetURLs")
 
 	// Asset file copied.
-	_, gotErr := os.Stat(filepath.Join(out, "steps/hello-step/assets/icon.svg"))
-	assert.NoError(t, gotErr, "asset file copied")
+	assert.FileExists(t, filepath.Join(root, mustFS(steplibindex.StepAssetPath("hello-step", "icon.svg"))), "asset file copied")
 }
 
 func TestCollect_asset_permissions_preserved(t *testing.T) {
@@ -60,16 +59,16 @@ func TestCollect_asset_permissions_preserved(t *testing.T) {
 	_, gotErr := generateFromSteplibClone(inputFS, out, Options{GeneratedAt: fixedTime}, testLogger{t})
 	require.NoError(t, gotErr, "generateFromSteplibClone")
 
-	dstInfo, err := os.Stat(filepath.Join(out, steplibindex.VersionDir(), "steps/perm-step/assets/icon.svg"))
+	dstInfo, err := os.Stat(filepath.Join(out, mustFS(steplibindex.StepAssetPath("perm-step", "icon.svg"))))
 	require.NoError(t, err, "stat copied asset")
 	assert.Equal(t, mode, dstInfo.Mode().Perm(), "copied asset preserves source file mode")
 }
 
 func TestCollect_deprecated_step(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	var info steplibindex.StepInfo
-	readJSON(t, filepath.Join(out, "steps/deprecated-step/step-info.json"), &info)
+	readJSON(t, filepath.Join(root, mustFS(steplibindex.StepInfoPath("deprecated-step"))), &info)
 
 	assert.Equal(t, "bitrise", info.Maintainer, "Maintainer")
 	require.NotNil(t, info.Deprecation, "Deprecation")
@@ -106,17 +105,15 @@ func TestCollect_invalid_version_dir_skipped(t *testing.T) {
 	assert.Equal(t, 1, stats.StepCount, "StepCount")
 	assert.Equal(t, 1, stats.VersionCount, "VersionCount")
 
-	_, statErr := os.Stat(filepath.Join(out, steplibindex.VersionDir(), "steps/my-step/1.0.0/step.json"))
-	assert.NoError(t, statErr, "valid version written")
-	_, statErr = os.Stat(filepath.Join(out, steplibindex.VersionDir(), "steps/my-step/not-a-semver/step.json"))
-	assert.True(t, os.IsNotExist(statErr), "non-semver version dir skipped")
+	assert.FileExists(t, filepath.Join(out, mustFS(steplibindex.StepJSONPath("my-step", "1.0.0"))), "valid version written")
+	assert.NoFileExists(t, filepath.Join(out, mustFS(steplibindex.StepJSONPath("my-step", "not-a-semver"))), "non-semver version dir skipped")
 }
 
 func TestCollect_multi_platform_executables(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	var step models.StepModel
-	readJSON(t, filepath.Join(out, "steps/multi-platform-step/3.2.1/step.json"), &step)
+	readJSON(t, filepath.Join(root, mustFS(steplibindex.StepJSONPath("multi-platform-step", "3.2.1"))), &step)
 
 	require.NotNil(t, step.Executables, "Executables")
 	require.Len(t, *step.Executables, 4, "Executables len")
@@ -142,10 +139,10 @@ func TestCollect_multi_platform_executables(t *testing.T) {
 }
 
 func TestCollect_bash_step_has_no_executables(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	var step models.StepModel
-	readJSON(t, filepath.Join(out, "steps/bash-step/1.0.0/step.json"), &step)
+	readJSON(t, filepath.Join(root, mustFS(steplibindex.StepJSONPath("bash-step", "1.0.0"))), &step)
 
 	// The Script step ships no precompiled binary, so activation builds from
 	// source (Executables nil). It also declares no toolkit, and the generator

--- a/steplibrary/indexgen/collect_test.go
+++ b/steplibrary/indexgen/collect_test.go
@@ -13,6 +13,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// minimalStepYAML returns the smallest step.yml body that passes Validate:
+// a title plus a non-empty source block (git + a 40-char commit). Used by
+// tests that build synthetic input filesystems and don't care about the
+// step's content beyond "this version exists and is well-formed". Without a
+// source block the generator's validate-before-publish step would reject the
+// staged tree (checkStepJSON flags a missing source.git/source.commit).
+func minimalStepYAML(title string) []byte {
+	return []byte(
+		"title: " + title + "\n" +
+			"source:\n" +
+			"  git: https://example.com/repo.git\n" +
+			"  commit: '0000000000000000000000000000000000000000'\n",
+	)
+}
+
 func TestCollect_step_info_and_asset_copy(t *testing.T) {
 	out := runGenerateFromSteplibClone(t)
 
@@ -37,7 +52,7 @@ func TestCollect_asset_permissions_preserved(t *testing.T) {
 	inputFS := fstest.MapFS{
 		"steplib.yml":                     {Data: []byte("format_version: '0.9.0'\nsteplib_source: 'https://example.com'\n")},
 		"steps/perm-step/step-info.yml":   {Data: []byte("maintainer: test\n")},
-		"steps/perm-step/1.0.0/step.yml":  {Data: []byte("title: Perm Step\n")},
+		"steps/perm-step/1.0.0/step.yml":  {Data: minimalStepYAML("Perm Step")},
 		"steps/perm-step/assets/icon.svg": {Data: []byte("<svg/>"), Mode: mode},
 	}
 
@@ -80,9 +95,9 @@ func TestCollect_invalid_version_dir_skipped(t *testing.T) {
 	inputFS := fstest.MapFS{
 		"steplib.yml":                            {Data: []byte("format_version: '0.9.0'\n")},
 		"steps/my-step/step-info.yml":            {Data: []byte("maintainer: test\n")},
-		"steps/my-step/1.0.0/step.yml":           {Data: []byte("title: My Step\n")},
-		"steps/my-step/not-a-semver/step.yml":    {Data: []byte("title: Should be skipped\n")},
-		"steps/my-step/also-not-semver/step.yml": {Data: []byte("title: Also skipped\n")},
+		"steps/my-step/1.0.0/step.yml":           {Data: minimalStepYAML("My Step")},
+		"steps/my-step/not-a-semver/step.yml":    {Data: minimalStepYAML("Should be skipped")},
+		"steps/my-step/also-not-semver/step.yml": {Data: minimalStepYAML("Also skipped")},
 	}
 	out := t.TempDir()
 	stats, gotErr := generateFromSteplibClone(inputFS, out, Options{GeneratedAt: fixedTime}, testLogger{t})

--- a/steplibrary/indexgen/collect_test.go
+++ b/steplibrary/indexgen/collect_test.go
@@ -29,7 +29,7 @@ func minimalStepYAML(title string) []byte {
 }
 
 func TestCollect_step_info_and_asset_copy(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	var info steplibindex.StepInfo
 	readJSON(t, filepath.Join(out, "steps/hello-step/step-info.json"), &info)
@@ -66,7 +66,7 @@ func TestCollect_asset_permissions_preserved(t *testing.T) {
 }
 
 func TestCollect_deprecated_step(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	var info steplibindex.StepInfo
 	readJSON(t, filepath.Join(out, "steps/deprecated-step/step-info.json"), &info)
@@ -113,7 +113,7 @@ func TestCollect_invalid_version_dir_skipped(t *testing.T) {
 }
 
 func TestCollect_multi_platform_executables(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	var step models.StepModel
 	readJSON(t, filepath.Join(out, "steps/multi-platform-step/3.2.1/step.json"), &step)
@@ -142,7 +142,7 @@ func TestCollect_multi_platform_executables(t *testing.T) {
 }
 
 func TestCollect_bash_step_has_no_executables(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	var step models.StepModel
 	readJSON(t, filepath.Join(out, "steps/bash-step/1.0.0/step.json"), &step)

--- a/steplibrary/indexgen/collect_test.go
+++ b/steplibrary/indexgen/collect_test.go
@@ -18,7 +18,7 @@ import (
 // tests that build synthetic input filesystems and don't care about the
 // step's content beyond "this version exists and is well-formed". Without a
 // source block the generator's validate-before-publish step would reject the
-// staged tree (checkStepJSON flags a missing source.git/source.commit).
+// staged tree (missing source.git/source.commit).
 func minimalStepYAML(title string) []byte {
 	return []byte(
 		"title: " + title + "\n" +
@@ -44,9 +44,9 @@ func TestCollect_step_info_and_asset_copy(t *testing.T) {
 
 func TestCollect_asset_permissions_preserved(t *testing.T) {
 	// Embedded fixtures can't carry real file permissions, so drive the
-	// generator from an in-memory FS where the asset's mode is set explicitly
-	// (and distinct from the writer's 0644 default), then assert the copy
-	// preserves it.
+	// generator from an in-memory FS where the asset's mode is set explicitly to
+	// a value distinct from common defaults (and from the 0600 the writer uses
+	// for files it authors), then assert the copy preserves it.
 	const mode = os.FileMode(0o640)
 	inputFS := fstest.MapFS{
 		"steplib.yml":                     {Data: []byte("format_version: '0.9.0'\nsteplib_source: 'https://example.com'\n")},
@@ -92,11 +92,12 @@ func TestCollect_missing_step_info_is_error(t *testing.T) {
 
 func TestCollect_invalid_version_dir_skipped(t *testing.T) {
 	inputFS := fstest.MapFS{
-		"steplib.yml":                            {Data: []byte("format_version: '0.9.0'\n")},
-		"steps/my-step/step-info.yml":            {Data: []byte("maintainer: test\n")},
-		"steps/my-step/1.0.0/step.yml":           {Data: minimalStepYAML("My Step")},
-		"steps/my-step/not-a-semver/step.yml":    {Data: minimalStepYAML("Should be skipped")},
-		"steps/my-step/also-not-semver/step.yml": {Data: minimalStepYAML("Also skipped")},
+		"steplib.yml":                  {Data: []byte("format_version: '0.9.0'\n")},
+		"steps/my-step/step-info.yml":  {Data: []byte("maintainer: test\n")},
+		"steps/my-step/1.0.0/step.yml": {Data: minimalStepYAML("My Step")},
+		// Non-semver version dirs are skipped, so their content is never read.
+		"steps/my-step/not-a-semver/step.yml":    {Data: []byte("title: Should be skipped\n")},
+		"steps/my-step/also-not-semver/step.yml": {Data: []byte("title: Also skipped\n")},
 	}
 	out := t.TempDir()
 	stats, gotErr := generateFromSteplibClone(inputFS, out, Options{GeneratedAt: fixedTime}, testLogger{t})
@@ -146,11 +147,8 @@ func TestCollect_bash_step_has_no_executables(t *testing.T) {
 
 	// The Script step ships no precompiled binary, so activation builds from
 	// source (Executables nil). It also declares no toolkit, and the generator
-	// preserves that verbatim — like V1's parse pipeline (Normalize +
-	// FillMissingDefaults), it never synthesizes a default toolkit. The bash +
-	// step.sh default is applied at run time (toolkits.ToolkitForStep defaults to
-	// BashToolkit, which uses step.sh when no entry file is set), not baked into
-	// step.json.
+	// preserves that verbatim — it never synthesizes a default. The bash +
+	// step.sh default is applied at run time, not baked into step.json.
 	assert.Nil(t, step.Executables, "Executables")
 	assert.Nil(t, step.Toolkit, "Toolkit")
 	require.NotNil(t, step.Title, "Title")

--- a/steplibrary/indexgen/determinism_test.go
+++ b/steplibrary/indexgen/determinism_test.go
@@ -5,10 +5,8 @@ import (
 	"encoding/hex"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/bitrise-io/stepman/internal/specfixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,18 +23,10 @@ import (
 // Comparison is by per-file SHA-256 keyed on the output-relative path
 // (covering the whole v2/ tree); a failure prints which path's hash differs.
 func TestGenerator_deterministic_output(t *testing.T) {
-	opts := Options{GeneratedAt: fixedTime, SteplibCommitSHA: "deadbeefcafef00d"}
-
-	out1 := t.TempDir()
-	_, err := generateFromSteplibClone(specfixtures.SteplibClone(), out1, opts, testLogger{t})
-	require.NoError(t, err, "first generation")
-
-	out2 := t.TempDir()
-	_, err = generateFromSteplibClone(specfixtures.SteplibClone(), out2, opts, testLogger{t})
-	require.NoError(t, err, "second generation")
-
-	hashes1 := hashAllFiles(t, out1)
-	hashes2 := hashAllFiles(t, out2)
+	// Two runs of the same helper = identical fixture, Options, and logger; any
+	// output difference is therefore non-determinism in the generator.
+	hashes1 := hashAllFiles(t, runGenerateFromSteplibClone(t))
+	hashes2 := hashAllFiles(t, runGenerateFromSteplibClone(t))
 
 	require.NotEmpty(t, hashes1, "first generation produced no files")
 	assert.Equal(t, hashes1, hashes2,
@@ -56,7 +46,7 @@ func hashAllFiles(t *testing.T, dir string) map[string]string {
 		if d.IsDir() {
 			return nil
 		}
-		bytes, err := os.ReadFile(filepath.Join(dir, p))
+		bytes, err := fs.ReadFile(dirFS, p)
 		if err != nil {
 			return err
 		}

--- a/steplibrary/indexgen/determinism_test.go
+++ b/steplibrary/indexgen/determinism_test.go
@@ -1,0 +1,68 @@
+package indexgen
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/stepman/internal/specfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerator_deterministic_output asserts that two generations with
+// identical inputs and Options produce byte-identical output trees.
+//
+// This makes the regen-a-sample-tree workflow's implicit assumption an
+// asserted contract. It also catches any future non-determinism (map
+// iteration order leaking into output, time.Now() injected somewhere other
+// than Options.GeneratedAt, etc.) before it confuses anyone diffing a
+// regenerated sample tree.
+//
+// Comparison is by per-file SHA-256 keyed on the output-relative path
+// (covering the whole v2/ tree); a failure prints which path's hash differs.
+func TestGenerator_deterministic_output(t *testing.T) {
+	opts := Options{GeneratedAt: fixedTime, SteplibCommitSHA: "deadbeefcafef00d"}
+
+	out1 := t.TempDir()
+	_, err := generateFromSteplibClone(specfixtures.SteplibClone(), out1, opts, testLogger{t})
+	require.NoError(t, err, "first generation")
+
+	out2 := t.TempDir()
+	_, err = generateFromSteplibClone(specfixtures.SteplibClone(), out2, opts, testLogger{t})
+	require.NoError(t, err, "second generation")
+
+	hashes1 := hashAllFiles(t, out1)
+	hashes2 := hashAllFiles(t, out2)
+
+	require.NotEmpty(t, hashes1, "first generation produced no files")
+	assert.Equal(t, hashes1, hashes2,
+		"two generations with identical Options must produce byte-identical trees")
+}
+
+// hashAllFiles walks dir and returns a map from output-relative path to the
+// SHA-256 hex digest of that file's contents. Directories are skipped.
+func hashAllFiles(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	dirFS := os.DirFS(dir)
+	out := map[string]string{}
+	require.NoError(t, fs.WalkDir(dirFS, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		bytes, err := os.ReadFile(filepath.Join(dir, p))
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(bytes)
+		out[p] = hex.EncodeToString(sum[:])
+		return nil
+	}))
+	return out
+}

--- a/steplibrary/indexgen/index.go
+++ b/steplibrary/indexgen/index.go
@@ -3,27 +3,38 @@ package indexgen
 import (
 	"fmt"
 	"io/fs"
-	"path/filepath"
 	"strconv"
 
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
 )
 
-// writeStepFiles emits the per-step source files under steps/<id>/.
+// writeStepFiles emits the per-step source files under steps/<id>/. Output paths
+// come from steplibindex; the asset src is a source-steplib (input) path.
 func writeStepFiles(w *writer, inputFS fs.FS, s parsedStep) error {
-	if err := w.writeJSON(filepath.Join("steps", s.id, "step-info.json"), s.info); err != nil {
+	infoPath, err := steplibindex.StepInfoPath(s.id)
+	if err != nil {
+		return err
+	}
+	if err := w.writeJSON(infoPath.FS(), s.info); err != nil {
 		return err
 	}
 	for _, f := range s.assetFiles {
 		src := "steps/" + s.id + "/assets/" + f
-		dst := filepath.Join("steps", s.id, "assets", f)
-		if err := w.copyFileFromFS(inputFS, src, dst); err != nil {
+		dst, err := steplibindex.StepAssetPath(s.id, f)
+		if err != nil {
+			return err
+		}
+		if err := w.copyFileFromFS(inputFS, src, dst.FS()); err != nil {
 			return fmt.Errorf("copy asset %s: %w", src, err)
 		}
 	}
 	for _, v := range s.versions {
-		if err := w.writeJSON(filepath.Join("steps", s.id, v.version, "step.json"), v.model); err != nil {
+		stepJSONPath, err := steplibindex.StepJSONPath(s.id, v.version)
+		if err != nil {
+			return err
+		}
+		if err := w.writeJSON(stepJSONPath.FS(), v.model); err != nil {
 			return err
 		}
 	}
@@ -36,15 +47,23 @@ func writeIndexFiles(w *writer, steps []parsedStep) error {
 	for i, s := range steps {
 		ids[i] = s.id
 	}
-	if err := w.writeJSON("index/step_ids.json", steplibindex.StepIDs{StepIDs: ids}); err != nil {
+	if err := w.writeJSON(steplibindex.StepIDsPath().FS(), steplibindex.StepIDs{StepIDs: ids}); err != nil {
 		return err
 	}
 
 	for _, s := range steps {
-		if err := w.writeJSON(filepath.Join("index", "steps", s.id, "latest.json"), buildLatestPointer(s)); err != nil {
+		latestPath, err := steplibindex.LatestPointerPath(s.id)
+		if err != nil {
 			return err
 		}
-		if err := w.writeJSON(filepath.Join("index", "steps", s.id, "versions.json"), buildVersionsJSON(s)); err != nil {
+		if err := w.writeJSON(latestPath.FS(), buildLatestPointer(s)); err != nil {
+			return err
+		}
+		versionsPath, err := steplibindex.VersionsPath(s.id)
+		if err != nil {
+			return err
+		}
+		if err := w.writeJSON(versionsPath.FS(), buildVersionsJSON(s)); err != nil {
 			return err
 		}
 	}

--- a/steplibrary/indexgen/index_test.go
+++ b/steplibrary/indexgen/index_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestIndex_per_step_latest_pointer(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	var latest steplibindex.LatestPointer
-	readJSON(t, filepath.Join(out, "index/steps/hello-step/latest.json"), &latest)
+	readJSON(t, filepath.Join(root, mustFS(steplibindex.LatestPointerPath("hello-step"))), &latest)
 
 	assert.Equal(t, "hello-step", latest.StepID, "StepID")
 	assert.Equal(t, "2.0.0", latest.Latest, "Latest")
@@ -23,11 +23,11 @@ func TestIndex_per_step_latest_pointer(t *testing.T) {
 }
 
 func TestIndex_single_version_latest_pointer(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	// bash-step has exactly one version (1.0.0) in a single major.
 	var latest steplibindex.LatestPointer
-	readJSON(t, filepath.Join(out, "index/steps/bash-step/latest.json"), &latest)
+	readJSON(t, filepath.Join(root, mustFS(steplibindex.LatestPointerPath("bash-step"))), &latest)
 
 	assert.Equal(t, "bash-step", latest.StepID, "StepID")
 	assert.Equal(t, "1.0.0", latest.Latest, "Latest")
@@ -35,10 +35,10 @@ func TestIndex_single_version_latest_pointer(t *testing.T) {
 }
 
 func TestIndex_versions_newest_first(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	var versions steplibindex.Versions
-	readJSON(t, filepath.Join(out, "index/steps/hello-step/versions.json"), &versions)
+	readJSON(t, filepath.Join(root, mustFS(steplibindex.VersionsPath("hello-step"))), &versions)
 
 	assert.Equal(t, "hello-step", versions.StepID, "StepID")
 	assert.Equal(t, []string{"2.0.0", "1.1.0", "1.0.0"}, versions.Versions, "Versions newest-first")

--- a/steplibrary/indexgen/index_test.go
+++ b/steplibrary/indexgen/index_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestIndex_per_step_latest_pointer(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	var latest steplibindex.LatestPointer
 	readJSON(t, filepath.Join(out, "index/steps/hello-step/latest.json"), &latest)
@@ -23,7 +23,7 @@ func TestIndex_per_step_latest_pointer(t *testing.T) {
 }
 
 func TestIndex_single_version_latest_pointer(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	// bash-step has exactly one version (1.0.0) in a single major.
 	var latest steplibindex.LatestPointer
@@ -35,7 +35,7 @@ func TestIndex_single_version_latest_pointer(t *testing.T) {
 }
 
 func TestIndex_versions_newest_first(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	var versions steplibindex.Versions
 	readJSON(t, filepath.Join(out, "index/steps/hello-step/versions.json"), &versions)

--- a/steplibrary/indexgen/indexgen.go
+++ b/steplibrary/indexgen/indexgen.go
@@ -197,11 +197,14 @@ func writeInventory(w *writer, inputFS fs.FS, steps []parsedStep, steplibYML mod
 }
 
 // publish atomically swaps the staged tree in for any existing one at outputDir.
-func publish(staging, outputDir string) error {
+func publish(stagingDir, outputDir string) error {
+	if _, err := os.Stat(stagingDir); err != nil {
+		return fmt.Errorf("staging dir (%s): %w", stagingDir, err)
+	}
 	if err := os.RemoveAll(outputDir); err != nil {
 		return fmt.Errorf("clear output dir %s: %w", outputDir, err)
 	}
-	if err := os.Rename(staging, outputDir); err != nil {
+	if err := os.Rename(stagingDir, outputDir); err != nil {
 		return fmt.Errorf("publish inventory to %s: %w", outputDir, err)
 	}
 	return nil

--- a/steplibrary/indexgen/indexgen.go
+++ b/steplibrary/indexgen/indexgen.go
@@ -133,9 +133,10 @@ func generateFromSteplibClone(inputFS fs.FS, outputDir string, opts Options, log
 		}
 	}()
 
-	// Root the tree under the format-version dir (e.g. v2/) inside staging, so
-	// the published outputDir contains <version>/{meta.json,index,steps}.
-	w := &writer{outputDir: filepath.Join(staging, steplibindex.VersionDir()), fw: realFileWriter{}, fm: fileutil.NewFileManager(), fileCount: 0, byteCount: 0}
+	// The writer is rooted at the inventory root (staging); every path it gets
+	// comes from steplibindex, which roots files under the format-version dir
+	// (e.g. v2/), so the published outputDir contains <version>/{meta,index,steps}.
+	w := &writer{outputDir: staging, fw: realFileWriter{}, fm: fileutil.NewFileManager(), fileCount: 0, byteCount: 0}
 	if err := writeInventory(w, inputFS, steps, steplibYML, opts); err != nil {
 		return Stats{}, err
 	}
@@ -190,7 +191,7 @@ func writeInventory(w *writer, inputFS fs.FS, steps []parsedStep, steplibYML mod
 		SteplibSource:     steplibYML.SteplibSource,
 		DownloadLocations: steplibYML.DownloadLocations,
 	}
-	if err := w.writeJSON("meta.json", meta); err != nil {
+	if err := w.writeJSON(steplibindex.MetaPath().FS(), meta); err != nil {
 		return fmt.Errorf("write meta.json: %w", err)
 	}
 	return nil

--- a/steplibrary/indexgen/indexgen.go
+++ b/steplibrary/indexgen/indexgen.go
@@ -1,6 +1,13 @@
 // Package indexgen generates the V2 step library inventory tree from a
 // bitrise-steplib source. The wire-format types it emits live in
 // steplibrary/steplibindex.
+//
+// Generation stages the whole tree in a sibling temp directory, runs
+// validate.go's Validate against the staged tree, and only then atomically
+// publishes it with a single rename. Validation is unconditional: an invalid
+// staged tree is never published, so any existing inventory at the output dir
+// is left untouched on a validation failure, and a successful Generate
+// guarantees the published inventory passes Validate.
 package indexgen
 
 import (
@@ -154,6 +161,18 @@ func generateFromSteplibClone(inputFS fs.FS, outputDir string, opts Options, log
 	}
 	if err := w.writeJSON("meta.json", meta); err != nil {
 		return Stats{}, fmt.Errorf("write meta.json: %w", err)
+	}
+
+	// Validate the fully-staged tree before publishing. An invalid tree is
+	// never published, so any existing inventory at outputDir is left
+	// untouched on a validation failure. staging is the dir CONTAINING the
+	// version dir (v2/), which is exactly the root Validate expects.
+	violations, err := Validate(os.DirFS(staging))
+	if err != nil {
+		return Stats{}, fmt.Errorf("validate staged inventory: %w", err)
+	}
+	if len(violations) > 0 {
+		return Stats{}, fmt.Errorf("staged inventory failed validation (%d violations, first: %s)", len(violations), violations[0])
 	}
 
 	// Publish: swap the freshly staged tree in for any existing one.

--- a/steplibrary/indexgen/indexgen.go
+++ b/steplibrary/indexgen/indexgen.go
@@ -144,7 +144,11 @@ func generateFromSteplibClone(inputFS fs.FS, outputDir string, opts Options, log
 	// published, so any existing inventory at outputDir is left untouched. staging
 	// is the dir CONTAINING the version dir (v2/), the root Validate expects.
 	if violations := Validate(os.DirFS(staging)); len(violations) > 0 {
-		return Stats{}, fmt.Errorf("staged inventory failed validation (%d violations, first: %s)", len(violations), violations[0])
+		errs := make([]error, len(violations))
+		for i, v := range violations {
+			errs[i] = v
+		}
+		return Stats{}, fmt.Errorf("staged inventory failed validation (%d violations):\n%w", len(violations), errors.Join(errs...))
 	}
 
 	if err := publish(staging, outputDir); err != nil {

--- a/steplibrary/indexgen/indexgen.go
+++ b/steplibrary/indexgen/indexgen.go
@@ -2,9 +2,9 @@
 // bitrise-steplib source. The wire-format types it emits live in
 // steplibrary/steplibindex.
 //
-// Generation stages the whole tree in a sibling temp directory, runs
-// validate.go's Validate against the staged tree, and only then atomically
-// publishes it with a single rename. Validation is unconditional: an invalid
+// Generation stages the whole tree in a sibling temp directory, runs Validate
+// against the staged tree, and only then atomically publishes it with a single
+// rename. Validation is unconditional: an invalid
 // staged tree is never published, so any existing inventory at the output dir
 // is left untouched on a validation failure, and a successful Generate
 // guarantees the published inventory passes Validate.

--- a/steplibrary/indexgen/indexgen.go
+++ b/steplibrary/indexgen/indexgen.go
@@ -167,10 +167,7 @@ func generateFromSteplibClone(inputFS fs.FS, outputDir string, opts Options, log
 	// never published, so any existing inventory at outputDir is left
 	// untouched on a validation failure. staging is the dir CONTAINING the
 	// version dir (v2/), which is exactly the root Validate expects.
-	violations, err := Validate(os.DirFS(staging))
-	if err != nil {
-		return Stats{}, fmt.Errorf("validate staged inventory: %w", err)
-	}
+	violations := Validate(os.DirFS(staging))
 	if len(violations) > 0 {
 		return Stats{}, fmt.Errorf("staged inventory failed validation (%d violations, first: %s)", len(violations), violations[0])
 	}

--- a/steplibrary/indexgen/indexgen.go
+++ b/steplibrary/indexgen/indexgen.go
@@ -136,7 +136,7 @@ func generateFromSteplibClone(inputFS fs.FS, outputDir string, opts Options, log
 	// The writer is rooted at the inventory root (staging); every path it gets
 	// comes from steplibindex, which roots files under the format-version dir
 	// (e.g. v2/), so the published outputDir contains <version>/{meta,index,steps}.
-	w := &writer{outputDir: staging, fw: realFileWriter{}, fm: fileutil.NewFileManager(), fileCount: 0, byteCount: 0}
+	w := newWriter(staging, fileutil.NewFileManager())
 	if err := writeInventory(w, inputFS, steps, steplibYML, opts); err != nil {
 		return Stats{}, err
 	}

--- a/steplibrary/indexgen/indexgen.go
+++ b/steplibrary/indexgen/indexgen.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/command/git"
 	"github.com/bitrise-io/go-utils/v2/fileutil"
+	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
 	"github.com/bitrise-io/stepman/stepman"
 )
@@ -120,15 +121,9 @@ func generateFromSteplibClone(inputFS fs.FS, outputDir string, opts Options, log
 		return Stats{}, err
 	}
 
-	// Stage in a sibling of outputDir (same filesystem, so the publish rename
-	// is atomic and never cross-device).
-	parent := filepath.Dir(outputDir)
-	if err := os.MkdirAll(parent, 0o700); err != nil {
-		return Stats{}, fmt.Errorf("create output parent %s: %w", parent, err)
-	}
-	staging, err := os.MkdirTemp(parent, ".indexgen-staging-*")
+	staging, err := createStagingDir(outputDir)
 	if err != nil {
-		return Stats{}, fmt.Errorf("create staging dir: %w", err)
+		return Stats{}, err
 	}
 	defer func() {
 		// On success staging has been renamed away, so RemoveAll is a no-op;
@@ -141,17 +136,49 @@ func generateFromSteplibClone(inputFS fs.FS, outputDir string, opts Options, log
 	// Root the tree under the format-version dir (e.g. v2/) inside staging, so
 	// the published outputDir contains <version>/{meta.json,index,steps}.
 	w := &writer{outputDir: filepath.Join(staging, steplibindex.VersionDir()), fw: realFileWriter{}, fm: fileutil.NewFileManager(), fileCount: 0, byteCount: 0}
+	if err := writeInventory(w, inputFS, steps, steplibYML, opts); err != nil {
+		return Stats{}, err
+	}
 
+	// Validate the fully-staged tree before publishing: an invalid tree is never
+	// published, so any existing inventory at outputDir is left untouched. staging
+	// is the dir CONTAINING the version dir (v2/), the root Validate expects.
+	if violations := Validate(os.DirFS(staging)); len(violations) > 0 {
+		return Stats{}, fmt.Errorf("staged inventory failed validation (%d violations, first: %s)", len(violations), violations[0])
+	}
+
+	if err := publish(staging, outputDir); err != nil {
+		return Stats{}, err
+	}
+
+	return buildStats(steps, w, start), nil
+}
+
+// createStagingDir makes a fresh staging directory as a sibling of outputDir
+// (same filesystem, so publish's rename is atomic and never cross-device).
+func createStagingDir(outputDir string) (string, error) {
+	parent := filepath.Dir(outputDir)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return "", fmt.Errorf("create output parent %s: %w", parent, err)
+	}
+	staging, err := os.MkdirTemp(parent, ".indexgen-staging-*")
+	if err != nil {
+		return "", fmt.Errorf("create staging dir: %w", err)
+	}
+	return staging, nil
+}
+
+// writeInventory emits the full V2 tree through w: per-step source files, the
+// derived index files, and meta.json.
+func writeInventory(w *writer, inputFS fs.FS, steps []parsedStep, steplibYML models.StepCollectionModel, opts Options) error {
 	for _, s := range steps {
 		if err := writeStepFiles(w, inputFS, s); err != nil {
-			return Stats{}, fmt.Errorf("write step %s: %w", s.id, err)
+			return fmt.Errorf("write step %s: %w", s.id, err)
 		}
 	}
-
 	if err := writeIndexFiles(w, steps); err != nil {
-		return Stats{}, fmt.Errorf("write index files: %w", err)
+		return fmt.Errorf("write index files: %w", err)
 	}
-
 	meta := steplibindex.Meta{
 		FormatVersion:     steplibindex.FormatVersion,
 		UpdatedAt:         opts.GeneratedAt,
@@ -160,26 +187,24 @@ func generateFromSteplibClone(inputFS fs.FS, outputDir string, opts Options, log
 		DownloadLocations: steplibYML.DownloadLocations,
 	}
 	if err := w.writeJSON("meta.json", meta); err != nil {
-		return Stats{}, fmt.Errorf("write meta.json: %w", err)
+		return fmt.Errorf("write meta.json: %w", err)
 	}
+	return nil
+}
 
-	// Validate the fully-staged tree before publishing. An invalid tree is
-	// never published, so any existing inventory at outputDir is left
-	// untouched on a validation failure. staging is the dir CONTAINING the
-	// version dir (v2/), which is exactly the root Validate expects.
-	violations := Validate(os.DirFS(staging))
-	if len(violations) > 0 {
-		return Stats{}, fmt.Errorf("staged inventory failed validation (%d violations, first: %s)", len(violations), violations[0])
-	}
-
-	// Publish: swap the freshly staged tree in for any existing one.
+// publish atomically swaps the staged tree in for any existing one at outputDir.
+func publish(staging, outputDir string) error {
 	if err := os.RemoveAll(outputDir); err != nil {
-		return Stats{}, fmt.Errorf("clear output dir %s: %w", outputDir, err)
+		return fmt.Errorf("clear output dir %s: %w", outputDir, err)
 	}
 	if err := os.Rename(staging, outputDir); err != nil {
-		return Stats{}, fmt.Errorf("publish inventory to %s: %w", outputDir, err)
+		return fmt.Errorf("publish inventory to %s: %w", outputDir, err)
 	}
+	return nil
+}
 
+// buildStats summarizes a completed generation.
+func buildStats(steps []parsedStep, w *writer, start time.Time) Stats {
 	versionCount := 0
 	for _, s := range steps {
 		versionCount += len(s.versions)
@@ -190,5 +215,5 @@ func generateFromSteplibClone(inputFS fs.FS, outputDir string, opts Options, log
 		FilesWritten: w.fileCount,
 		BytesWritten: w.byteCount,
 		Duration:     time.Since(start),
-	}, nil
+	}
 }

--- a/steplibrary/indexgen/indexgen_test.go
+++ b/steplibrary/indexgen/indexgen_test.go
@@ -24,8 +24,11 @@ func (l testLogger) Infof(format string, v ...any)  { l.t.Logf("INFO "+format, v
 func (l testLogger) Warnf(format string, v ...any)  { l.t.Logf("WARN "+format, v...) }
 func (l testLogger) Errorf(format string, v ...any) { l.t.Logf("ERROR "+format, v...) }
 
-// runGenerateFromSteplibClone runs the generator against the checked-in
-// testdata using a fresh temp output dir. Returns the output dir for assertions.
+// runGenerateFromSteplibClone runs the generator against the checked-in testdata
+// in a fresh temp dir and returns the inventory root: the dir CONTAINING the
+// version dir (v2/), which is the root Validate expects. Each call is an
+// isolated, disposable copy — callers may mutate the tree without touching the
+// read-only embedded fixture.
 func runGenerateFromSteplibClone(t *testing.T) string {
 	t.Helper()
 	out := t.TempDir()
@@ -36,8 +39,15 @@ func runGenerateFromSteplibClone(t *testing.T) string {
 		testLogger{t},
 	)
 	require.NoError(t, gotErr, "generateFromSteplibClone")
-	// The tree is rooted under the format-version dir (e.g. v2/).
-	return filepath.Join(out, steplibindex.VersionDir())
+	return out
+}
+
+// generatedVersionDir is the version-dir (v2/) root of a freshly generated tree,
+// where the index/steps/meta files live. Most generator-output assertions want
+// this; Validate wants the parent (runGenerateFromSteplibClone).
+func generatedVersionDir(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(runGenerateFromSteplibClone(t), steplibindex.VersionDir())
 }
 
 func readJSON(t *testing.T, path string, into any) {
@@ -48,7 +58,7 @@ func readJSON(t *testing.T, path string, into any) {
 }
 
 func TestGenerator_meta(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	var meta steplibindex.Meta
 	readJSON(t, filepath.Join(out, "meta.json"), &meta)
@@ -65,7 +75,7 @@ func TestGenerator_meta(t *testing.T) {
 }
 
 func TestGenerator_step_ids_sorted(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	var ids steplibindex.StepIDs
 	readJSON(t, filepath.Join(out, "index/step_ids.json"), &ids)
@@ -96,7 +106,7 @@ func TestGenerator_stats(t *testing.T) {
 }
 
 func TestGenerator_authored_files_are_owner_only(t *testing.T) {
-	out := runGenerateFromSteplibClone(t)
+	out := generatedVersionDir(t)
 
 	// Files and dirs the generator authors get owner-only perms (no group/other).
 	// Copied assets keep their source perms and are covered separately.

--- a/steplibrary/indexgen/indexgen_test.go
+++ b/steplibrary/indexgen/indexgen_test.go
@@ -42,14 +42,6 @@ func runGenerateFromSteplibClone(t *testing.T) string {
 	return out
 }
 
-// generatedVersionDir is the version-dir (v2/) root of a freshly generated tree,
-// where the index/steps/meta files live. Most generator-output assertions want
-// this; Validate wants the parent (runGenerateFromSteplibClone).
-func generatedVersionDir(t *testing.T) string {
-	t.Helper()
-	return filepath.Join(runGenerateFromSteplibClone(t), steplibindex.VersionDir())
-}
-
 func readJSON(t *testing.T, path string, into any) {
 	t.Helper()
 	bytes, err := os.ReadFile(path)
@@ -58,10 +50,10 @@ func readJSON(t *testing.T, path string, into any) {
 }
 
 func TestGenerator_meta(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	var meta steplibindex.Meta
-	readJSON(t, filepath.Join(out, "meta.json"), &meta)
+	readJSON(t, filepath.Join(root, steplibindex.MetaPath().FS()), &meta)
 
 	assert.Equal(t, steplibindex.FormatVersion, meta.FormatVersion, "FormatVersion")
 	assert.Equal(t, 2, meta.FormatVersion, "FormatVersion literal")
@@ -75,10 +67,10 @@ func TestGenerator_meta(t *testing.T) {
 }
 
 func TestGenerator_step_ids_sorted(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	var ids steplibindex.StepIDs
-	readJSON(t, filepath.Join(out, "index/step_ids.json"), &ids)
+	readJSON(t, filepath.Join(root, steplibindex.StepIDsPath().FS()), &ids)
 
 	want := []string{"bash-step", "deprecated-step", "hello-step", "multi-platform-step"}
 	assert.Equal(t, want, ids.StepIDs, "step IDs")
@@ -106,15 +98,15 @@ func TestGenerator_stats(t *testing.T) {
 }
 
 func TestGenerator_authored_files_are_owner_only(t *testing.T) {
-	out := generatedVersionDir(t)
+	root := runGenerateFromSteplibClone(t)
 
 	// Files and dirs the generator authors get owner-only perms (no group/other).
 	// Copied assets keep their source perms and are covered separately.
-	metaInfo, err := os.Stat(filepath.Join(out, "meta.json"))
+	metaInfo, err := os.Stat(filepath.Join(root, steplibindex.MetaPath().FS()))
 	require.NoError(t, err, "stat meta.json")
 	assert.Equal(t, os.FileMode(0o600), metaInfo.Mode().Perm(), "authored file is 0600")
 
-	dirInfo, err := os.Stat(filepath.Join(out, "index"))
+	dirInfo, err := os.Stat(filepath.Join(root, steplibindex.VersionDir(), steplibindex.IndexRootFS))
 	require.NoError(t, err, "stat index/ dir")
 	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm(), "authored dir is 0700")
 }
@@ -136,7 +128,7 @@ func TestGenerator_publish_replaces_existing_tree(t *testing.T) {
 
 	_, statErr := os.Stat(stale)
 	assert.True(t, os.IsNotExist(statErr), "stale file should be gone after wholesale replace; got err=%v", statErr)
-	_, statErr = os.Stat(filepath.Join(out, steplibindex.VersionDir(), "meta.json"))
+	_, statErr = os.Stat(filepath.Join(out, steplibindex.MetaPath().FS()))
 	assert.NoError(t, statErr, "meta.json present after publish")
 }
 

--- a/steplibrary/indexgen/roundtrip_integration_test.go
+++ b/steplibrary/indexgen/roundtrip_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package indexgen
 
 import (
@@ -22,28 +24,17 @@ import (
 // produced it, just JSON-encoded.
 //
 // It runs against the real default steplib — every step, every version — so it
-// needs network access and is gated on RUN_STEPLIB_GEN (skipped in CI):
+// needs network and builds only under the "integration" build tag (excluded
+// from a normal `go test ./...`); STEPLIB_URI overrides the source. For each
+// step it parses the source step.yml through the same pipeline the generator
+// uses, parses the generated step.json, and asserts the two serialize to equal
+// JSON.
 //
-//	RUN_STEPLIB_GEN=1 go test -run TestRoundTrip -v ./steplibrary/indexgen/
-//
-// STEPLIB_URI overrides the source (default: bitrise-steplib). For every
-// step.yml in the steplib it:
-//
-//  1. Parses the source step.yml through the same pipeline the generator
-//     uses (yaml.Unmarshal + Normalize + FillMissingDefaults) → fromYAML.
-//  2. Parses the generated step.json into a models.StepModel → fromJSON.
-//  3. Marshals both back to JSON and asserts semantic equality (assert.JSONEq).
-//
-// Comparing via the JSON wire format rather than reflect.DeepEqual on the
-// Go structs is deliberate: an empty slice and a nil slice both serialize
-// to the same JSON under omitempty, so they're semantically equivalent for
-// every consumer of the wire format. The contract is "the bytes a consumer
-// receives carry the same step", not "the in-memory Go struct is
-// bit-identical."
+// The comparison is via the JSON wire format, not reflect.DeepEqual on the Go
+// structs, on purpose: a nil and an empty slice serialize identically under
+// omitempty, so they're equivalent to every consumer of the bytes. The contract
+// is "the bytes carry the same step", not "the in-memory struct is identical".
 func TestRoundTrip_stepYAML_to_stepJSON(t *testing.T) {
-	if os.Getenv("RUN_STEPLIB_GEN") == "" {
-		t.Skip("set RUN_STEPLIB_GEN=1 to round-trip every step in a real steplib")
-	}
 	uri := cmp.Or(os.Getenv("STEPLIB_URI"), "https://github.com/bitrise-io/bitrise-steplib.git")
 
 	// Generate the V2 tree (Generate clones the steplib into stepman's local
@@ -128,10 +119,9 @@ func generatedStepJSONPath(p, v2Dir string) (jsonPath string, ok bool) {
 }
 
 // parseStepYMLForRoundTrip mirrors the generator's canonical step.yml parse
-// pipeline (yaml.Unmarshal + Normalize + FillMissingDefaults). It is
-// duplicated here on purpose: the round-trip property we're asserting is
-// "the bytes the generator emits decode back to whatever its pipeline
-// produced", so we re-derive the expected model from first principles
+// pipeline. It is duplicated here on purpose: the round-trip property we're
+// asserting is "the bytes the generator emits decode back to whatever its
+// pipeline produced", so we re-derive the expected model from first principles
 // rather than calling the generator's internal helper.
 func parseStepYMLForRoundTrip(t *testing.T, inputFS fs.FS, ymlPath string) models.StepModel {
 	t.Helper()

--- a/steplibrary/indexgen/roundtrip_test.go
+++ b/steplibrary/indexgen/roundtrip_test.go
@@ -85,7 +85,7 @@ type stepYAMLJSONPair struct {
 // collectStepYMLAndJSONPaths walks inputFS's source steps/ tree for every
 // step.yml and returns the matching pair of (input step.yml path, generated
 // step.json path under the v2 output dir). Asserts each generated step.json
-// exists. Non-semver version dirs are skipped to match the generator.
+// exists.
 func collectStepYMLAndJSONPaths(t *testing.T, inputFS fs.FS, outV2Dir string) []stepYAMLJSONPair {
 	t.Helper()
 	var pairs []stepYAMLJSONPair
@@ -94,26 +94,37 @@ func collectStepYMLAndJSONPaths(t *testing.T, inputFS fs.FS, outV2Dir string) []
 		if walkErr != nil {
 			return walkErr
 		}
-		if d.IsDir() || filepath.Base(p) != "step.yml" {
+		if d.IsDir() {
 			return nil
 		}
-		// p looks like "steps/<id>/<version>/step.yml" — drop the trailing
-		// "/step.yml" to get the version dir, then locate the JSON counterpart
-		// in the v2 output (which mirrors the steps/<id>/<version>/ layout).
-		rel := strings.TrimSuffix(p, "/step.yml") // steps/<id>/<version>
-		segs := strings.Split(rel, "/")
-		if len(segs) != 3 {
-			return nil // not a steps/<id>/<version> path
+		jsonPath, ok := generatedStepJSONPath(p, outV2Dir)
+		if !ok {
+			return nil
 		}
-		if _, err := models.ParseSemver(segs[2]); err != nil {
-			return nil // non-semver version dir: generator skips these
-		}
-		jsonPath := filepath.Join(outV2Dir, rel, "step.json")
 		require.FileExists(t, jsonPath, "generated step.json missing for %s", p)
 		pairs = append(pairs, stepYAMLJSONPair{yamlPath: p, jsonPath: jsonPath})
 		return nil
 	}))
 	return pairs
+}
+
+// generatedStepJSONPath maps a source "steps/<id>/<version>/step.yml" path to
+// its generated step.json path under v2Dir. ok is false for paths the
+// generator doesn't emit a step.json for: non-step.yml files and non-semver
+// version dirs.
+func generatedStepJSONPath(p, v2Dir string) (jsonPath string, ok bool) {
+	if filepath.Base(p) != "step.yml" {
+		return "", false
+	}
+	rel := strings.TrimSuffix(p, "/step.yml") // steps/<id>/<version>
+	segs := strings.Split(rel, "/")
+	if len(segs) != 3 {
+		return "", false // not a steps/<id>/<version> path
+	}
+	if _, err := models.ParseSemver(segs[2]); err != nil {
+		return "", false // non-semver version dir: generator skips these
+	}
+	return filepath.Join(v2Dir, rel, "step.json"), true
 }
 
 // parseStepYMLForRoundTrip mirrors the generator's canonical step.yml parse

--- a/steplibrary/indexgen/roundtrip_test.go
+++ b/steplibrary/indexgen/roundtrip_test.go
@@ -1,6 +1,7 @@
 package indexgen
 
 import (
+	"cmp"
 	"encoding/json"
 	"io/fs"
 	"os"
@@ -8,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bitrise-io/stepman/internal/specfixtures"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
+	"github.com/bitrise-io/stepman/stepman"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -20,12 +21,18 @@ import (
 // contract: a generated step.json must be exactly the V1 step.yml that
 // produced it, just JSON-encoded.
 //
-// For every step.yml in the source fixtures we:
+// It runs against the real default steplib — every step, every version — so it
+// needs network access and is gated on RUN_STEPLIB_GEN (skipped in CI):
 //
-//  1. Parse the source step.yml through the same pipeline the generator
+//	RUN_STEPLIB_GEN=1 go test -run TestRoundTrip -v ./steplibrary/indexgen/
+//
+// STEPLIB_URI overrides the source (default: bitrise-steplib). For every
+// step.yml in the steplib it:
+//
+//  1. Parses the source step.yml through the same pipeline the generator
 //     uses (yaml.Unmarshal + Normalize + FillMissingDefaults) → fromYAML.
-//  2. Parse the generated step.json into a models.StepModel → fromJSON.
-//  3. Marshal both back to JSON and assert semantic equality (assert.JSONEq).
+//  2. Parses the generated step.json into a models.StepModel → fromJSON.
+//  3. Marshals both back to JSON and asserts semantic equality (assert.JSONEq).
 //
 // Comparing via the JSON wire format rather than reflect.DeepEqual on the
 // Go structs is deliberate: an empty slice and a nil slice both serialize
@@ -33,16 +40,26 @@ import (
 // every consumer of the wire format. The contract is "the bytes a consumer
 // receives carry the same step", not "the in-memory Go struct is
 // bit-identical."
-//
-// Any future regression that silently drops a field surfaces here. The
-// validator catches structural problems with the inventory tree as a
-// whole; this catches per-version content drift the validator can't see.
 func TestRoundTrip_stepYAML_to_stepJSON(t *testing.T) {
-	out := runGenerateFromSteplibClone(t) // the v2/ output dir
-	inputFS := specfixtures.SteplibClone()
+	if os.Getenv("RUN_STEPLIB_GEN") == "" {
+		t.Skip("set RUN_STEPLIB_GEN=1 to round-trip every step in a real steplib")
+	}
+	uri := cmp.Or(os.Getenv("STEPLIB_URI"), "https://github.com/bitrise-io/bitrise-steplib.git")
 
-	pairs := collectStepYMLAndJSONPaths(t, inputFS, out)
+	// Generate the V2 tree (Generate clones the steplib into stepman's local
+	// cache), then read the clone back to pair each step.yml with its step.json.
+	out := t.TempDir()
+	_, err := Generate(uri, out, Options{}, testLogger{t})
+	require.NoError(t, err, "Generate")
+
+	route, found := stepman.ReadRoute(uri)
+	require.True(t, found, "no route for %s after Generate", uri)
+	inputFS := os.DirFS(stepman.GetLibraryBaseDirPath(route))
+	v2Dir := filepath.Join(out, steplibindex.VersionDir())
+
+	pairs := collectStepYMLAndJSONPaths(t, inputFS, v2Dir)
 	require.NotEmpty(t, pairs, "expected at least one step.yml/step.json pair to compare")
+	t.Logf("round-tripping %d step versions from %s", len(pairs), uri)
 
 	for _, p := range pairs {
 		t.Run(p.yamlPath, func(t *testing.T) {

--- a/steplibrary/indexgen/roundtrip_test.go
+++ b/steplibrary/indexgen/roundtrip_test.go
@@ -1,0 +1,128 @@
+package indexgen
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/stepman/internal/specfixtures"
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+// TestRoundTrip_stepYAML_to_stepJSON locks in the central V2 wire-format
+// contract: a generated step.json must be exactly the V1 step.yml that
+// produced it, just JSON-encoded.
+//
+// For every step.yml in the source fixtures we:
+//
+//  1. Parse the source step.yml through the same pipeline the generator
+//     uses (yaml.Unmarshal + Normalize + FillMissingDefaults) → fromYAML.
+//  2. Parse the generated step.json into a models.StepModel → fromJSON.
+//  3. Marshal both back to JSON and assert semantic equality (assert.JSONEq).
+//
+// Comparing via the JSON wire format rather than reflect.DeepEqual on the
+// Go structs is deliberate: an empty slice and a nil slice both serialize
+// to the same JSON under omitempty, so they're semantically equivalent for
+// every consumer of the wire format. The contract is "the bytes a consumer
+// receives carry the same step", not "the in-memory Go struct is
+// bit-identical."
+//
+// Any future regression that silently drops a field surfaces here. The
+// validator catches structural problems with the inventory tree as a
+// whole; this catches per-version content drift the validator can't see.
+func TestRoundTrip_stepYAML_to_stepJSON(t *testing.T) {
+	out := runGenerateFromSteplibClone(t) // the v2/ output dir
+	inputFS := specfixtures.SteplibClone()
+
+	pairs := collectStepYMLAndJSONPaths(t, inputFS, out)
+	require.NotEmpty(t, pairs, "expected at least one step.yml/step.json pair to compare")
+
+	for _, p := range pairs {
+		t.Run(p.yamlPath, func(t *testing.T) {
+			fromYAML := parseStepYMLForRoundTrip(t, inputFS, p.yamlPath)
+			fromJSON := parseStepJSONForRoundTrip(t, p.jsonPath)
+
+			yamlAsJSON, err := json.Marshal(fromYAML)
+			require.NoError(t, err, "re-marshal fromYAML")
+			jsonAsJSON, err := json.Marshal(fromJSON)
+			require.NoError(t, err, "re-marshal fromJSON")
+
+			assert.JSONEq(t, string(yamlAsJSON), string(jsonAsJSON),
+				"step.yml and the generated step.json must serialize to semantically equal JSON")
+		})
+	}
+}
+
+type stepYAMLJSONPair struct {
+	yamlPath string // path within inputFS, e.g. "steps/hello-step/1.0.0/step.yml"
+	jsonPath string // absolute path on disk, e.g. "<v2>/steps/hello-step/1.0.0/step.json"
+}
+
+// collectStepYMLAndJSONPaths walks inputFS's source steps/ tree for every
+// step.yml and returns the matching pair of (input step.yml path, generated
+// step.json path under the v2 output dir). Asserts each generated step.json
+// exists. Non-semver version dirs are skipped to match the generator.
+func collectStepYMLAndJSONPaths(t *testing.T, inputFS fs.FS, outV2Dir string) []stepYAMLJSONPair {
+	t.Helper()
+	var pairs []stepYAMLJSONPair
+
+	require.NoError(t, fs.WalkDir(inputFS, steplibindex.StepsRootFS, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || filepath.Base(p) != "step.yml" {
+			return nil
+		}
+		// p looks like "steps/<id>/<version>/step.yml" — drop the trailing
+		// "/step.yml" to get the version dir, then locate the JSON counterpart
+		// in the v2 output (which mirrors the steps/<id>/<version>/ layout).
+		rel := strings.TrimSuffix(p, "/step.yml") // steps/<id>/<version>
+		segs := strings.Split(rel, "/")
+		if len(segs) != 3 {
+			return nil // not a steps/<id>/<version> path
+		}
+		if _, err := models.ParseSemver(segs[2]); err != nil {
+			return nil // non-semver version dir: generator skips these
+		}
+		jsonPath := filepath.Join(outV2Dir, rel, "step.json")
+		require.FileExists(t, jsonPath, "generated step.json missing for %s", p)
+		pairs = append(pairs, stepYAMLJSONPair{yamlPath: p, jsonPath: jsonPath})
+		return nil
+	}))
+	return pairs
+}
+
+// parseStepYMLForRoundTrip mirrors the generator's canonical step.yml parse
+// pipeline (yaml.Unmarshal + Normalize + FillMissingDefaults). It is
+// duplicated here on purpose: the round-trip property we're asserting is
+// "the bytes the generator emits decode back to whatever its pipeline
+// produced", so we re-derive the expected model from first principles
+// rather than calling the generator's internal helper.
+func parseStepYMLForRoundTrip(t *testing.T, inputFS fs.FS, ymlPath string) models.StepModel {
+	t.Helper()
+	bytes, err := fs.ReadFile(inputFS, ymlPath)
+	require.NoError(t, err, "read %s", ymlPath)
+
+	var step models.StepModel
+	require.NoError(t, yaml.Unmarshal(bytes, &step), "yaml.Unmarshal %s", ymlPath)
+	require.NoError(t, step.Normalize(), "Normalize %s", ymlPath)
+	require.NoError(t, step.FillMissingDefaults(), "FillMissingDefaults %s", ymlPath)
+	return step
+}
+
+func parseStepJSONForRoundTrip(t *testing.T, jsonPath string) models.StepModel {
+	t.Helper()
+	bytes, err := os.ReadFile(jsonPath)
+	require.NoError(t, err, "read %s", jsonPath)
+
+	var step models.StepModel
+	require.NoError(t, json.Unmarshal(bytes, &step), "json.Unmarshal %s", jsonPath)
+	return step
+}

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -286,27 +286,22 @@ func validateAssetURL(rel, stepDir string) string {
 // from a previous generation (a removed step), or a stray file from a generator
 // bug. It reads the accumulated seen set, so it must run after all other checks.
 func (v *validator) staleFileViolations() []ValidationError {
-	roots := []string{
-		path.Join(steplibindex.VersionDir(), steplibindex.StepsRootFS),
-		path.Join(steplibindex.VersionDir(), steplibindex.IndexRootFS),
-	}
-	var issues []ValidationError
-	for _, root := range roots {
-		walkErr := fs.WalkDir(v.fs, root, func(p string, d fs.DirEntry, err error) error {
-			switch {
-			case err != nil:
-				// A missing or unreadable expected root is itself a violation.
-				issues = append(issues, violationf(p, "walk failed: %s", err))
-			case !d.IsDir() && !v.seen[p]:
-				issues = append(issues, violationf(p, "unexpected file under %s/", root))
-			}
-			return nil
-		})
-		if walkErr != nil {
-			// The callback handles each entry's error and always returns nil, so
-			// this only fires if that ever changes — don't let it be dropped.
-			issues = append(issues, violationf(root, "walk aborted: %s", walkErr))
+	root := steplibindex.VersionDir()
+	issues := []ValidationError{}
+	walkErr := fs.WalkDir(v.fs, root, func(p string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			// A missing or unreadable expected root is itself a violation.
+			issues = append(issues, violationf(p, "walk failed: %s", err))
+		case !d.IsDir() && !v.seen[p]:
+			issues = append(issues, violationf(p, "unexpected file under %s/", root))
 		}
+		return nil
+	})
+	if walkErr != nil {
+		// The callback handles each entry's error and always returns nil, so
+		// this only fires if that ever changes — don't let it be dropped.
+		issues = append(issues, violationf(root, "walk aborted: %s", walkErr))
 	}
 	return issues
 }

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -2,7 +2,6 @@ package indexgen
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"path"
@@ -28,6 +27,11 @@ func (e ValidationError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Path, e.Msg)
 }
 
+// violationf builds a ValidationError with a formatted message.
+func violationf(p, format string, args ...any) ValidationError {
+	return ValidationError{Path: p, Msg: fmt.Sprintf(format, args...)}
+}
+
 // Validate walks the V2 inventory tree rooted at inventoryFS and returns the
 // list of consistency violations. An empty slice means the tree is internally
 // consistent.
@@ -42,110 +46,120 @@ func (e ValidationError) Error() string {
 // reported as a violation, so callers only need to check whether the returned
 // slice is empty.
 func Validate(inventoryFS fs.FS) []ValidationError {
-	v := &validator{fs: inventoryFS, seen: map[string]bool{}, errs: nil}
-	v.run()
-	return v.errs
+	v := &validator{fs: inventoryFS, seen: map[string]bool{}}
+	issues := v.collect()
+
+	// Sort violations by (Path, Msg) so the output is deterministic across runs.
+	// Without this, map-iteration order leaks into the output and breaks any
+	// consumer that diffs error logs (golden files, CI dashboards, etc.).
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].Path != issues[j].Path {
+			return issues[i].Path < issues[j].Path
+		}
+		return issues[i].Msg < issues[j].Msg
+	})
+	return issues
 }
 
+// validator carries the read-only inventory and the set of paths consumed so
+// far. Each check returns its own violations; the consumed set is the one piece
+// of cross-check state (populated as files are read, drained by the stale-file
+// sweep at the end).
 type validator struct {
 	fs   fs.FS
 	seen map[string]bool // paths the validator has consumed; remainder is stale
-	errs []ValidationError
-}
-
-func (v *validator) flag(p, msg string, args ...any) {
-	v.errs = append(v.errs, ValidationError{Path: p, Msg: fmt.Sprintf(msg, args...)})
 }
 
 func (v *validator) consume(p string) { v.seen[p] = true }
 
-func (v *validator) run() {
+func (v *validator) collect() []ValidationError {
+	var issues []ValidationError
+
 	var meta steplibindex.Meta
-	if v.readJSON(steplibindex.MetaPathFS(), &meta) {
-		v.checkMeta(meta)
+	metaIssues, ok := v.readJSON(steplibindex.MetaPathFS(), &meta)
+	issues = append(issues, metaIssues...)
+	if ok {
+		issues = append(issues, v.checkMeta(meta)...)
 	}
 
 	var stepIDs steplibindex.StepIDs
-	haveIDs := v.readJSON(steplibindex.StepIDsPathFS(), &stepIDs)
-
+	stepIDsIssues, haveIDs := v.readJSON(steplibindex.StepIDsPathFS(), &stepIDs)
+	issues = append(issues, stepIDsIssues...)
 	if haveIDs {
 		if len(stepIDs.StepIDs) == 0 {
-			v.flag(steplibindex.StepIDsPathFS(), "step_ids is empty: a steplib must contain at least one step")
+			issues = append(issues, violationf(steplibindex.StepIDsPathFS(), "step_ids is empty: a steplib must contain at least one step"))
 		}
-		v.checkStepIDsSorted(stepIDs)
+		issues = append(issues, v.checkStepIDsSorted(stepIDs)...)
 		for _, id := range stepIDs.StepIDs {
-			v.checkStep(id)
+			issues = append(issues, v.checkStep(id)...)
 		}
 	}
 
-	v.checkNoStaleFiles()
-
-	// Sort violations by (Path, Msg) so the error output is deterministic
-	// across runs. Without this, map-iteration order leaks into the
-	// validator's output and breaks any consumer that diffs error logs
-	// (golden files, CI dashboards, etc.).
-	sort.Slice(v.errs, func(i, j int) bool {
-		if v.errs[i].Path != v.errs[j].Path {
-			return v.errs[i].Path < v.errs[j].Path
-		}
-		return v.errs[i].Msg < v.errs[j].Msg
-	})
+	issues = append(issues, v.staleFileViolations()...)
+	return issues
 }
 
-// readJSON marks the file as consumed and parses it into `into`. Returns
-// false (and logs a violation) on missing/unreadable/invalid JSON.
-func (v *validator) readJSON(p string, into any) bool {
+// readJSON marks the file as consumed and parses it into `into`. ok is false
+// (and a violation is returned) on missing/unreadable/invalid JSON; on success
+// it returns no violations.
+func (v *validator) readJSON(p string, into any) (issues []ValidationError, ok bool) {
 	v.consume(p)
 	bytes, err := fs.ReadFile(v.fs, p)
 	if err != nil {
-		v.flag(p, "missing or unreadable: %s", err)
-		return false
+		return []ValidationError{violationf(p, "missing or unreadable: %s", err)}, false
 	}
 	if err := json.Unmarshal(bytes, into); err != nil {
-		v.flag(p, "invalid JSON: %s", err)
-		return false
+		return []ValidationError{violationf(p, "invalid JSON: %s", err)}, false
 	}
-	return true
+	return nil, true
 }
 
-func (v *validator) checkMeta(m steplibindex.Meta) {
+func (v *validator) checkMeta(m steplibindex.Meta) []ValidationError {
+	var issues []ValidationError
 	if m.FormatVersion != steplibindex.FormatVersion {
-		v.flag(steplibindex.MetaPathFS(), "format_version is %d, expected %d", m.FormatVersion, steplibindex.FormatVersion)
+		issues = append(issues, violationf(steplibindex.MetaPathFS(), "format_version is %d, expected %d", m.FormatVersion, steplibindex.FormatVersion))
 	}
 	if m.UpdatedAt.IsZero() {
-		v.flag(steplibindex.MetaPathFS(), "updated_at is zero")
+		issues = append(issues, violationf(steplibindex.MetaPathFS(), "updated_at is zero"))
 	}
+	return issues
 }
 
-func (v *validator) checkStepIDsSorted(ids steplibindex.StepIDs) {
+func (v *validator) checkStepIDsSorted(ids steplibindex.StepIDs) []ValidationError {
+	var issues []ValidationError
 	if !sort.StringsAreSorted(ids.StepIDs) {
-		v.flag(steplibindex.StepIDsPathFS(), "step_ids is not sorted lexicographically")
+		issues = append(issues, violationf(steplibindex.StepIDsPathFS(), "step_ids is not sorted lexicographically"))
 	}
 	// Duplicate detection.
 	seen := make(map[string]bool, len(ids.StepIDs))
 	for _, id := range ids.StepIDs {
 		if seen[id] {
-			v.flag(steplibindex.StepIDsPathFS(), "duplicate step id %q", id)
+			issues = append(issues, violationf(steplibindex.StepIDsPathFS(), "duplicate step id %q", id))
 		}
 		seen[id] = true
 	}
+	return issues
 }
 
-func (v *validator) checkStep(id string) {
+func (v *validator) checkStep(id string) []ValidationError {
 	latestPath := steplibindex.LatestPointerPathFS(id)
 	versionsPath := steplibindex.VersionsPathFS(id)
 
+	var issues []ValidationError
+
 	var latest steplibindex.LatestPointer
-	haveLatest := v.readJSON(latestPath, &latest)
+	latestIssues, haveLatest := v.readJSON(latestPath, &latest)
+	issues = append(issues, latestIssues...)
 
 	var versions steplibindex.Versions
-	haveVersions := v.readJSON(versionsPath, &versions)
+	versionsIssues, haveVersions := v.readJSON(versionsPath, &versions)
+	issues = append(issues, versionsIssues...)
 
 	if haveLatest && latest.StepID != id {
-		v.flag(latestPath, "step_id is %q, expected %q", latest.StepID, id)
+		issues = append(issues, violationf(latestPath, "step_id is %q, expected %q", latest.StepID, id))
 	}
 	if haveVersions && versions.StepID != id {
-		v.flag(versionsPath, "step_id is %q, expected %q", versions.StepID, id)
+		issues = append(issues, violationf(versionsPath, "step_id is %q, expected %q", versions.StepID, id))
 	}
 
 	// Cross-check pointers against the versions list.
@@ -157,14 +171,14 @@ func (v *validator) checkStep(id string) {
 	}
 	if haveLatest && haveVersions {
 		if !declaredVersions[latest.Latest] {
-			v.flag(latestPath, "latest %q is not in %s", latest.Latest, versionsPath)
+			issues = append(issues, violationf(latestPath, "latest %q is not in %s", latest.Latest, versionsPath))
 		}
 		for major, ver := range latest.LatestByMajor {
 			if !declaredVersions[ver] {
-				v.flag(latestPath, "latest_by_major[%q]=%q is not in versions.json", major, ver)
+				issues = append(issues, violationf(latestPath, "latest_by_major[%q]=%q is not in versions.json", major, ver))
 			}
 			if !strings.HasPrefix(ver, major+".") {
-				v.flag(latestPath, "latest_by_major[%q]=%q has a different major", major, ver)
+				issues = append(issues, violationf(latestPath, "latest_by_major[%q]=%q has a different major", major, ver))
 			}
 		}
 	}
@@ -172,59 +186,62 @@ func (v *validator) checkStep(id string) {
 	// Every declared version must have its step.json on disk.
 	if haveVersions {
 		for _, ver := range versions.Versions {
-			v.checkStepJSON(id, ver)
+			issues = append(issues, v.checkStepJSON(id, ver)...)
 		}
 	}
 
-	v.checkStepInfo(id)
+	issues = append(issues, v.checkStepInfo(id)...)
+	return issues
 }
 
-func (v *validator) checkStepJSON(id, version string) {
+func (v *validator) checkStepJSON(id, version string) []ValidationError {
 	p := steplibindex.StepJSONPathFS(id, version)
 	var step models.StepModel
-	if !v.readJSON(p, &step) {
-		return
+	if issues, ok := v.readJSON(p, &step); !ok {
+		return issues
 	}
 	if step.Source == nil {
-		v.flag(p, "missing source")
-		return
+		return []ValidationError{violationf(p, "missing source")}
 	}
+	var issues []ValidationError
 	if step.Source.Git == "" {
-		v.flag(p, "missing source.git")
+		issues = append(issues, violationf(p, "missing source.git"))
 	}
 	if step.Source.Commit == "" {
-		v.flag(p, "missing source.commit")
+		issues = append(issues, violationf(p, "missing source.commit"))
 	}
+	return issues
 }
 
-func (v *validator) checkStepInfo(id string) {
+func (v *validator) checkStepInfo(id string) []ValidationError {
 	p := steplibindex.StepInfoPathFS(id)
 	if _, err := fs.Stat(v.fs, p); err != nil {
 		// step-info.json is mandatory: the generator writes it for every step.
 		v.consume(p)
-		v.flag(p, "missing or unreadable: %s", err)
-		return
+		return []ValidationError{violationf(p, "missing or unreadable: %s", err)}
 	}
 	var info steplibindex.StepInfo
-	if !v.readJSON(p, &info) {
-		return
+	if issues, ok := v.readJSON(p, &info); !ok {
+		return issues
 	}
+	var issues []ValidationError
 	stepDir := steplibindex.StepDirFS(id)
 	for _, rel := range info.AssetURLs {
 		// asset_urls are step-dir-relative (e.g. "assets/icon.svg"); resolve each
 		// against the step's own dir, after rejecting anything that isn't a clean
 		// step-relative reference.
 		if problem := validateAssetURL(rel, stepDir); problem != "" {
-			v.flag(p, "asset_urls entry %q %s; must be step-relative", rel, problem)
+			issues = append(issues, violationf(p, "asset_urls entry %q %s; must be step-relative", rel, problem))
 			continue
 		}
 		assetPath := path.Join(stepDir, rel)
 		if _, err := fs.Stat(v.fs, assetPath); err != nil {
-			v.flag(p, "asset_urls entry %q points to %q which does not exist", rel, assetPath)
+			issues = append(issues, violationf(p, "asset_urls entry %q points to %q which does not exist", rel, assetPath))
 			continue
 		}
 		v.consume(assetPath)
 	}
+	return issues
 }
 
 // validateAssetURL reports why rel is not a valid step-relative asset reference,
@@ -247,37 +264,32 @@ func validateAssetURL(rel, stepDir string) string {
 	return ""
 }
 
-// checkNoStaleFiles walks v2/steps and v2/index once each and flags any file
-// the validator did not consume above. This catches "left-over files from a
-// previous generation" — e.g., a step that was later removed, or a stray
-// file from a generator bug.
-func (v *validator) checkNoStaleFiles() {
+// staleFileViolations walks v2/steps and v2/index once each and returns a
+// violation for every file the checks above did not consume — left-over files
+// from a previous generation (a removed step), or a stray file from a generator
+// bug. It reads the accumulated seen set, so it must run after all other checks.
+func (v *validator) staleFileViolations() []ValidationError {
 	roots := []string{
 		path.Join(steplibindex.VersionDir(), steplibindex.StepsRootFS),
 		path.Join(steplibindex.VersionDir(), steplibindex.IndexRootFS),
 	}
+	var issues []ValidationError
 	for _, root := range roots {
-		if walkErr := fs.WalkDir(v.fs, root, func(p string, d fs.DirEntry, err error) error {
-			if err != nil {
-				// A missing root (e.g. v2/steps when there are no steps) isn't a
-				// traversal failure — the empty steplib is already flagged via the
-				// step_ids check. Any other walk error is reported, not swallowed.
-				if !errors.Is(err, fs.ErrNotExist) {
-					v.flag(p, "walk failed: %s", err)
-				}
-				return nil
-			}
-			if d.IsDir() {
-				return nil
-			}
-			if !v.seen[p] {
-				v.flag(p, "unexpected file under %s/", root)
+		walkErr := fs.WalkDir(v.fs, root, func(p string, d fs.DirEntry, err error) error {
+			switch {
+			case err != nil:
+				// A missing or unreadable expected root is itself a violation.
+				issues = append(issues, violationf(p, "walk failed: %s", err))
+			case !d.IsDir() && !v.seen[p]:
+				issues = append(issues, violationf(p, "unexpected file under %s/", root))
 			}
 			return nil
-		}); walkErr != nil {
+		})
+		if walkErr != nil {
 			// The callback handles each entry's error and always returns nil, so
 			// this only fires if that ever changes — don't let it be dropped.
-			v.flag(root, "walk aborted: %s", walkErr)
+			issues = append(issues, violationf(root, "walk aborted: %s", walkErr))
 		}
 	}
+	return issues
 }

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -209,7 +209,9 @@ func (v *validator) checkStepInfo(id string) {
 	}
 	for _, rel := range info.AssetURLs {
 		if strings.HasPrefix(rel, "http://") || strings.HasPrefix(rel, "https://") {
-			// Absolute URL — out of scope for filesystem validation.
+			// asset_urls must be step-dir-relative; an absolute URL violates the
+			// spec, so flag it rather than skipping.
+			v.flag(p, "asset_urls entry %q is an absolute URL; must be step-relative", rel)
 			continue
 		}
 		// The step-info.json's asset_urls are written as step-dir-relative

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -35,9 +35,8 @@ func (e ValidationError) Error() string {
 // Intended uses:
 //   - Pre-deploy CI gate: run against a freshly generated tree before
 //     publishing to the V2 host. Fail the build on any violation.
-//   - Generator test smoke check: every generator test can pipe its output
-//     through Validate to catch cross-file consistency bugs that targeted
-//     per-file assertions would miss.
+//   - Generator test smoke check: run a generated tree through Validate to
+//     catch cross-file inconsistencies that per-file assertions would miss.
 //
 // A filesystem traversal failure (e.g. an unreadable directory) is itself
 // reported as a violation, so callers only need to check whether the returned

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -2,6 +2,7 @@ package indexgen
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"path"
@@ -38,14 +39,13 @@ func (e ValidationError) Error() string {
 //     through Validate to catch cross-file consistency bugs that targeted
 //     per-file assertions would miss.
 //
-// The returned error (the second return value) is reserved for situations
-// where the walk itself cannot proceed (e.g., the filesystem is unreadable).
-// "The tree is malformed" is reported via the ValidationError slice, not
-// the error.
-func Validate(inventoryFS fs.FS) ([]ValidationError, error) {
+// A filesystem traversal failure (e.g. an unreadable directory) is itself
+// reported as a violation, so callers only need to check whether the returned
+// slice is empty.
+func Validate(inventoryFS fs.FS) []ValidationError {
 	v := &validator{fs: inventoryFS, seen: map[string]bool{}, errs: nil}
 	v.run()
-	return v.errs, nil
+	return v.errs
 }
 
 type validator struct {
@@ -236,8 +236,17 @@ func (v *validator) checkNoStaleFiles() {
 	}
 	for _, root := range roots {
 		_ = fs.WalkDir(v.fs, root, func(p string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil // ignore walk errors (e.g., dir doesn't exist) and directories
+			if err != nil {
+				// A missing root (e.g. v2/steps for a steplib with no steps) is
+				// fine; any other traversal failure is reported as a violation
+				// rather than silently swallowed.
+				if !errors.Is(err, fs.ErrNotExist) {
+					v.flag(p, "walk failed: %s", err)
+				}
+				return nil
+			}
+			if d.IsDir() {
+				return nil
 			}
 			if !v.seen[p] {
 				v.flag(p, "unexpected file under %s/", root)

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -209,29 +209,42 @@ func (v *validator) checkStepInfo(id string) {
 	if !v.readJSON(p, &info) {
 		return
 	}
+	stepDir := steplibindex.StepDirFS(id)
 	for _, rel := range info.AssetURLs {
-		if strings.HasPrefix(rel, "http://") || strings.HasPrefix(rel, "https://") {
-			// asset_urls must be step-dir-relative; an absolute URL violates the
-			// spec, so flag it rather than skipping.
-			v.flag(p, "asset_urls entry %q is an absolute URL; must be step-relative", rel)
+		// asset_urls are step-dir-relative (e.g. "assets/icon.svg"); resolve each
+		// against the step's own dir, after rejecting anything that isn't a clean
+		// step-relative reference.
+		if problem := validateAssetURL(rel, stepDir); problem != "" {
+			v.flag(p, "asset_urls entry %q %s; must be step-relative", rel, problem)
 			continue
 		}
-		if path.IsAbs(rel) {
-			// An absolute path is not step-relative either; without this check
-			// path.Join below would absorb the leading slash and could resolve it
-			// to a real asset, silently masking the violation.
-			v.flag(p, "asset_urls entry %q is an absolute path; must be step-relative", rel)
-			continue
-		}
-		// The step-info.json's asset_urls are written as step-dir-relative
-		// (e.g. "assets/icon.svg"); resolve them against the step's own dir.
-		assetPath := path.Join(steplibindex.StepDirFS(id), rel)
+		assetPath := path.Join(stepDir, rel)
 		if _, err := fs.Stat(v.fs, assetPath); err != nil {
 			v.flag(p, "asset_urls entry %q points to %q which does not exist", rel, assetPath)
 			continue
 		}
 		v.consume(assetPath)
 	}
+}
+
+// validateAssetURL reports why rel is not a valid step-relative asset reference,
+// or "" if it is fine. The single rule — relative, scheme-less, and resolving
+// within stepDir — rejects absolute URLs, absolute paths, and parent-directory
+// traversal alike, so a bad entry can't slip through one gap while another is
+// guarded.
+func validateAssetURL(rel, stepDir string) string {
+	switch {
+	case strings.Contains(rel, "://"):
+		return "is an absolute URL"
+	case path.IsAbs(rel):
+		return "is an absolute path"
+	}
+	// path.Join cleans the result, collapsing any "../"; if it no longer sits
+	// under stepDir the entry escaped the step's own directory.
+	if resolved := path.Join(stepDir, rel); resolved != stepDir && !strings.HasPrefix(resolved, stepDir+"/") {
+		return "escapes the step directory"
+	}
+	return ""
 }
 
 // checkNoStaleFiles walks v2/steps and v2/index once each and flags any file

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -216,6 +216,13 @@ func (v *validator) checkStepInfo(id string) {
 			v.flag(p, "asset_urls entry %q is an absolute URL; must be step-relative", rel)
 			continue
 		}
+		if path.IsAbs(rel) {
+			// An absolute path is not step-relative either; without this check
+			// path.Join below would absorb the leading slash and could resolve it
+			// to a real asset, silently masking the violation.
+			v.flag(p, "asset_urls entry %q is an absolute path; must be step-relative", rel)
+			continue
+		}
 		// The step-info.json's asset_urls are written as step-dir-relative
 		// (e.g. "assets/icon.svg"); resolve them against the step's own dir.
 		assetPath := path.Join(steplibindex.StepDirFS(id), rel)

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -1,0 +1,246 @@
+package indexgen
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
+)
+
+// ValidationError is a single consistency violation found by Validate.
+// Path is the slash-separated path of the file the violation belongs to,
+// or "" for tree-level issues. Msg explains what's wrong.
+type ValidationError struct {
+	Path string
+	Msg  string
+}
+
+func (e ValidationError) Error() string {
+	if e.Path == "" {
+		return e.Msg
+	}
+	return fmt.Sprintf("%s: %s", e.Path, e.Msg)
+}
+
+// Validate walks the V2 inventory tree rooted at inventoryFS and returns the
+// list of consistency violations. An empty slice means the tree is internally
+// consistent.
+//
+// Intended uses:
+//   - Pre-deploy CI gate: run against a freshly generated tree before
+//     publishing to the V2 host. Fail the build on any violation.
+//   - Generator test smoke check: every generator test can pipe its output
+//     through Validate to catch cross-file consistency bugs that targeted
+//     per-file assertions would miss.
+//
+// The returned error (the second return value) is reserved for situations
+// where the walk itself cannot proceed (e.g., the filesystem is unreadable).
+// "The tree is malformed" is reported via the ValidationError slice, not
+// the error.
+func Validate(inventoryFS fs.FS) ([]ValidationError, error) {
+	v := &validator{fs: inventoryFS, seen: map[string]bool{}, errs: nil}
+	v.run()
+	return v.errs, nil
+}
+
+type validator struct {
+	fs   fs.FS
+	seen map[string]bool // paths the validator has consumed; remainder is stale
+	errs []ValidationError
+}
+
+func (v *validator) flag(p, msg string, args ...any) {
+	v.errs = append(v.errs, ValidationError{Path: p, Msg: fmt.Sprintf(msg, args...)})
+}
+
+func (v *validator) consume(p string) { v.seen[p] = true }
+
+func (v *validator) run() {
+	var meta steplibindex.Meta
+	if v.readJSON(steplibindex.MetaPathFS(), &meta) {
+		v.checkMeta(meta)
+	}
+
+	var stepIDs steplibindex.StepIDs
+	haveIDs := v.readJSON(steplibindex.StepIDsPathFS(), &stepIDs)
+
+	if haveIDs {
+		v.checkStepIDsSorted(stepIDs)
+		for _, id := range stepIDs.StepIDs {
+			v.checkStep(id)
+		}
+	}
+
+	v.checkNoStaleFiles()
+
+	// Sort violations by (Path, Msg) so the error output is deterministic
+	// across runs. Without this, map-iteration order leaks into the
+	// validator's output and breaks any consumer that diffs error logs
+	// (golden files, CI dashboards, etc.).
+	sort.Slice(v.errs, func(i, j int) bool {
+		if v.errs[i].Path != v.errs[j].Path {
+			return v.errs[i].Path < v.errs[j].Path
+		}
+		return v.errs[i].Msg < v.errs[j].Msg
+	})
+}
+
+// readJSON marks the file as consumed and parses it into `into`. Returns
+// false (and logs a violation) on missing/unreadable/invalid JSON.
+func (v *validator) readJSON(p string, into any) bool {
+	v.consume(p)
+	bytes, err := fs.ReadFile(v.fs, p)
+	if err != nil {
+		v.flag(p, "missing or unreadable: %s", err)
+		return false
+	}
+	if err := json.Unmarshal(bytes, into); err != nil {
+		v.flag(p, "invalid JSON: %s", err)
+		return false
+	}
+	return true
+}
+
+func (v *validator) checkMeta(m steplibindex.Meta) {
+	if m.FormatVersion != steplibindex.FormatVersion {
+		v.flag(steplibindex.MetaPathFS(), "format_version is %d, expected %d", m.FormatVersion, steplibindex.FormatVersion)
+	}
+	if m.UpdatedAt.IsZero() {
+		v.flag(steplibindex.MetaPathFS(), "updated_at is zero")
+	}
+}
+
+func (v *validator) checkStepIDsSorted(ids steplibindex.StepIDs) {
+	if !sort.StringsAreSorted(ids.StepIDs) {
+		v.flag(steplibindex.StepIDsPathFS(), "step_ids is not sorted lexicographically")
+	}
+	// Duplicate detection.
+	seen := make(map[string]bool, len(ids.StepIDs))
+	for _, id := range ids.StepIDs {
+		if seen[id] {
+			v.flag(steplibindex.StepIDsPathFS(), "duplicate step id %q", id)
+		}
+		seen[id] = true
+	}
+}
+
+func (v *validator) checkStep(id string) {
+	latestPath := steplibindex.LatestPointerPathFS(id)
+	versionsPath := steplibindex.VersionsPathFS(id)
+
+	var latest steplibindex.LatestPointer
+	haveLatest := v.readJSON(latestPath, &latest)
+
+	var versions steplibindex.Versions
+	haveVersions := v.readJSON(versionsPath, &versions)
+
+	if haveLatest && latest.StepID != id {
+		v.flag(latestPath, "step_id is %q, expected %q", latest.StepID, id)
+	}
+	if haveVersions && versions.StepID != id {
+		v.flag(versionsPath, "step_id is %q, expected %q", versions.StepID, id)
+	}
+
+	// Cross-check pointers against the versions list.
+	declaredVersions := map[string]bool{}
+	if haveVersions {
+		for _, ver := range versions.Versions {
+			declaredVersions[ver] = true
+		}
+	}
+	if haveLatest && haveVersions {
+		if !declaredVersions[latest.Latest] {
+			v.flag(latestPath, "latest %q is not in %s", latest.Latest, versionsPath)
+		}
+		for major, ver := range latest.LatestByMajor {
+			if !declaredVersions[ver] {
+				v.flag(latestPath, "latest_by_major[%q]=%q is not in versions.json", major, ver)
+			}
+			if !strings.HasPrefix(ver, major+".") {
+				v.flag(latestPath, "latest_by_major[%q]=%q has a different major", major, ver)
+			}
+		}
+	}
+
+	// Every declared version must have its step.json on disk.
+	if haveVersions {
+		for _, ver := range versions.Versions {
+			v.checkStepJSON(id, ver)
+		}
+	}
+
+	v.checkStepInfo(id)
+}
+
+func (v *validator) checkStepJSON(id, version string) {
+	p := steplibindex.StepJSONPathFS(id, version)
+	var step models.StepModel
+	if !v.readJSON(p, &step) {
+		return
+	}
+	if step.Source == nil {
+		v.flag(p, "missing source")
+		return
+	}
+	if step.Source.Git == "" {
+		v.flag(p, "missing source.git")
+	}
+	if step.Source.Commit == "" {
+		v.flag(p, "missing source.commit")
+	}
+}
+
+func (v *validator) checkStepInfo(id string) {
+	p := steplibindex.StepInfoPathFS(id)
+	if _, err := fs.Stat(v.fs, p); err != nil {
+		// step-info.json is mandatory: the generator writes it for every step.
+		v.consume(p)
+		v.flag(p, "missing or unreadable: %s", err)
+		return
+	}
+	var info steplibindex.StepInfo
+	if !v.readJSON(p, &info) {
+		return
+	}
+	for _, rel := range info.AssetURLs {
+		if strings.HasPrefix(rel, "http://") || strings.HasPrefix(rel, "https://") {
+			// Absolute URL — out of scope for filesystem validation.
+			continue
+		}
+		// The step-info.json's asset_urls are written as step-dir-relative
+		// (e.g. "assets/icon.svg"); resolve them against the step's own dir.
+		assetPath := path.Join(steplibindex.StepDirFS(id), rel)
+		if _, err := fs.Stat(v.fs, assetPath); err != nil {
+			v.flag(p, "asset_urls entry %q points to %q which does not exist", rel, assetPath)
+			continue
+		}
+		v.consume(assetPath)
+	}
+}
+
+// checkNoStaleFiles walks v2/steps and v2/index once each and flags any file
+// the validator did not consume above. This catches "left-over files from a
+// previous generation" — e.g., a step that was later removed, or a stray
+// file from a generator bug.
+func (v *validator) checkNoStaleFiles() {
+	roots := []string{
+		path.Join(steplibindex.VersionDir(), steplibindex.StepsRootFS),
+		path.Join(steplibindex.VersionDir(), steplibindex.IndexRootFS),
+	}
+	for _, root := range roots {
+		_ = fs.WalkDir(v.fs, root, func(p string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil // ignore walk errors (e.g., dir doesn't exist) and directories
+			}
+			if !v.seen[p] {
+				v.flag(p, "unexpected file under %s/", root)
+			}
+			return nil
+		})
+	}
+}

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -1,6 +1,7 @@
 package indexgen
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -76,18 +77,18 @@ func (v *validator) collect() []ValidationError {
 	var issues []ValidationError
 
 	var meta steplibindex.Meta
-	metaIssues, ok := v.readJSON(steplibindex.MetaPathFS(), &meta)
+	metaIssues, ok := v.readJSON(steplibindex.MetaPath().FS(), &meta)
 	issues = append(issues, metaIssues...)
 	if ok {
 		issues = append(issues, v.checkMeta(meta)...)
 	}
 
 	var stepIDs steplibindex.StepIDs
-	stepIDsIssues, haveIDs := v.readJSON(steplibindex.StepIDsPathFS(), &stepIDs)
+	stepIDsIssues, haveIDs := v.readJSON(steplibindex.StepIDsPath().FS(), &stepIDs)
 	issues = append(issues, stepIDsIssues...)
 	if haveIDs {
 		if len(stepIDs.StepIDs) == 0 {
-			issues = append(issues, violationf(steplibindex.StepIDsPathFS(), "step_ids is empty: a steplib must contain at least one step"))
+			issues = append(issues, violationf(steplibindex.StepIDsPath().FS(), "step_ids is empty: a steplib must contain at least one step"))
 		}
 		issues = append(issues, v.checkStepIDsSorted(stepIDs)...)
 		for _, id := range stepIDs.StepIDs {
@@ -117,10 +118,10 @@ func (v *validator) readJSON(p string, into any) (issues []ValidationError, ok b
 func (v *validator) checkMeta(m steplibindex.Meta) []ValidationError {
 	var issues []ValidationError
 	if m.FormatVersion != steplibindex.FormatVersion {
-		issues = append(issues, violationf(steplibindex.MetaPathFS(), "format_version is %d, expected %d", m.FormatVersion, steplibindex.FormatVersion))
+		issues = append(issues, violationf(steplibindex.MetaPath().FS(), "format_version is %d, expected %d", m.FormatVersion, steplibindex.FormatVersion))
 	}
 	if m.UpdatedAt.IsZero() {
-		issues = append(issues, violationf(steplibindex.MetaPathFS(), "updated_at is zero"))
+		issues = append(issues, violationf(steplibindex.MetaPath().FS(), "updated_at is zero"))
 	}
 	return issues
 }
@@ -128,13 +129,13 @@ func (v *validator) checkMeta(m steplibindex.Meta) []ValidationError {
 func (v *validator) checkStepIDsSorted(ids steplibindex.StepIDs) []ValidationError {
 	var issues []ValidationError
 	if !sort.StringsAreSorted(ids.StepIDs) {
-		issues = append(issues, violationf(steplibindex.StepIDsPathFS(), "step_ids is not sorted lexicographically"))
+		issues = append(issues, violationf(steplibindex.StepIDsPath().FS(), "step_ids is not sorted lexicographically"))
 	}
 	// Duplicate detection.
 	seen := make(map[string]bool, len(ids.StepIDs))
 	for _, id := range ids.StepIDs {
 		if seen[id] {
-			issues = append(issues, violationf(steplibindex.StepIDsPathFS(), "duplicate step id %q", id))
+			issues = append(issues, violationf(steplibindex.StepIDsPath().FS(), "duplicate step id %q", id))
 		}
 		seen[id] = true
 	}
@@ -142,8 +143,17 @@ func (v *validator) checkStepIDsSorted(ids steplibindex.StepIDs) []ValidationErr
 }
 
 func (v *validator) checkStep(id string) []ValidationError {
-	latestPath := steplibindex.LatestPointerPathFS(id)
-	versionsPath := steplibindex.VersionsPathFS(id)
+	// Build the step's paths once; a non-nil error means the id itself is not a
+	// safe path segment, which is a violation of step_ids.json.
+	latestP, errLatest := steplibindex.LatestPointerPath(id)
+	versionsP, errVersions := steplibindex.VersionsPath(id)
+	infoP, errInfo := steplibindex.StepInfoPath(id)
+	stepDir, errDir := steplibindex.StepDirFS(id)
+	if err := cmp.Or(errLatest, errVersions, errInfo, errDir); err != nil {
+		return []ValidationError{violationf(steplibindex.StepIDsPath().FS(), "step id %q is invalid: %s", id, err)}
+	}
+	latestPath := latestP.FS()
+	versionsPath := versionsP.FS()
 
 	var issues []ValidationError
 
@@ -186,16 +196,23 @@ func (v *validator) checkStep(id string) []ValidationError {
 	// Every declared version must have its step.json on disk.
 	if haveVersions {
 		for _, ver := range versions.Versions {
-			issues = append(issues, v.checkStepJSON(id, ver)...)
+			issues = append(issues, v.checkStepJSON(id, ver, versionsPath)...)
 		}
 	}
 
-	issues = append(issues, v.checkStepInfo(id)...)
+	issues = append(issues, v.checkStepInfo(infoP.FS(), stepDir)...)
 	return issues
 }
 
-func (v *validator) checkStepJSON(id, version string) []ValidationError {
-	p := steplibindex.StepJSONPathFS(id, version)
+// checkStepJSON validates v2/steps/<id>/<version>/step.json. versionsPath is the
+// step's versions.json, where an invalid version string is reported (the version
+// comes from there).
+func (v *validator) checkStepJSON(id, version, versionsPath string) []ValidationError {
+	stepJSON, err := steplibindex.StepJSONPath(id, version)
+	if err != nil {
+		return []ValidationError{violationf(versionsPath, "version %q is invalid: %s", version, err)}
+	}
+	p := stepJSON.FS()
 	var step models.StepModel
 	if issues, ok := v.readJSON(p, &step); !ok {
 		return issues
@@ -213,30 +230,30 @@ func (v *validator) checkStepJSON(id, version string) []ValidationError {
 	return issues
 }
 
-func (v *validator) checkStepInfo(id string) []ValidationError {
-	p := steplibindex.StepInfoPathFS(id)
-	if _, err := fs.Stat(v.fs, p); err != nil {
+// checkStepInfo validates the step's step-info.json (at infoPath) and that each
+// asset_urls entry is a step-relative path resolving to a real file under stepDir.
+func (v *validator) checkStepInfo(infoPath, stepDir string) []ValidationError {
+	if _, err := fs.Stat(v.fs, infoPath); err != nil {
 		// step-info.json is mandatory: the generator writes it for every step.
-		v.consume(p)
-		return []ValidationError{violationf(p, "missing or unreadable: %s", err)}
+		v.consume(infoPath)
+		return []ValidationError{violationf(infoPath, "missing or unreadable: %s", err)}
 	}
 	var info steplibindex.StepInfo
-	if issues, ok := v.readJSON(p, &info); !ok {
+	if issues, ok := v.readJSON(infoPath, &info); !ok {
 		return issues
 	}
 	var issues []ValidationError
-	stepDir := steplibindex.StepDirFS(id)
 	for _, rel := range info.AssetURLs {
 		// asset_urls are step-dir-relative (e.g. "assets/icon.svg"); resolve each
 		// against the step's own dir, after rejecting anything that isn't a clean
 		// step-relative reference.
 		if problem := validateAssetURL(rel, stepDir); problem != "" {
-			issues = append(issues, violationf(p, "asset_urls entry %q %s; must be step-relative", rel, problem))
+			issues = append(issues, violationf(infoPath, "asset_urls entry %q %s; must be step-relative", rel, problem))
 			continue
 		}
 		assetPath := path.Join(stepDir, rel)
 		if _, err := fs.Stat(v.fs, assetPath); err != nil {
-			issues = append(issues, violationf(p, "asset_urls entry %q points to %q which does not exist", rel, assetPath))
+			issues = append(issues, violationf(infoPath, "asset_urls entry %q points to %q which does not exist", rel, assetPath))
 			continue
 		}
 		v.consume(assetPath)

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -244,41 +244,33 @@ func (v *validator) checkStepInfo(infoPath, stepDir string) []ValidationError {
 	}
 	var issues []ValidationError
 	for _, rel := range info.AssetURLs {
-		// asset_urls are step-dir-relative (e.g. "assets/icon.svg"); resolve each
-		// against the step's own dir, after rejecting anything that isn't a clean
-		// step-relative reference.
-		if problem := validateAssetURL(rel, stepDir); problem != "" {
-			issues = append(issues, violationf(infoPath, "asset_urls entry %q %s; must be step-relative", rel, problem))
-			continue
-		}
-		assetPath := path.Join(stepDir, rel)
-		if _, err := fs.Stat(v.fs, assetPath); err != nil {
-			issues = append(issues, violationf(infoPath, "asset_urls entry %q points to %q which does not exist", rel, assetPath))
-			continue
-		}
-		v.consume(assetPath)
+		issues = append(issues, v.checkAssetURL(infoPath, stepDir, rel)...)
 	}
 	return issues
 }
 
-// validateAssetURL reports why rel is not a valid step-relative asset reference,
-// or "" if it is fine. The single rule — relative, scheme-less, and resolving
-// within stepDir — rejects absolute URLs, absolute paths, and parent-directory
-// traversal alike, so a bad entry can't slip through one gap while another is
-// guarded.
-func validateAssetURL(rel, stepDir string) string {
+// checkAssetURL validates one asset_urls entry (attributed to infoPath): it must
+// be a clean step-relative reference — no absolute URL or path, no parent-dir
+// traversal — that resolves to a real file under stepDir. On success it marks
+// the resolved asset consumed so the stale-file sweep won't flag it.
+func (v *validator) checkAssetURL(infoPath, stepDir, rel string) []ValidationError {
 	switch {
 	case strings.Contains(rel, "://"):
-		return "is an absolute URL"
+		return []ValidationError{violationf(infoPath, "asset_urls entry %q is an absolute URL; must be step-relative", rel)}
 	case path.IsAbs(rel):
-		return "is an absolute path"
+		return []ValidationError{violationf(infoPath, "asset_urls entry %q is an absolute path; must be step-relative", rel)}
 	}
 	// path.Join cleans the result, collapsing any "../"; if it no longer sits
 	// under stepDir the entry escaped the step's own directory.
-	if resolved := path.Join(stepDir, rel); resolved != stepDir && !strings.HasPrefix(resolved, stepDir+"/") {
-		return "escapes the step directory"
+	resolved := path.Join(stepDir, rel)
+	if resolved != stepDir && !strings.HasPrefix(resolved, stepDir+"/") {
+		return []ValidationError{violationf(infoPath, "asset_urls entry %q escapes the step directory; must be step-relative", rel)}
 	}
-	return ""
+	if _, err := fs.Stat(v.fs, resolved); err != nil {
+		return []ValidationError{violationf(infoPath, "asset_urls entry %q points to %q which does not exist", rel, resolved)}
+	}
+	v.consume(resolved)
+	return nil
 }
 
 // staleFileViolations walks v2/steps and v2/index once each and returns a

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -257,7 +257,7 @@ func (v *validator) checkNoStaleFiles() {
 		path.Join(steplibindex.VersionDir(), steplibindex.IndexRootFS),
 	}
 	for _, root := range roots {
-		_ = fs.WalkDir(v.fs, root, func(p string, d fs.DirEntry, err error) error {
+		if walkErr := fs.WalkDir(v.fs, root, func(p string, d fs.DirEntry, err error) error {
 			if err != nil {
 				// A missing root (e.g. v2/steps when there are no steps) isn't a
 				// traversal failure — the empty steplib is already flagged via the
@@ -274,6 +274,10 @@ func (v *validator) checkNoStaleFiles() {
 				v.flag(p, "unexpected file under %s/", root)
 			}
 			return nil
-		})
+		}); walkErr != nil {
+			// The callback handles each entry's error and always returns nil, so
+			// this only fires if that ever changes — don't let it be dropped.
+			v.flag(root, "walk aborted: %s", walkErr)
+		}
 	}
 }

--- a/steplibrary/indexgen/validate.go
+++ b/steplibrary/indexgen/validate.go
@@ -70,6 +70,9 @@ func (v *validator) run() {
 	haveIDs := v.readJSON(steplibindex.StepIDsPathFS(), &stepIDs)
 
 	if haveIDs {
+		if len(stepIDs.StepIDs) == 0 {
+			v.flag(steplibindex.StepIDsPathFS(), "step_ids is empty: a steplib must contain at least one step")
+		}
 		v.checkStepIDsSorted(stepIDs)
 		for _, id := range stepIDs.StepIDs {
 			v.checkStep(id)
@@ -237,9 +240,9 @@ func (v *validator) checkNoStaleFiles() {
 	for _, root := range roots {
 		_ = fs.WalkDir(v.fs, root, func(p string, d fs.DirEntry, err error) error {
 			if err != nil {
-				// A missing root (e.g. v2/steps for a steplib with no steps) is
-				// fine; any other traversal failure is reported as a violation
-				// rather than silently swallowed.
+				// A missing root (e.g. v2/steps when there are no steps) isn't a
+				// traversal failure — the empty steplib is already flagged via the
+				// step_ids check. Any other walk error is reported, not swallowed.
 				if !errors.Is(err, fs.ErrNotExist) {
 					v.flag(p, "walk failed: %s", err)
 				}

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -1,7 +1,10 @@
 package indexgen
 
 import (
+	"errors"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -50,8 +53,7 @@ func flagMatching(errs []ValidationError, pathContains, msgContains string) *Val
 func TestValidate_passesOnGeneratedOutput(t *testing.T) {
 	root := runGenerateInventoryRoot(t)
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err, "Validate")
+	errs := Validate(os.DirFS(root))
 	assert.Empty(t, errs, "generator output should validate cleanly; got %+v", errs)
 }
 
@@ -59,8 +61,7 @@ func TestValidate_flagsMissingMeta(t *testing.T) {
 	root := runGenerateInventoryRoot(t)
 	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.MetaPathFS())))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "meta.json", "missing"), "missing meta.json must be flagged; got %+v", errs)
 }
 
@@ -69,8 +70,7 @@ func TestValidate_flagsBadFormatVersion(t *testing.T) {
 	bad := []byte(`{"format_version": 99, "updated_at": "2026-05-15T12:00:00Z"}`)
 	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.MetaPathFS()), bad, 0o644))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "meta.json", "format_version"), "bad format_version must be flagged; got %+v", errs)
 }
 
@@ -81,8 +81,7 @@ func TestValidate_flagsUnsortedStepIDs(t *testing.T) {
 	bad := []byte(`{"step_ids": ["hello-step", "bash-step", "deprecated-step", "multi-platform-step"]}`)
 	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.StepIDsPathFS()), bad, 0o644))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "step_ids.json", "not sorted"), "unsorted step_ids must be flagged; got %+v", errs)
 }
 
@@ -91,8 +90,7 @@ func TestValidate_flagsLatestPointingAtMissingVersion(t *testing.T) {
 	bad := []byte(`{"step_id": "hello-step", "latest": "99.99.99", "latest_by_major": {"99": "99.99.99"}}`)
 	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.LatestPointerPathFS("hello-step")), bad, 0o644))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "hello-step/latest.json", "not in"),
 		"latest pointing at missing version must be flagged; got %+v", errs)
 }
@@ -103,8 +101,7 @@ func TestValidate_flagsLatestByMajorWrongMajor(t *testing.T) {
 	bad := []byte(`{"step_id": "hello-step", "latest": "2.0.0", "latest_by_major": {"1": "2.0.0", "2": "2.0.0"}}`)
 	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.LatestPointerPathFS("hello-step")), bad, 0o644))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "hello-step/latest.json", "different major"),
 		"latest_by_major pointing at wrong major must be flagged; got %+v", errs)
 }
@@ -115,8 +112,7 @@ func TestValidate_flagsLatestStepIDMismatch(t *testing.T) {
 	bad := []byte(`{"step_id": "wrong-id", "latest": "2.0.0", "latest_by_major": {"1": "1.1.0", "2": "2.0.0"}}`)
 	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.LatestPointerPathFS("hello-step")), bad, 0o644))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "hello-step/latest.json", "expected"),
 		"latest.json step_id mismatch must be flagged; got %+v", errs)
 }
@@ -126,8 +122,7 @@ func TestValidate_flagsMissingStepJSON(t *testing.T) {
 	// Delete hello-step's 1.0.0/step.json while leaving the version in versions.json.
 	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.StepJSONPathFS("hello-step", "1.0.0"))))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "hello-step/1.0.0/step.json", "missing"),
 		"missing step.json for a declared version must be flagged; got %+v", errs)
 }
@@ -137,8 +132,7 @@ func TestValidate_flagsMissingStepInfo(t *testing.T) {
 	// step-info.json is mandatory: deleting it must be flagged (not skipped).
 	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.StepInfoPathFS("hello-step"))))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "hello-step/step-info.json", "missing"),
 		"missing mandatory step-info.json must be flagged; got %+v", errs)
 }
@@ -148,8 +142,7 @@ func TestValidate_flagsStepInfoAssetMissing(t *testing.T) {
 	// Delete the asset hello-step's step-info.json references.
 	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.StepAssetPathFS("hello-step", "icon.svg"))))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "hello-step/step-info.json", "does not exist"),
 		"missing asset referenced by step-info.json must be flagged; got %+v", errs)
 }
@@ -161,8 +154,7 @@ func TestValidate_flagsAbsoluteAssetURL(t *testing.T) {
 	bad := []byte(`{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","https://cdn.example/icon.svg"]}`)
 	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.StepInfoPathFS("hello-step")), bad, 0o644))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "hello-step/step-info.json", "absolute URL"),
 		"absolute asset_urls entry must be flagged; got %+v", errs)
 }
@@ -173,8 +165,7 @@ func TestValidate_flagsStaleIndexFile(t *testing.T) {
 	stalePath := filepath.Join(root, steplibindex.VersionDir(), steplibindex.IndexRootFS, "stale.json")
 	require.NoError(t, os.WriteFile(stalePath, []byte("{}"), 0o644))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "stale.json", "unexpected"),
 		"unexpected file under index/ must be flagged; got %+v", errs)
 }
@@ -186,18 +177,42 @@ func TestValidate_flagsStaleStepDir(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(stalePath), 0o755))
 	require.NoError(t, os.WriteFile(stalePath, []byte(`{"title":"ghost"}`), 0o644))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "ghost-step", "unexpected"),
 		"step dir not in step_ids.json must be flagged; got %+v", errs)
+}
+
+// failingReadDirFS wraps an fs.FS and returns a non-ErrNotExist error when
+// ReadDir is called on failDir — to exercise the stale-file walk's error path.
+type failingReadDirFS struct {
+	fs.FS
+	failDir string
+}
+
+func (f failingReadDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if name == f.failDir {
+		return nil, errors.New("simulated readdir failure")
+	}
+	return fs.ReadDir(f.FS, name)
+}
+
+func TestValidate_flagsWalkFailure(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// A real (non-ErrNotExist) traversal failure must be reported as a
+	// violation, not silently swallowed.
+	failDir := path.Join(steplibindex.VersionDir(), steplibindex.StepsRootFS)
+	fsys := failingReadDirFS{FS: os.DirFS(root), failDir: failDir}
+
+	errs := Validate(fsys)
+	assert.NotNil(t, flagMatching(errs, failDir, "walk failed"),
+		"a walk failure must be reported as a violation; got %+v", errs)
 }
 
 func TestValidate_flagsInvalidJSON(t *testing.T) {
 	root := runGenerateInventoryRoot(t)
 	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.MetaPathFS()), []byte("not json"), 0o644))
 
-	errs, err := Validate(os.DirFS(root))
-	require.NoError(t, err)
+	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "meta.json", "invalid JSON"),
 		"invalid JSON must be flagged; got %+v", errs)
 }

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -1,10 +1,7 @@
 package indexgen
 
 import (
-	"errors"
-	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -190,32 +187,6 @@ func TestValidate_flagsStaleStepDir(t *testing.T) {
 	errs := Validate(os.DirFS(root))
 	assert.NotNil(t, flagMatching(errs, "ghost-step", "unexpected"),
 		"step dir not in step_ids.json must be flagged; got %+v", errs)
-}
-
-// failingReadDirFS wraps an fs.FS and returns a non-ErrNotExist error when
-// ReadDir is called on failDir — to exercise the stale-file walk's error path.
-type failingReadDirFS struct {
-	fs.FS
-	failDir string
-}
-
-func (f failingReadDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	if name == f.failDir {
-		return nil, errors.New("simulated readdir failure")
-	}
-	return fs.ReadDir(f.FS, name)
-}
-
-func TestValidate_flagsWalkFailure(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// A real (non-ErrNotExist) traversal failure must be reported as a
-	// violation, not silently swallowed.
-	failDir := path.Join(steplibindex.VersionDir(), steplibindex.StepsRootFS)
-	fsys := failingReadDirFS{FS: os.DirFS(root), failDir: failDir}
-
-	errs := Validate(fsys)
-	assert.NotNil(t, flagMatching(errs, failDir, "walk failed"),
-		"a walk failure must be reported as a violation; got %+v", errs)
 }
 
 func TestValidate_flagsInvalidJSON(t *testing.T) {

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -24,7 +24,7 @@ func flagMatching(errs []ValidationError, pathContains, msgContains string) *Val
 	return nil
 }
 
-func writeFile(t *testing.T, root, relPath, content string) {
+func seedFile(t *testing.T, root, relPath, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(filepath.Join(root, relPath), []byte(content), 0o644))
 }
@@ -55,42 +55,42 @@ func TestValidate(t *testing.T) {
 			wantPath: "meta.json", wantMsg: "missing",
 		},
 		"meta.json invalid JSON": {
-			mutate:   func(t *testing.T, root string) { writeFile(t, root, steplibindex.MetaPathFS(), "not json") },
+			mutate:   func(t *testing.T, root string) { seedFile(t, root, steplibindex.MetaPathFS(), "not json") },
 			wantPath: "meta.json", wantMsg: "invalid JSON",
 		},
 		"meta.json wrong format_version": {
 			mutate: func(t *testing.T, root string) {
-				writeFile(t, root, steplibindex.MetaPathFS(), `{"format_version": 99, "updated_at": "2026-05-15T12:00:00Z"}`)
+				seedFile(t, root, steplibindex.MetaPathFS(), `{"format_version": 99, "updated_at": "2026-05-15T12:00:00Z"}`)
 			},
 			wantPath: "meta.json", wantMsg: "format_version",
 		},
 		"empty step_ids": {
-			mutate:   func(t *testing.T, root string) { writeFile(t, root, steplibindex.StepIDsPathFS(), `{"step_ids":[]}`) },
+			mutate:   func(t *testing.T, root string) { seedFile(t, root, steplibindex.StepIDsPathFS(), `{"step_ids":[]}`) },
 			wantPath: "step_ids.json", wantMsg: "empty",
 		},
 		"unsorted step_ids": {
 			mutate: func(t *testing.T, root string) {
 				// Still references only real steps so only the sort check fires.
-				writeFile(t, root, steplibindex.StepIDsPathFS(), `{"step_ids": ["hello-step", "bash-step", "deprecated-step", "multi-platform-step"]}`)
+				seedFile(t, root, steplibindex.StepIDsPathFS(), `{"step_ids": ["hello-step", "bash-step", "deprecated-step", "multi-platform-step"]}`)
 			},
 			wantPath: "step_ids.json", wantMsg: "not sorted",
 		},
 		"latest points at a missing version": {
 			mutate: func(t *testing.T, root string) {
-				writeFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "hello-step", "latest": "99.99.99", "latest_by_major": {"99": "99.99.99"}}`)
+				seedFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "hello-step", "latest": "99.99.99", "latest_by_major": {"99": "99.99.99"}}`)
 			},
 			wantPath: "hello-step/latest.json", wantMsg: "not in",
 		},
 		"latest_by_major points at a different major": {
 			mutate: func(t *testing.T, root string) {
 				// hello-step has 1.0.0, 1.1.0, 2.0.0; point major "1" at 2.0.0.
-				writeFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "hello-step", "latest": "2.0.0", "latest_by_major": {"1": "2.0.0", "2": "2.0.0"}}`)
+				seedFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "hello-step", "latest": "2.0.0", "latest_by_major": {"1": "2.0.0", "2": "2.0.0"}}`)
 			},
 			wantPath: "hello-step/latest.json", wantMsg: "different major",
 		},
 		"latest.json step_id mismatch": {
 			mutate: func(t *testing.T, root string) {
-				writeFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "wrong-id", "latest": "2.0.0", "latest_by_major": {"1": "1.1.0", "2": "2.0.0"}}`)
+				seedFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "wrong-id", "latest": "2.0.0", "latest_by_major": {"1": "1.1.0", "2": "2.0.0"}}`)
 			},
 			wantPath: "hello-step/latest.json", wantMsg: "expected",
 		},
@@ -113,7 +113,7 @@ func TestValidate(t *testing.T) {
 		"absolute asset_urls entry": {
 			mutate: func(t *testing.T, root string) {
 				// Keep the real relative asset so only the absolute-URL check fires.
-				writeFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","https://cdn.example/icon.svg"]}`)
+				seedFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","https://cdn.example/icon.svg"]}`)
 			},
 			wantPath: "hello-step/step-info.json", wantMsg: "absolute URL",
 		},
@@ -122,7 +122,7 @@ func TestValidate(t *testing.T) {
 				// "/assets/icon.svg" mirrors the real relative asset, so it would
 				// resolve and pass if absolute paths weren't rejected outright. Keep
 				// the real relative entry so only the absolute-path check fires.
-				writeFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","/assets/icon.svg"]}`)
+				seedFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","/assets/icon.svg"]}`)
 			},
 			wantPath: "hello-step/step-info.json", wantMsg: "absolute path",
 		},
@@ -131,19 +131,19 @@ func TestValidate(t *testing.T) {
 				// "../../bash-step/..." resolves to a sibling step's real file, so it
 				// would pass if only absolute paths were rejected. Keep the real
 				// relative asset so only the escape check fires.
-				writeFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","assets/../../bash-step/step-info.json"]}`)
+				seedFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","assets/../../bash-step/step-info.json"]}`)
 			},
 			wantPath: "hello-step/step-info.json", wantMsg: "escapes",
 		},
 		"asset on disk missing from step-info.json": {
 			mutate: func(t *testing.T, root string) {
-				writeFile(t, root, steplibindex.StepAssetPathFS("hello-step", "extra.svg"), "<svg/>")
+				seedFile(t, root, steplibindex.StepAssetPathFS("hello-step", "extra.svg"), "<svg/>")
 			},
 			wantPath: "hello-step/assets/extra.svg", wantMsg: "unexpected",
 		},
 		"stale file under index/": {
 			mutate: func(t *testing.T, root string) {
-				writeFile(t, root, filepath.Join(steplibindex.VersionDir(), steplibindex.IndexRootFS, "stale.json"), "{}")
+				seedFile(t, root, filepath.Join(steplibindex.VersionDir(), steplibindex.IndexRootFS, "stale.json"), "{}")
 			},
 			wantPath: "stale.json", wantMsg: "unexpected",
 		},

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -135,6 +135,15 @@ func TestValidate(t *testing.T) {
 			},
 			wantPath: "hello-step/step-info.json", wantMsg: "absolute URL",
 		},
+		"absolute asset_urls path": {
+			mutate: func(t *testing.T, root string) {
+				// "/assets/icon.svg" mirrors the real relative asset, so it would
+				// resolve and pass if absolute paths weren't rejected outright. Keep
+				// the real relative entry so only the absolute-path check fires.
+				writeFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","/assets/icon.svg"]}`)
+			},
+			wantPath: "hello-step/step-info.json", wantMsg: "absolute path",
+		},
 		"asset on disk missing from step-info.json": {
 			mutate: func(t *testing.T, root string) {
 				writeFile(t, root, steplibindex.StepAssetPathFS("hello-step", "extra.svg"), "<svg/>")

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -189,6 +189,18 @@ func TestValidate_flagsStaleStepDir(t *testing.T) {
 		"step dir not in step_ids.json must be flagged; got %+v", errs)
 }
 
+func TestValidate_flagsUnreferencedAsset(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// An asset present on disk but not listed in step-info.json's asset_urls is
+	// not consumed by checkStepInfo, so the stale-file walk must flag it.
+	extra := filepath.Join(root, steplibindex.StepAssetPathFS("hello-step", "extra.svg"))
+	require.NoError(t, os.WriteFile(extra, []byte("<svg/>"), 0o644))
+
+	errs := Validate(os.DirFS(root))
+	assert.NotNil(t, flagMatching(errs, "hello-step/assets/extra.svg", "unexpected"),
+		"an asset on disk but missing from step-info.json must be flagged; got %+v", errs)
+}
+
 func TestValidate_flagsInvalidJSON(t *testing.T) {
 	root := runGenerateInventoryRoot(t)
 	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.MetaPathFS()), []byte("not json"), 0o644))

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -154,6 +154,19 @@ func TestValidate_flagsStepInfoAssetMissing(t *testing.T) {
 		"missing asset referenced by step-info.json must be flagged; got %+v", errs)
 }
 
+func TestValidate_flagsAbsoluteAssetURL(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// asset_urls must be step-dir-relative; an absolute URL violates the spec.
+	// Keep the real relative asset too so only the absolute-URL check fires.
+	bad := []byte(`{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","https://cdn.example/icon.svg"]}`)
+	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.StepInfoPathFS("hello-step")), bad, 0o644))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "hello-step/step-info.json", "absolute URL"),
+		"absolute asset_urls entry must be flagged; got %+v", errs)
+}
+
 func TestValidate_flagsStaleIndexFile(t *testing.T) {
 	root := runGenerateInventoryRoot(t)
 	// Drop a stale file into v2/index/.

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -34,6 +34,15 @@ func removeFile(t *testing.T, root, relPath string) {
 	require.NoError(t, os.Remove(filepath.Join(root, relPath)))
 }
 
+// mustFS returns p.FS() for a path constructor result, panicking if it errored.
+// The test ids/versions are all valid, so the error is a test-setup bug.
+func mustFS(p steplibindex.Path, err error) string {
+	if err != nil {
+		panic(err)
+	}
+	return p.FS()
+}
+
 // TestValidate mutates a freshly generated (and therefore valid) inventory and
 // asserts the matching consistency check fires. The clean baseline must produce
 // no violations; every other case proves a specific check. Comparison via the
@@ -51,69 +60,69 @@ func TestValidate(t *testing.T) {
 			mutate: func(*testing.T, string) {},
 		},
 		"missing meta.json": {
-			mutate:   func(t *testing.T, root string) { removeFile(t, root, steplibindex.MetaPathFS()) },
+			mutate:   func(t *testing.T, root string) { removeFile(t, root, steplibindex.MetaPath().FS()) },
 			wantPath: "meta.json", wantMsg: "missing",
 		},
 		"meta.json invalid JSON": {
-			mutate:   func(t *testing.T, root string) { seedFile(t, root, steplibindex.MetaPathFS(), "not json") },
+			mutate:   func(t *testing.T, root string) { seedFile(t, root, steplibindex.MetaPath().FS(), "not json") },
 			wantPath: "meta.json", wantMsg: "invalid JSON",
 		},
 		"meta.json wrong format_version": {
 			mutate: func(t *testing.T, root string) {
-				seedFile(t, root, steplibindex.MetaPathFS(), `{"format_version": 99, "updated_at": "2026-05-15T12:00:00Z"}`)
+				seedFile(t, root, steplibindex.MetaPath().FS(), `{"format_version": 99, "updated_at": "2026-05-15T12:00:00Z"}`)
 			},
 			wantPath: "meta.json", wantMsg: "format_version",
 		},
 		"empty step_ids": {
-			mutate:   func(t *testing.T, root string) { seedFile(t, root, steplibindex.StepIDsPathFS(), `{"step_ids":[]}`) },
+			mutate:   func(t *testing.T, root string) { seedFile(t, root, steplibindex.StepIDsPath().FS(), `{"step_ids":[]}`) },
 			wantPath: "step_ids.json", wantMsg: "empty",
 		},
 		"unsorted step_ids": {
 			mutate: func(t *testing.T, root string) {
 				// Still references only real steps so only the sort check fires.
-				seedFile(t, root, steplibindex.StepIDsPathFS(), `{"step_ids": ["hello-step", "bash-step", "deprecated-step", "multi-platform-step"]}`)
+				seedFile(t, root, steplibindex.StepIDsPath().FS(), `{"step_ids": ["hello-step", "bash-step", "deprecated-step", "multi-platform-step"]}`)
 			},
 			wantPath: "step_ids.json", wantMsg: "not sorted",
 		},
 		"latest points at a missing version": {
 			mutate: func(t *testing.T, root string) {
-				seedFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "hello-step", "latest": "99.99.99", "latest_by_major": {"99": "99.99.99"}}`)
+				seedFile(t, root, mustFS(steplibindex.LatestPointerPath("hello-step")), `{"step_id": "hello-step", "latest": "99.99.99", "latest_by_major": {"99": "99.99.99"}}`)
 			},
 			wantPath: "hello-step/latest.json", wantMsg: "not in",
 		},
 		"latest_by_major points at a different major": {
 			mutate: func(t *testing.T, root string) {
 				// hello-step has 1.0.0, 1.1.0, 2.0.0; point major "1" at 2.0.0.
-				seedFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "hello-step", "latest": "2.0.0", "latest_by_major": {"1": "2.0.0", "2": "2.0.0"}}`)
+				seedFile(t, root, mustFS(steplibindex.LatestPointerPath("hello-step")), `{"step_id": "hello-step", "latest": "2.0.0", "latest_by_major": {"1": "2.0.0", "2": "2.0.0"}}`)
 			},
 			wantPath: "hello-step/latest.json", wantMsg: "different major",
 		},
 		"latest.json step_id mismatch": {
 			mutate: func(t *testing.T, root string) {
-				seedFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "wrong-id", "latest": "2.0.0", "latest_by_major": {"1": "1.1.0", "2": "2.0.0"}}`)
+				seedFile(t, root, mustFS(steplibindex.LatestPointerPath("hello-step")), `{"step_id": "wrong-id", "latest": "2.0.0", "latest_by_major": {"1": "1.1.0", "2": "2.0.0"}}`)
 			},
 			wantPath: "hello-step/latest.json", wantMsg: "expected",
 		},
 		"declared version missing its step.json": {
 			mutate: func(t *testing.T, root string) {
-				removeFile(t, root, steplibindex.StepJSONPathFS("hello-step", "1.0.0"))
+				removeFile(t, root, mustFS(steplibindex.StepJSONPath("hello-step", "1.0.0")))
 			},
 			wantPath: "hello-step/1.0.0/step.json", wantMsg: "missing",
 		},
 		"missing mandatory step-info.json": {
-			mutate:   func(t *testing.T, root string) { removeFile(t, root, steplibindex.StepInfoPathFS("hello-step")) },
+			mutate:   func(t *testing.T, root string) { removeFile(t, root, mustFS(steplibindex.StepInfoPath("hello-step"))) },
 			wantPath: "hello-step/step-info.json", wantMsg: "missing",
 		},
 		"step-info asset that does not exist": {
 			mutate: func(t *testing.T, root string) {
-				removeFile(t, root, steplibindex.StepAssetPathFS("hello-step", "icon.svg"))
+				removeFile(t, root, mustFS(steplibindex.StepAssetPath("hello-step", "icon.svg")))
 			},
 			wantPath: "hello-step/step-info.json", wantMsg: "does not exist",
 		},
 		"absolute asset_urls entry": {
 			mutate: func(t *testing.T, root string) {
 				// Keep the real relative asset so only the absolute-URL check fires.
-				seedFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","https://cdn.example/icon.svg"]}`)
+				seedFile(t, root, mustFS(steplibindex.StepInfoPath("hello-step")), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","https://cdn.example/icon.svg"]}`)
 			},
 			wantPath: "hello-step/step-info.json", wantMsg: "absolute URL",
 		},
@@ -122,7 +131,7 @@ func TestValidate(t *testing.T) {
 				// "/assets/icon.svg" mirrors the real relative asset, so it would
 				// resolve and pass if absolute paths weren't rejected outright. Keep
 				// the real relative entry so only the absolute-path check fires.
-				seedFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","/assets/icon.svg"]}`)
+				seedFile(t, root, mustFS(steplibindex.StepInfoPath("hello-step")), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","/assets/icon.svg"]}`)
 			},
 			wantPath: "hello-step/step-info.json", wantMsg: "absolute path",
 		},
@@ -131,13 +140,13 @@ func TestValidate(t *testing.T) {
 				// "../../bash-step/..." resolves to a sibling step's real file, so it
 				// would pass if only absolute paths were rejected. Keep the real
 				// relative asset so only the escape check fires.
-				seedFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","assets/../../bash-step/step-info.json"]}`)
+				seedFile(t, root, mustFS(steplibindex.StepInfoPath("hello-step")), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","assets/../../bash-step/step-info.json"]}`)
 			},
 			wantPath: "hello-step/step-info.json", wantMsg: "escapes",
 		},
 		"asset on disk missing from step-info.json": {
 			mutate: func(t *testing.T, root string) {
-				seedFile(t, root, steplibindex.StepAssetPathFS("hello-step", "extra.svg"), "<svg/>")
+				seedFile(t, root, mustFS(steplibindex.StepAssetPath("hello-step", "extra.svg")), "<svg/>")
 			},
 			wantPath: "hello-step/assets/extra.svg", wantMsg: "unexpected",
 		},
@@ -149,7 +158,7 @@ func TestValidate(t *testing.T) {
 		},
 		"step dir not in step_ids.json": {
 			mutate: func(t *testing.T, root string) {
-				p := filepath.Join(root, steplibindex.StepJSONPathFS("ghost-step", "1.0.0"))
+				p := filepath.Join(root, mustFS(steplibindex.StepJSONPath("ghost-step", "1.0.0")))
 				require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
 				require.NoError(t, os.WriteFile(p, []byte(`{"title":"ghost"}`), 0o644))
 			},

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -191,8 +191,8 @@ func TestValidate_flagsStaleStepDir(t *testing.T) {
 
 func TestValidate_flagsUnreferencedAsset(t *testing.T) {
 	root := runGenerateInventoryRoot(t)
-	// An asset present on disk but not listed in step-info.json's asset_urls is
-	// not consumed by checkStepInfo, so the stale-file walk must flag it.
+	// An asset present on disk but not listed in step-info.json's asset_urls
+	// must be flagged by the stale-file walk.
 	extra := filepath.Join(root, steplibindex.StepAssetPathFS("hello-step", "extra.svg"))
 	require.NoError(t, os.WriteFile(extra, []byte("<svg/>"), 0o644))
 

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// runGenerateInventoryRoot generates a tree into a fresh temp dir and returns
-// the inventory root: the dir CONTAINING the version dir (v2/), which is the
-// root Validate expects. Tests mutate files under root and re-run Validate.
-func runGenerateInventoryRoot(t *testing.T) string {
+// generateFreshInventory generates a tree into a fresh temp dir and returns the
+// inventory root: the dir CONTAINING the version dir (v2/), which is the root
+// Validate expects. Each call is an isolated, disposable copy — tests mutate
+// files under root and re-run Validate without touching the shared fixture.
+func generateFreshInventory(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
 	_, gotErr := generateFromSteplibClone(
@@ -28,9 +29,9 @@ func runGenerateInventoryRoot(t *testing.T) string {
 	return root
 }
 
-// flagMatching returns the first error whose Path and Msg both contain the
-// given substrings. Returns nil if no match. Used to assert "the right
-// violation fired" without coupling tests to exact message wording.
+// flagMatching returns the first violation whose Path and Msg both contain the
+// given substrings, or nil. Lets cases assert "the right violation fired"
+// without coupling to exact message wording.
 func flagMatching(errs []ValidationError, pathContains, msgContains string) *ValidationError {
 	for i := range errs {
 		if (pathContains == "" || strings.Contains(errs[i].Path, pathContains)) &&
@@ -41,171 +42,134 @@ func flagMatching(errs []ValidationError, pathContains, msgContains string) *Val
 	return nil
 }
 
-// TestValidate_passesOnGeneratedOutput is the headline assertion: a freshly
-// generated tree from the canonical fixtures must validate cleanly. (The
-// generator already runs Validate internally before publishing, so a
-// successful generate is itself proof; this re-runs it explicitly to lock the
-// contract in independently.) Every targeted test below mutates this baseline
-// to prove a specific check fires.
-func TestValidate_passesOnGeneratedOutput(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-
-	errs := Validate(os.DirFS(root))
-	assert.Empty(t, errs, "generator output should validate cleanly; got %+v", errs)
+func writeFile(t *testing.T, root, relPath, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, relPath), []byte(content), 0o644))
 }
 
-func TestValidate_flagsMissingMeta(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.MetaPathFS())))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "meta.json", "missing"), "missing meta.json must be flagged; got %+v", errs)
+func removeFile(t *testing.T, root, relPath string) {
+	t.Helper()
+	require.NoError(t, os.Remove(filepath.Join(root, relPath)))
 }
 
-func TestValidate_flagsBadFormatVersion(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	bad := []byte(`{"format_version": 99, "updated_at": "2026-05-15T12:00:00Z"}`)
-	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.MetaPathFS()), bad, 0o644))
+// TestValidate mutates a freshly generated (and therefore valid) inventory and
+// asserts the matching consistency check fires. The clean baseline must produce
+// no violations; every other case proves a specific check. Comparison via the
+// generator's own output keeps the fixtures honest — no hand-built tree to
+// drift from what the generator actually emits.
+func TestValidate(t *testing.T) {
+	// wantMsg == "" means "expect no violations"; otherwise the run must produce
+	// a violation whose Path and Msg contain wantPath / wantMsg.
+	cases := map[string]struct {
+		mutate   func(t *testing.T, root string)
+		wantPath string
+		wantMsg  string
+	}{
+		"clean generated output is valid": {
+			mutate: func(*testing.T, string) {},
+		},
+		"missing meta.json": {
+			mutate:   func(t *testing.T, root string) { removeFile(t, root, steplibindex.MetaPathFS()) },
+			wantPath: "meta.json", wantMsg: "missing",
+		},
+		"meta.json invalid JSON": {
+			mutate:   func(t *testing.T, root string) { writeFile(t, root, steplibindex.MetaPathFS(), "not json") },
+			wantPath: "meta.json", wantMsg: "invalid JSON",
+		},
+		"meta.json wrong format_version": {
+			mutate: func(t *testing.T, root string) {
+				writeFile(t, root, steplibindex.MetaPathFS(), `{"format_version": 99, "updated_at": "2026-05-15T12:00:00Z"}`)
+			},
+			wantPath: "meta.json", wantMsg: "format_version",
+		},
+		"empty step_ids": {
+			mutate:   func(t *testing.T, root string) { writeFile(t, root, steplibindex.StepIDsPathFS(), `{"step_ids":[]}`) },
+			wantPath: "step_ids.json", wantMsg: "empty",
+		},
+		"unsorted step_ids": {
+			mutate: func(t *testing.T, root string) {
+				// Still references only real steps so only the sort check fires.
+				writeFile(t, root, steplibindex.StepIDsPathFS(), `{"step_ids": ["hello-step", "bash-step", "deprecated-step", "multi-platform-step"]}`)
+			},
+			wantPath: "step_ids.json", wantMsg: "not sorted",
+		},
+		"latest points at a missing version": {
+			mutate: func(t *testing.T, root string) {
+				writeFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "hello-step", "latest": "99.99.99", "latest_by_major": {"99": "99.99.99"}}`)
+			},
+			wantPath: "hello-step/latest.json", wantMsg: "not in",
+		},
+		"latest_by_major points at a different major": {
+			mutate: func(t *testing.T, root string) {
+				// hello-step has 1.0.0, 1.1.0, 2.0.0; point major "1" at 2.0.0.
+				writeFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "hello-step", "latest": "2.0.0", "latest_by_major": {"1": "2.0.0", "2": "2.0.0"}}`)
+			},
+			wantPath: "hello-step/latest.json", wantMsg: "different major",
+		},
+		"latest.json step_id mismatch": {
+			mutate: func(t *testing.T, root string) {
+				writeFile(t, root, steplibindex.LatestPointerPathFS("hello-step"), `{"step_id": "wrong-id", "latest": "2.0.0", "latest_by_major": {"1": "1.1.0", "2": "2.0.0"}}`)
+			},
+			wantPath: "hello-step/latest.json", wantMsg: "expected",
+		},
+		"declared version missing its step.json": {
+			mutate: func(t *testing.T, root string) {
+				removeFile(t, root, steplibindex.StepJSONPathFS("hello-step", "1.0.0"))
+			},
+			wantPath: "hello-step/1.0.0/step.json", wantMsg: "missing",
+		},
+		"missing mandatory step-info.json": {
+			mutate:   func(t *testing.T, root string) { removeFile(t, root, steplibindex.StepInfoPathFS("hello-step")) },
+			wantPath: "hello-step/step-info.json", wantMsg: "missing",
+		},
+		"step-info asset that does not exist": {
+			mutate: func(t *testing.T, root string) {
+				removeFile(t, root, steplibindex.StepAssetPathFS("hello-step", "icon.svg"))
+			},
+			wantPath: "hello-step/step-info.json", wantMsg: "does not exist",
+		},
+		"absolute asset_urls entry": {
+			mutate: func(t *testing.T, root string) {
+				// Keep the real relative asset so only the absolute-URL check fires.
+				writeFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","https://cdn.example/icon.svg"]}`)
+			},
+			wantPath: "hello-step/step-info.json", wantMsg: "absolute URL",
+		},
+		"asset on disk missing from step-info.json": {
+			mutate: func(t *testing.T, root string) {
+				writeFile(t, root, steplibindex.StepAssetPathFS("hello-step", "extra.svg"), "<svg/>")
+			},
+			wantPath: "hello-step/assets/extra.svg", wantMsg: "unexpected",
+		},
+		"stale file under index/": {
+			mutate: func(t *testing.T, root string) {
+				writeFile(t, root, filepath.Join(steplibindex.VersionDir(), steplibindex.IndexRootFS, "stale.json"), "{}")
+			},
+			wantPath: "stale.json", wantMsg: "unexpected",
+		},
+		"step dir not in step_ids.json": {
+			mutate: func(t *testing.T, root string) {
+				p := filepath.Join(root, steplibindex.StepJSONPathFS("ghost-step", "1.0.0"))
+				require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+				require.NoError(t, os.WriteFile(p, []byte(`{"title":"ghost"}`), 0o644))
+			},
+			wantPath: "ghost-step", wantMsg: "unexpected",
+		},
+	}
 
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "meta.json", "format_version"), "bad format_version must be flagged; got %+v", errs)
-}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := generateFreshInventory(t)
+			tc.mutate(t, root)
 
-func TestValidate_flagsEmptySteplib(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// A steplib with no steps is not valid.
-	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.StepIDsPathFS()), []byte(`{"step_ids":[]}`), 0o644))
+			errs := Validate(os.DirFS(root))
 
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "step_ids.json", "empty"),
-		"a steplib with no steps must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsUnsortedStepIDs(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// Hand-write an unsorted step_ids.json that still references only real steps
-	// so the per-step checks pass and only the sort check fires.
-	bad := []byte(`{"step_ids": ["hello-step", "bash-step", "deprecated-step", "multi-platform-step"]}`)
-	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.StepIDsPathFS()), bad, 0o644))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "step_ids.json", "not sorted"), "unsorted step_ids must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsLatestPointingAtMissingVersion(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	bad := []byte(`{"step_id": "hello-step", "latest": "99.99.99", "latest_by_major": {"99": "99.99.99"}}`)
-	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.LatestPointerPathFS("hello-step")), bad, 0o644))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "hello-step/latest.json", "not in"),
-		"latest pointing at missing version must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsLatestByMajorWrongMajor(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// hello-step has 1.0.0, 1.1.0, 2.0.0. Point major "1" at 2.0.0.
-	bad := []byte(`{"step_id": "hello-step", "latest": "2.0.0", "latest_by_major": {"1": "2.0.0", "2": "2.0.0"}}`)
-	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.LatestPointerPathFS("hello-step")), bad, 0o644))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "hello-step/latest.json", "different major"),
-		"latest_by_major pointing at wrong major must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsLatestStepIDMismatch(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// step_id disagreeing with the dir name must be flagged.
-	bad := []byte(`{"step_id": "wrong-id", "latest": "2.0.0", "latest_by_major": {"1": "1.1.0", "2": "2.0.0"}}`)
-	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.LatestPointerPathFS("hello-step")), bad, 0o644))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "hello-step/latest.json", "expected"),
-		"latest.json step_id mismatch must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsMissingStepJSON(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// Delete hello-step's 1.0.0/step.json while leaving the version in versions.json.
-	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.StepJSONPathFS("hello-step", "1.0.0"))))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "hello-step/1.0.0/step.json", "missing"),
-		"missing step.json for a declared version must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsMissingStepInfo(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// step-info.json is mandatory: deleting it must be flagged (not skipped).
-	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.StepInfoPathFS("hello-step"))))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "hello-step/step-info.json", "missing"),
-		"missing mandatory step-info.json must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsStepInfoAssetMissing(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// Delete the asset hello-step's step-info.json references.
-	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.StepAssetPathFS("hello-step", "icon.svg"))))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "hello-step/step-info.json", "does not exist"),
-		"missing asset referenced by step-info.json must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsAbsoluteAssetURL(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// asset_urls must be step-dir-relative; an absolute URL violates the spec.
-	// Keep the real relative asset too so only the absolute-URL check fires.
-	bad := []byte(`{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","https://cdn.example/icon.svg"]}`)
-	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.StepInfoPathFS("hello-step")), bad, 0o644))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "hello-step/step-info.json", "absolute URL"),
-		"absolute asset_urls entry must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsStaleIndexFile(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// Drop a stale file into v2/index/.
-	stalePath := filepath.Join(root, steplibindex.VersionDir(), steplibindex.IndexRootFS, "stale.json")
-	require.NoError(t, os.WriteFile(stalePath, []byte("{}"), 0o644))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "stale.json", "unexpected"),
-		"unexpected file under index/ must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsStaleStepDir(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// Drop a file under v2/steps/ for a step that step_ids.json doesn't know about.
-	stalePath := filepath.Join(root, steplibindex.StepJSONPathFS("ghost-step", "1.0.0"))
-	require.NoError(t, os.MkdirAll(filepath.Dir(stalePath), 0o755))
-	require.NoError(t, os.WriteFile(stalePath, []byte(`{"title":"ghost"}`), 0o644))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "ghost-step", "unexpected"),
-		"step dir not in step_ids.json must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsUnreferencedAsset(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	// An asset present on disk but not listed in step-info.json's asset_urls
-	// must be flagged by the stale-file walk.
-	extra := filepath.Join(root, steplibindex.StepAssetPathFS("hello-step", "extra.svg"))
-	require.NoError(t, os.WriteFile(extra, []byte("<svg/>"), 0o644))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "hello-step/assets/extra.svg", "unexpected"),
-		"an asset on disk but missing from step-info.json must be flagged; got %+v", errs)
-}
-
-func TestValidate_flagsInvalidJSON(t *testing.T) {
-	root := runGenerateInventoryRoot(t)
-	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.MetaPathFS()), []byte("not json"), 0o644))
-
-	errs := Validate(os.DirFS(root))
-	assert.NotNil(t, flagMatching(errs, "meta.json", "invalid JSON"),
-		"invalid JSON must be flagged; got %+v", errs)
+			if tc.wantMsg == "" {
+				assert.Empty(t, errs)
+				return
+			}
+			assert.NotNil(t, flagMatching(errs, tc.wantPath, tc.wantMsg),
+				"want a %q violation at %q; got %+v", tc.wantMsg, tc.wantPath, errs)
+		})
+	}
 }

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -74,6 +74,16 @@ func TestValidate_flagsBadFormatVersion(t *testing.T) {
 	assert.NotNil(t, flagMatching(errs, "meta.json", "format_version"), "bad format_version must be flagged; got %+v", errs)
 }
 
+func TestValidate_flagsEmptySteplib(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// A steplib with no steps is not valid.
+	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.StepIDsPathFS()), []byte(`{"step_ids":[]}`), 0o644))
+
+	errs := Validate(os.DirFS(root))
+	assert.NotNil(t, flagMatching(errs, "step_ids.json", "empty"),
+		"a steplib with no steps must be flagged; got %+v", errs)
+}
+
 func TestValidate_flagsUnsortedStepIDs(t *testing.T) {
 	root := runGenerateInventoryRoot(t)
 	// Hand-write an unsorted step_ids.json that still references only real steps

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -6,28 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bitrise-io/stepman/internal/specfixtures"
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// generateFreshInventory generates a tree into a fresh temp dir and returns the
-// inventory root: the dir CONTAINING the version dir (v2/), which is the root
-// Validate expects. Each call is an isolated, disposable copy — tests mutate
-// files under root and re-run Validate without touching the shared fixture.
-func generateFreshInventory(t *testing.T) string {
-	t.Helper()
-	root := t.TempDir()
-	_, gotErr := generateFromSteplibClone(
-		specfixtures.SteplibClone(),
-		root,
-		Options{GeneratedAt: fixedTime, SteplibCommitSHA: "deadbeefcafef00d"},
-		testLogger{t},
-	)
-	require.NoError(t, gotErr, "generateFromSteplibClone")
-	return root
-}
 
 // flagMatching returns the first violation whose Path and Msg both contain the
 // given substrings, or nil. Lets cases assert "the right violation fired"
@@ -144,6 +126,15 @@ func TestValidate(t *testing.T) {
 			},
 			wantPath: "hello-step/step-info.json", wantMsg: "absolute path",
 		},
+		"asset_urls escapes the step directory": {
+			mutate: func(t *testing.T, root string) {
+				// "../../bash-step/..." resolves to a sibling step's real file, so it
+				// would pass if only absolute paths were rejected. Keep the real
+				// relative asset so only the escape check fires.
+				writeFile(t, root, steplibindex.StepInfoPathFS("hello-step"), `{"maintainer":"bitrise","deprecation":null,"asset_urls":["assets/icon.svg","assets/../../bash-step/step-info.json"]}`)
+			},
+			wantPath: "hello-step/step-info.json", wantMsg: "escapes",
+		},
 		"asset on disk missing from step-info.json": {
 			mutate: func(t *testing.T, root string) {
 				writeFile(t, root, steplibindex.StepAssetPathFS("hello-step", "extra.svg"), "<svg/>")
@@ -168,7 +159,7 @@ func TestValidate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			root := generateFreshInventory(t)
+			root := runGenerateFromSteplibClone(t)
 			tc.mutate(t, root)
 
 			errs := Validate(os.DirFS(root))

--- a/steplibrary/indexgen/validate_test.go
+++ b/steplibrary/indexgen/validate_test.go
@@ -1,0 +1,190 @@
+package indexgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/stepman/internal/specfixtures"
+	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runGenerateInventoryRoot generates a tree into a fresh temp dir and returns
+// the inventory root: the dir CONTAINING the version dir (v2/), which is the
+// root Validate expects. Tests mutate files under root and re-run Validate.
+func runGenerateInventoryRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	_, gotErr := generateFromSteplibClone(
+		specfixtures.SteplibClone(),
+		root,
+		Options{GeneratedAt: fixedTime, SteplibCommitSHA: "deadbeefcafef00d"},
+		testLogger{t},
+	)
+	require.NoError(t, gotErr, "generateFromSteplibClone")
+	return root
+}
+
+// flagMatching returns the first error whose Path and Msg both contain the
+// given substrings. Returns nil if no match. Used to assert "the right
+// violation fired" without coupling tests to exact message wording.
+func flagMatching(errs []ValidationError, pathContains, msgContains string) *ValidationError {
+	for i := range errs {
+		if (pathContains == "" || strings.Contains(errs[i].Path, pathContains)) &&
+			(msgContains == "" || strings.Contains(errs[i].Msg, msgContains)) {
+			return &errs[i]
+		}
+	}
+	return nil
+}
+
+// TestValidate_passesOnGeneratedOutput is the headline assertion: a freshly
+// generated tree from the canonical fixtures must validate cleanly. (The
+// generator already runs Validate internally before publishing, so a
+// successful generate is itself proof; this re-runs it explicitly to lock the
+// contract in independently.) Every targeted test below mutates this baseline
+// to prove a specific check fires.
+func TestValidate_passesOnGeneratedOutput(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err, "Validate")
+	assert.Empty(t, errs, "generator output should validate cleanly; got %+v", errs)
+}
+
+func TestValidate_flagsMissingMeta(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.MetaPathFS())))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "meta.json", "missing"), "missing meta.json must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsBadFormatVersion(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	bad := []byte(`{"format_version": 99, "updated_at": "2026-05-15T12:00:00Z"}`)
+	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.MetaPathFS()), bad, 0o644))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "meta.json", "format_version"), "bad format_version must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsUnsortedStepIDs(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// Hand-write an unsorted step_ids.json that still references only real steps
+	// so the per-step checks pass and only the sort check fires.
+	bad := []byte(`{"step_ids": ["hello-step", "bash-step", "deprecated-step", "multi-platform-step"]}`)
+	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.StepIDsPathFS()), bad, 0o644))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "step_ids.json", "not sorted"), "unsorted step_ids must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsLatestPointingAtMissingVersion(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	bad := []byte(`{"step_id": "hello-step", "latest": "99.99.99", "latest_by_major": {"99": "99.99.99"}}`)
+	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.LatestPointerPathFS("hello-step")), bad, 0o644))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "hello-step/latest.json", "not in"),
+		"latest pointing at missing version must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsLatestByMajorWrongMajor(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// hello-step has 1.0.0, 1.1.0, 2.0.0. Point major "1" at 2.0.0.
+	bad := []byte(`{"step_id": "hello-step", "latest": "2.0.0", "latest_by_major": {"1": "2.0.0", "2": "2.0.0"}}`)
+	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.LatestPointerPathFS("hello-step")), bad, 0o644))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "hello-step/latest.json", "different major"),
+		"latest_by_major pointing at wrong major must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsLatestStepIDMismatch(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// step_id disagreeing with the dir name must be flagged.
+	bad := []byte(`{"step_id": "wrong-id", "latest": "2.0.0", "latest_by_major": {"1": "1.1.0", "2": "2.0.0"}}`)
+	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.LatestPointerPathFS("hello-step")), bad, 0o644))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "hello-step/latest.json", "expected"),
+		"latest.json step_id mismatch must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsMissingStepJSON(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// Delete hello-step's 1.0.0/step.json while leaving the version in versions.json.
+	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.StepJSONPathFS("hello-step", "1.0.0"))))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "hello-step/1.0.0/step.json", "missing"),
+		"missing step.json for a declared version must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsMissingStepInfo(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// step-info.json is mandatory: deleting it must be flagged (not skipped).
+	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.StepInfoPathFS("hello-step"))))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "hello-step/step-info.json", "missing"),
+		"missing mandatory step-info.json must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsStepInfoAssetMissing(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// Delete the asset hello-step's step-info.json references.
+	require.NoError(t, os.Remove(filepath.Join(root, steplibindex.StepAssetPathFS("hello-step", "icon.svg"))))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "hello-step/step-info.json", "does not exist"),
+		"missing asset referenced by step-info.json must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsStaleIndexFile(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// Drop a stale file into v2/index/.
+	stalePath := filepath.Join(root, steplibindex.VersionDir(), steplibindex.IndexRootFS, "stale.json")
+	require.NoError(t, os.WriteFile(stalePath, []byte("{}"), 0o644))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "stale.json", "unexpected"),
+		"unexpected file under index/ must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsStaleStepDir(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	// Drop a file under v2/steps/ for a step that step_ids.json doesn't know about.
+	stalePath := filepath.Join(root, steplibindex.StepJSONPathFS("ghost-step", "1.0.0"))
+	require.NoError(t, os.MkdirAll(filepath.Dir(stalePath), 0o755))
+	require.NoError(t, os.WriteFile(stalePath, []byte(`{"title":"ghost"}`), 0o644))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "ghost-step", "unexpected"),
+		"step dir not in step_ids.json must be flagged; got %+v", errs)
+}
+
+func TestValidate_flagsInvalidJSON(t *testing.T) {
+	root := runGenerateInventoryRoot(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, steplibindex.MetaPathFS()), []byte("not json"), 0o644))
+
+	errs, err := Validate(os.DirFS(root))
+	require.NoError(t, err)
+	assert.NotNil(t, flagMatching(errs, "meta.json", "invalid JSON"),
+		"invalid JSON must be flagged; got %+v", errs)
+}

--- a/steplibrary/indexgen/writer.go
+++ b/steplibrary/indexgen/writer.go
@@ -9,22 +9,18 @@ import (
 	"github.com/bitrise-io/go-utils/v2/fileutil"
 )
 
-// fileWriter abstracts the OS calls used by writeJSON, making them injectable
-// for testing without affecting the fs.FS-based read path.
-type fileWriter interface {
-	MkdirAll(path string, perm os.FileMode) error
-	WriteFile(name string, data []byte, perm os.FileMode) error
-}
-
-type realFileWriter struct{}
-
 // writer emits files under outputDir and tracks file count + byte count for Stats.
 type writer struct {
 	outputDir string
-	fw        fileWriter
 	fm        fileutil.FileManager
 	fileCount int
 	byteCount int64
+}
+
+// newWriter returns a writer that emits files under outputDir, using fm to copy
+// asset files.
+func newWriter(outputDir string, fm fileutil.FileManager) *writer {
+	return &writer{outputDir: outputDir, fm: fm, fileCount: 0, byteCount: 0}
 }
 
 func (w *writer) writeJSON(relPath string, v any) error {
@@ -35,10 +31,10 @@ func (w *writer) writeJSON(relPath string, v any) error {
 	bytes = append(bytes, '\n')
 	full := filepath.Join(w.outputDir, relPath)
 	// Files we author get owner-only perms (no group/other needed).
-	if err := w.fw.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
 		return err
 	}
-	if err := w.fw.WriteFile(full, bytes, 0o600); err != nil {
+	if err := os.WriteFile(full, bytes, 0o600); err != nil {
 		return err
 	}
 	w.fileCount++
@@ -64,12 +60,4 @@ func (w *writer) copyFileFromFS(srcFS fs.FS, srcPath, relDst string) error {
 	w.fileCount++
 	w.byteCount += info.Size()
 	return nil
-}
-
-func (realFileWriter) MkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(path, perm)
-}
-
-func (realFileWriter) WriteFile(name string, data []byte, perm os.FileMode) error {
-	return os.WriteFile(name, data, perm)
 }

--- a/steplibrary/steplibindex/paths.go
+++ b/steplibrary/steplibindex/paths.go
@@ -59,7 +59,7 @@ type seg struct {
 	dyn bool
 }
 
-func lit(v string) seg { return seg{v: v} }
+func lit(v string) seg { return seg{v: v, dyn: false} }
 func dyn(v string) seg { return seg{v: v, dyn: true} }
 
 // validateSegment rejects a dynamic segment that is not a safe single path

--- a/steplibrary/steplibindex/paths.go
+++ b/steplibrary/steplibindex/paths.go
@@ -1,0 +1,118 @@
+package steplibindex
+
+import (
+	"net/url"
+	"path"
+)
+
+// Paths to every file in the V2 inventory tree. There must be exactly one
+// source of truth for the layout so that the generator, the HTTP reader, and
+// the validator never drift.
+//
+// Two parallel families are exposed because the two consumption modes are
+// genuinely different:
+//
+//   - Filesystem paths (FS-suffixed) are slash-separated, relative to the
+//     inventory root, and suitable for fs.FS lookups, path.Join, and the
+//     generator's writer.
+//   - URL paths (URL-suffixed) are absolute (leading slash) and have
+//     url.PathEscape applied to the dynamic id/version segments so that
+//     unusual but valid step IDs (e.g. ones containing reserved URL chars)
+//     never break the HTTP reader.
+
+// Top-level directories inside the inventory tree.
+//
+// Note: the helpers below that build index/steps/<id>/... paths use the
+// inline literal "steps" rather than referencing StepsRootFS. This is
+// deliberate: the "steps" segment under index/ is the per-step *index* dir
+// (a different namespace from the top-level source-of-truth steps/ tree),
+// and reusing StepsRootFS there would conflate the two. The name collision
+// is in the V2 layout itself; the constants do not paper over it.
+const (
+	StepsRootFS = "steps"
+	IndexRootFS = "index"
+)
+
+// MetaPathFS returns the inventory-relative path of v2/meta.json.
+func MetaPathFS() string { return path.Join(VersionDir(), "meta.json") }
+
+// MetaPathURL returns the URL form of MetaPathFS.
+func MetaPathURL() string { return "/" + MetaPathFS() }
+
+// StepIDsPathFS returns the inventory-relative path of v2/index/step_ids.json.
+func StepIDsPathFS() string { return path.Join(VersionDir(), IndexRootFS, "step_ids.json") }
+
+// StepIDsPathURL returns the URL form of StepIDsPathFS.
+func StepIDsPathURL() string { return "/" + StepIDsPathFS() }
+
+// LatestPointerPathFS returns the inventory-relative path of
+// v2/index/steps/<id>/latest.json.
+func LatestPointerPathFS(stepID string) string {
+	return path.Join(VersionDir(), IndexRootFS, "steps", stepID, "latest.json")
+}
+
+// LatestPointerPathURL returns the URL form of LatestPointerPathFS with the
+// step ID URL-escaped.
+func LatestPointerPathURL(stepID string) string {
+	return "/" + path.Join(VersionDir(), IndexRootFS, "steps", url.PathEscape(stepID), "latest.json")
+}
+
+// VersionsPathFS returns the inventory-relative path of
+// v2/index/steps/<id>/versions.json.
+func VersionsPathFS(stepID string) string {
+	return path.Join(VersionDir(), IndexRootFS, "steps", stepID, "versions.json")
+}
+
+// VersionsPathURL returns the URL form of VersionsPathFS with the step ID
+// URL-escaped.
+func VersionsPathURL(stepID string) string {
+	return "/" + path.Join(VersionDir(), IndexRootFS, "steps", url.PathEscape(stepID), "versions.json")
+}
+
+// StepInfoPathFS returns the inventory-relative path of
+// v2/steps/<id>/step-info.json.
+func StepInfoPathFS(stepID string) string {
+	return path.Join(VersionDir(), StepsRootFS, stepID, "step-info.json")
+}
+
+// StepInfoPathURL returns the URL form of StepInfoPathFS with the step ID
+// URL-escaped.
+func StepInfoPathURL(stepID string) string {
+	return "/" + path.Join(VersionDir(), StepsRootFS, url.PathEscape(stepID), "step-info.json")
+}
+
+// StepJSONPathFS returns the inventory-relative path of
+// v2/steps/<id>/<version>/step.json.
+func StepJSONPathFS(stepID, version string) string {
+	return path.Join(VersionDir(), StepsRootFS, stepID, version, "step.json")
+}
+
+// StepJSONPathURL returns the URL form of StepJSONPathFS with the step ID
+// and version URL-escaped.
+func StepJSONPathURL(stepID, version string) string {
+	return "/" + path.Join(VersionDir(), StepsRootFS, url.PathEscape(stepID), url.PathEscape(version), "step.json")
+}
+
+// StepAssetDirFS returns the inventory-relative path of v2/steps/<id>/assets.
+func StepAssetDirFS(stepID string) string {
+	return path.Join(VersionDir(), StepsRootFS, stepID, "assets")
+}
+
+// StepAssetPathFS returns the inventory-relative path of
+// v2/steps/<id>/assets/<file>.
+func StepAssetPathFS(stepID, file string) string {
+	return path.Join(VersionDir(), StepsRootFS, stepID, "assets", file)
+}
+
+// StepDirFS returns the inventory-relative path of the v2/steps/<id>/ directory
+// (the per-step subtree that holds step-info.json, assets/, and per-version
+// dirs).
+func StepDirFS(stepID string) string {
+	return path.Join(VersionDir(), StepsRootFS, stepID)
+}
+
+// IndexStepDirFS returns the inventory-relative path of the
+// v2/index/steps/<id>/ directory (the per-step subtree of derived index files).
+func IndexStepDirFS(stepID string) string {
+	return path.Join(VersionDir(), IndexRootFS, "steps", stepID)
+}

--- a/steplibrary/steplibindex/paths.go
+++ b/steplibrary/steplibindex/paths.go
@@ -1,118 +1,157 @@
 package steplibindex
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"path"
+	"strings"
 )
 
 // Paths to every file in the V2 inventory tree. There must be exactly one
-// source of truth for the layout so that the generator, the HTTP reader, and
-// the validator never drift.
+// source of truth for the layout so the generator, the HTTP reader, and the
+// validator never drift.
 //
-// Two parallel families are exposed because the two consumption modes are
-// genuinely different:
+// Each file is one constructor returning a Path, which carries both addressing
+// modes so they can't drift from each other:
 //
-//   - Filesystem paths (FS-suffixed) are slash-separated, relative to the
-//     inventory root, and suitable for fs.FS lookups, path.Join, and the
-//     generator's writer.
-//   - URL paths (URL-suffixed) are absolute (leading slash) and have
-//     url.PathEscape applied to the dynamic id/version segments so that
-//     unusual but valid step IDs (e.g. ones containing reserved URL chars)
-//     never break the HTTP reader.
+//   - FS():  the inventory-relative path as a forward-slash string — the form
+//     io/fs requires (os.DirFS, fs.ReadFile, fs.WalkDir, …). It is slash-
+//     separated on every OS, so it is built with path.Join, never
+//     filepath.Join; ids and versions are left raw (unescaped).
+//   - URL(): absolute (leading slash), with url.PathEscape applied to the
+//     dynamic id/version segments — for the HTTP reader.
+//
+// Dynamic segments (step id, version, asset file) are validated as safe single
+// path components: a constructor returns an error if a segment is empty, a
+// "."/".." traversal element, or contains a path separator or NUL. This is a
+// security boundary — the segment is interpolated into filesystem and URL paths,
+// so an unchecked separator or ".." could read or write outside the step's
+// subtree. Directories (StepDirFS, IndexStepDirFS, StepAssetDirFS) are FS-only:
+// they are path bases / walk roots, never fetched by URL.
 
-// Top-level directories inside the inventory tree.
-//
-// Note: the helpers below that build index/steps/<id>/... paths use the
-// inline literal "steps" rather than referencing StepsRootFS. This is
-// deliberate: the "steps" segment under index/ is the per-step *index* dir
-// (a different namespace from the top-level source-of-truth steps/ tree),
-// and reusing StepsRootFS there would conflate the two. The name collision
-// is in the V2 layout itself; the constants do not paper over it.
+// Top-level directories inside the inventory tree. The "steps" segment under
+// index/ is the per-step index namespace — distinct from this top-level
+// source-of-truth steps/ tree — so it is written inline, not via StepsRootFS.
 const (
 	StepsRootFS = "steps"
 	IndexRootFS = "index"
 )
 
-// MetaPathFS returns the inventory-relative path of v2/meta.json.
-func MetaPathFS() string { return path.Join(VersionDir(), "meta.json") }
-
-// MetaPathURL returns the URL form of MetaPathFS.
-func MetaPathURL() string { return "/" + MetaPathFS() }
-
-// StepIDsPathFS returns the inventory-relative path of v2/index/step_ids.json.
-func StepIDsPathFS() string { return path.Join(VersionDir(), IndexRootFS, "step_ids.json") }
-
-// StepIDsPathURL returns the URL form of StepIDsPathFS.
-func StepIDsPathURL() string { return "/" + StepIDsPathFS() }
-
-// LatestPointerPathFS returns the inventory-relative path of
-// v2/index/steps/<id>/latest.json.
-func LatestPointerPathFS(stepID string) string {
-	return path.Join(VersionDir(), IndexRootFS, "steps", stepID, "latest.json")
+// Path is a single file in the V2 inventory tree, addressable as a filesystem
+// path (FS) or an HTTP URL path (URL). Both forms are built together so they
+// cannot drift.
+type Path struct {
+	fs  string
+	url string
 }
 
-// LatestPointerPathURL returns the URL form of LatestPointerPathFS with the
-// step ID URL-escaped.
-func LatestPointerPathURL(stepID string) string {
-	return "/" + path.Join(VersionDir(), IndexRootFS, "steps", url.PathEscape(stepID), "latest.json")
+// FS returns the slash-separated path relative to the inventory root.
+func (p Path) FS() string { return p.fs }
+
+// URL returns the absolute, percent-escaped URL path.
+func (p Path) URL() string { return p.url }
+
+// seg is one path segment. Dynamic segments (step id, version, asset file) are
+// validated and percent-escaped in the URL form; static ones are taken verbatim.
+type seg struct {
+	v   string
+	dyn bool
 }
 
-// VersionsPathFS returns the inventory-relative path of
-// v2/index/steps/<id>/versions.json.
-func VersionsPathFS(stepID string) string {
-	return path.Join(VersionDir(), IndexRootFS, "steps", stepID, "versions.json")
+func lit(v string) seg { return seg{v: v} }
+func dyn(v string) seg { return seg{v: v, dyn: true} }
+
+// validateSegment rejects a dynamic segment that is not a safe single path
+// component, so it can never escape or restructure the path it is spliced into.
+func validateSegment(s string) error {
+	switch {
+	case s == "":
+		return errors.New("path segment is empty")
+	case s == "." || s == "..":
+		return fmt.Errorf("path segment %q is a directory-traversal element", s)
+	case strings.ContainsAny(s, `/\`):
+		return fmt.Errorf("path segment %q contains a path separator", s)
+	case strings.ContainsRune(s, 0):
+		return fmt.Errorf("path segment %q contains a NUL byte", s)
+	}
+	return nil
 }
 
-// VersionsPathURL returns the URL form of VersionsPathFS with the step ID
-// URL-escaped.
-func VersionsPathURL(stepID string) string {
-	return "/" + path.Join(VersionDir(), IndexRootFS, "steps", url.PathEscape(stepID), "versions.json")
+// build assembles a Path from segments under the version dir (e.g. v2/),
+// validating every dynamic segment. It is the single place each layout is
+// spelled out, so the FS and URL forms are always derived from the same list.
+func build(segs ...seg) (Path, error) {
+	fsParts := []string{VersionDir()}
+	urlParts := []string{VersionDir()}
+	for _, s := range segs {
+		if s.dyn {
+			if err := validateSegment(s.v); err != nil {
+				return Path{}, err
+			}
+			urlParts = append(urlParts, url.PathEscape(s.v))
+		} else {
+			urlParts = append(urlParts, s.v)
+		}
+		fsParts = append(fsParts, s.v)
+	}
+	return Path{fs: path.Join(fsParts...), url: "/" + path.Join(urlParts...)}, nil
 }
 
-// StepInfoPathFS returns the inventory-relative path of
-// v2/steps/<id>/step-info.json.
-func StepInfoPathFS(stepID string) string {
-	return path.Join(VersionDir(), StepsRootFS, stepID, "step-info.json")
+// staticPath builds a Path from static segments only; with no dynamic input
+// there is nothing to validate, so it cannot fail.
+func staticPath(segs ...string) Path {
+	joined := path.Join(append([]string{VersionDir()}, segs...)...)
+	return Path{fs: joined, url: "/" + joined}
 }
 
-// StepInfoPathURL returns the URL form of StepInfoPathFS with the step ID
-// URL-escaped.
-func StepInfoPathURL(stepID string) string {
-	return "/" + path.Join(VersionDir(), StepsRootFS, url.PathEscape(stepID), "step-info.json")
+// MetaPath is v2/meta.json.
+func MetaPath() Path { return staticPath("meta.json") }
+
+// StepIDsPath is v2/index/step_ids.json.
+func StepIDsPath() Path { return staticPath(IndexRootFS, "step_ids.json") }
+
+// LatestPointerPath is v2/index/steps/<id>/latest.json.
+func LatestPointerPath(stepID string) (Path, error) {
+	return build(lit(IndexRootFS), lit("steps"), dyn(stepID), lit("latest.json"))
 }
 
-// StepJSONPathFS returns the inventory-relative path of
-// v2/steps/<id>/<version>/step.json.
-func StepJSONPathFS(stepID, version string) string {
-	return path.Join(VersionDir(), StepsRootFS, stepID, version, "step.json")
+// VersionsPath is v2/index/steps/<id>/versions.json.
+func VersionsPath(stepID string) (Path, error) {
+	return build(lit(IndexRootFS), lit("steps"), dyn(stepID), lit("versions.json"))
 }
 
-// StepJSONPathURL returns the URL form of StepJSONPathFS with the step ID
-// and version URL-escaped.
-func StepJSONPathURL(stepID, version string) string {
-	return "/" + path.Join(VersionDir(), StepsRootFS, url.PathEscape(stepID), url.PathEscape(version), "step.json")
+// StepInfoPath is v2/steps/<id>/step-info.json.
+func StepInfoPath(stepID string) (Path, error) {
+	return build(lit(StepsRootFS), dyn(stepID), lit("step-info.json"))
 }
 
-// StepAssetDirFS returns the inventory-relative path of v2/steps/<id>/assets.
-func StepAssetDirFS(stepID string) string {
-	return path.Join(VersionDir(), StepsRootFS, stepID, "assets")
+// StepJSONPath is v2/steps/<id>/<version>/step.json.
+func StepJSONPath(stepID, version string) (Path, error) {
+	return build(lit(StepsRootFS), dyn(stepID), dyn(version), lit("step.json"))
 }
 
-// StepAssetPathFS returns the inventory-relative path of
-// v2/steps/<id>/assets/<file>.
-func StepAssetPathFS(stepID, file string) string {
-	return path.Join(VersionDir(), StepsRootFS, stepID, "assets", file)
+// StepAssetPath is v2/steps/<id>/assets/<file>.
+func StepAssetPath(stepID, file string) (Path, error) {
+	return build(lit(StepsRootFS), dyn(stepID), lit("assets"), dyn(file))
 }
 
-// StepDirFS returns the inventory-relative path of the v2/steps/<id>/ directory
-// (the per-step subtree that holds step-info.json, assets/, and per-version
-// dirs).
-func StepDirFS(stepID string) string {
-	return path.Join(VersionDir(), StepsRootFS, stepID)
+// StepDirFS is the v2/steps/<id>/ directory (the per-step source subtree:
+// step-info.json, assets/, and per-version dirs).
+func StepDirFS(stepID string) (string, error) {
+	p, err := build(lit(StepsRootFS), dyn(stepID))
+	return p.FS(), err
 }
 
-// IndexStepDirFS returns the inventory-relative path of the
-// v2/index/steps/<id>/ directory (the per-step subtree of derived index files).
-func IndexStepDirFS(stepID string) string {
-	return path.Join(VersionDir(), IndexRootFS, "steps", stepID)
+// IndexStepDirFS is the v2/index/steps/<id>/ directory (the per-step subtree of
+// derived index files).
+func IndexStepDirFS(stepID string) (string, error) {
+	p, err := build(lit(IndexRootFS), lit("steps"), dyn(stepID))
+	return p.FS(), err
+}
+
+// StepAssetDirFS is the v2/steps/<id>/assets directory.
+func StepAssetDirFS(stepID string) (string, error) {
+	p, err := build(lit(StepsRootFS), dyn(stepID), lit("assets"))
+	return p.FS(), err
 }

--- a/steplibrary/steplibindex/paths_test.go
+++ b/steplibrary/steplibindex/paths_test.go
@@ -4,69 +4,81 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// TestPathURL_escaping covers the URL-form helpers' url.PathEscape behavior
-// on step IDs and versions that contain characters reserved in URL path
-// segments. It isolates the escaping rule so a regression fails loudly.
-func TestPathURL_escaping(t *testing.T) {
-	t.Run("LatestPointerPathURL", func(t *testing.T) {
-		cases := []struct{ stepID, want string }{
-			{"git-clone", "/v2/index/steps/git-clone/latest.json"},
-			{"with space", "/v2/index/steps/with%20space/latest.json"},
-			{"with/slash", "/v2/index/steps/with%2Fslash/latest.json"},
-			{"weird?chars", "/v2/index/steps/weird%3Fchars/latest.json"},
-			// url.PathEscape leaves "+" alone — it's valid unescaped in
-			// URL path segments per RFC 3986. The line documents the
-			// behavior so a future change to escape it is intentional.
-			{"with+plus", "/v2/index/steps/with+plus/latest.json"},
-		}
-		for _, c := range cases {
-			assert.Equal(t, c.want, LatestPointerPathURL(c.stepID), "stepID=%q", c.stepID)
-		}
-	})
+// TestPaths locks in the FS and URL forms of the dynamic inventory paths. The
+// URL form url.PathEscape's the dynamic id/version segments (e.g. a space →
+// %20); the FS form stays raw. Both come from one Path so they can't drift.
+func TestPaths(t *testing.T) {
+	cases := map[string]struct {
+		build   func() (Path, error)
+		wantFS  string
+		wantURL string
+	}{
+		"latest pointer": {func() (Path, error) { return LatestPointerPath("git-clone") }, "v2/index/steps/git-clone/latest.json", "/v2/index/steps/git-clone/latest.json"},
+		"versions":       {func() (Path, error) { return VersionsPath("git-clone") }, "v2/index/steps/git-clone/versions.json", "/v2/index/steps/git-clone/versions.json"},
+		"step-info":      {func() (Path, error) { return StepInfoPath("git-clone") }, "v2/steps/git-clone/step-info.json", "/v2/steps/git-clone/step-info.json"},
+		"step.json":      {func() (Path, error) { return StepJSONPath("git-clone", "1.0.0") }, "v2/steps/git-clone/1.0.0/step.json", "/v2/steps/git-clone/1.0.0/step.json"},
+		"asset":          {func() (Path, error) { return StepAssetPath("git-clone", "icon.svg") }, "v2/steps/git-clone/assets/icon.svg", "/v2/steps/git-clone/assets/icon.svg"},
 
-	t.Run("StepJSONPathURL_escapes_both_segments", func(t *testing.T) {
-		// Both stepID and version are url.PathEscape'd.
-		assert.Equal(t,
-			"/v2/steps/git-clone/1.0.0/step.json",
-			StepJSONPathURL("git-clone", "1.0.0"),
-		)
-		assert.Equal(t,
-			"/v2/steps/with%2Fslash/1.0.0/step.json",
-			StepJSONPathURL("with/slash", "1.0.0"),
-		)
-		assert.Equal(t,
-			"/v2/steps/git-clone/1.0.0%20beta/step.json",
-			StepJSONPathURL("git-clone", "1.0.0 beta"),
-		)
-	})
-
-	t.Run("VersionsPathURL_and_StepInfoPathURL", func(t *testing.T) {
-		// Confirm escaping wires through the other URL helpers too.
-		assert.Equal(t, "/v2/index/steps/has%2Fslash/versions.json", VersionsPathURL("has/slash"))
-		assert.Equal(t, "/v2/steps/has%2Fslash/step-info.json", StepInfoPathURL("has/slash"))
-	})
+		// URL form escapes reserved characters in dynamic segments; FS stays raw.
+		"id with space":      {func() (Path, error) { return LatestPointerPath("with space") }, "v2/index/steps/with space/latest.json", "/v2/index/steps/with%20space/latest.json"},
+		"id with question":   {func() (Path, error) { return LatestPointerPath("weird?chars") }, "v2/index/steps/weird?chars/latest.json", "/v2/index/steps/weird%3Fchars/latest.json"},
+		"version with space": {func() (Path, error) { return StepJSONPath("git-clone", "1.0.0 beta") }, "v2/steps/git-clone/1.0.0 beta/step.json", "/v2/steps/git-clone/1.0.0%20beta/step.json"},
+		// url.PathEscape leaves "+" alone — it's valid unescaped in a path segment.
+		"id with plus": {func() (Path, error) { return LatestPointerPath("with+plus") }, "v2/index/steps/with+plus/latest.json", "/v2/index/steps/with+plus/latest.json"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.build()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantFS, got.FS(), "FS")
+			assert.Equal(t, tc.wantURL, got.URL(), "URL")
+		})
+	}
 }
 
-// TestPathURL_constants documents the constant URL forms. Locks them in so
-// a typo in the layout-rename refactor would surface here.
-func TestPathURL_constants(t *testing.T) {
-	assert.Equal(t, "/v2/meta.json", MetaPathURL())
-	assert.Equal(t, "/v2/index/step_ids.json", StepIDsPathURL())
+// TestStaticPaths locks in the paths with no dynamic input (they can't fail).
+func TestStaticPaths(t *testing.T) {
+	assert.Equal(t, "v2/meta.json", MetaPath().FS(), "MetaPath FS")
+	assert.Equal(t, "/v2/meta.json", MetaPath().URL(), "MetaPath URL")
+	assert.Equal(t, "v2/index/step_ids.json", StepIDsPath().FS(), "StepIDsPath FS")
+	assert.Equal(t, "/v2/index/step_ids.json", StepIDsPath().URL(), "StepIDsPath URL")
 }
 
-// TestPathFS documents the filesystem-form helpers. The FS forms are what the
-// generator and validator use; lock the v2-rooted layout in.
-func TestPathFS(t *testing.T) {
-	assert.Equal(t, "v2/meta.json", MetaPathFS())
-	assert.Equal(t, "v2/index/step_ids.json", StepIDsPathFS())
-	assert.Equal(t, "v2/index/steps/git-clone/latest.json", LatestPointerPathFS("git-clone"))
-	assert.Equal(t, "v2/index/steps/git-clone/versions.json", VersionsPathFS("git-clone"))
-	assert.Equal(t, "v2/index/steps/git-clone", IndexStepDirFS("git-clone"))
-	assert.Equal(t, "v2/steps/git-clone/step-info.json", StepInfoPathFS("git-clone"))
-	assert.Equal(t, "v2/steps/git-clone/1.0.0/step.json", StepJSONPathFS("git-clone", "1.0.0"))
-	assert.Equal(t, "v2/steps/git-clone/assets", StepAssetDirFS("git-clone"))
-	assert.Equal(t, "v2/steps/git-clone/assets/icon.svg", StepAssetPathFS("git-clone", "icon.svg"))
-	assert.Equal(t, "v2/steps/git-clone", StepDirFS("git-clone"))
+// TestPaths_rejectsUnsafeSegments is the security-grade check: a dynamic segment
+// that could escape or restructure the path (empty, "."/"..", a separator, NUL)
+// is refused with an error rather than spliced in.
+func TestPaths_rejectsUnsafeSegments(t *testing.T) {
+	cases := map[string]func() (Path, error){
+		"empty id":       func() (Path, error) { return StepInfoPath("") },
+		"dot id":         func() (Path, error) { return StepInfoPath(".") },
+		"dotdot id":      func() (Path, error) { return StepInfoPath("..") },
+		"slash id":       func() (Path, error) { return StepInfoPath("a/b") },
+		"backslash id":   func() (Path, error) { return StepInfoPath(`a\b`) },
+		"nul id":         func() (Path, error) { return StepInfoPath("a\x00b") },
+		"dotdot version": func() (Path, error) { return StepJSONPath("git-clone", "..") },
+	}
+	for name, build := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := build()
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestDirPaths locks in the FS-only directory helpers.
+func TestDirPaths(t *testing.T) {
+	stepDir, err := StepDirFS("git-clone")
+	require.NoError(t, err)
+	assert.Equal(t, "v2/steps/git-clone", stepDir, "StepDirFS")
+
+	indexDir, err := IndexStepDirFS("git-clone")
+	require.NoError(t, err)
+	assert.Equal(t, "v2/index/steps/git-clone", indexDir, "IndexStepDirFS")
+
+	assetDir, err := StepAssetDirFS("git-clone")
+	require.NoError(t, err)
+	assert.Equal(t, "v2/steps/git-clone/assets", assetDir, "StepAssetDirFS")
 }

--- a/steplibrary/steplibindex/paths_test.go
+++ b/steplibrary/steplibindex/paths_test.go
@@ -1,0 +1,72 @@
+package steplibindex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPathURL_escaping covers the URL-form helpers' url.PathEscape behavior
+// on step IDs and versions that contain characters reserved in URL path
+// segments. It isolates the escaping rule so a regression fails loudly.
+func TestPathURL_escaping(t *testing.T) {
+	t.Run("LatestPointerPathURL", func(t *testing.T) {
+		cases := []struct{ stepID, want string }{
+			{"git-clone", "/v2/index/steps/git-clone/latest.json"},
+			{"with space", "/v2/index/steps/with%20space/latest.json"},
+			{"with/slash", "/v2/index/steps/with%2Fslash/latest.json"},
+			{"weird?chars", "/v2/index/steps/weird%3Fchars/latest.json"},
+			// url.PathEscape leaves "+" alone — it's valid unescaped in
+			// URL path segments per RFC 3986. The line documents the
+			// behavior so a future change to escape it is intentional.
+			{"with+plus", "/v2/index/steps/with+plus/latest.json"},
+		}
+		for _, c := range cases {
+			assert.Equal(t, c.want, LatestPointerPathURL(c.stepID), "stepID=%q", c.stepID)
+		}
+	})
+
+	t.Run("StepJSONPathURL_escapes_both_segments", func(t *testing.T) {
+		// Both stepID and version are url.PathEscape'd.
+		assert.Equal(t,
+			"/v2/steps/git-clone/1.0.0/step.json",
+			StepJSONPathURL("git-clone", "1.0.0"),
+		)
+		assert.Equal(t,
+			"/v2/steps/with%2Fslash/1.0.0/step.json",
+			StepJSONPathURL("with/slash", "1.0.0"),
+		)
+		assert.Equal(t,
+			"/v2/steps/git-clone/1.0.0%20beta/step.json",
+			StepJSONPathURL("git-clone", "1.0.0 beta"),
+		)
+	})
+
+	t.Run("VersionsPathURL_and_StepInfoPathURL", func(t *testing.T) {
+		// Confirm escaping wires through the other URL helpers too.
+		assert.Equal(t, "/v2/index/steps/has%2Fslash/versions.json", VersionsPathURL("has/slash"))
+		assert.Equal(t, "/v2/steps/has%2Fslash/step-info.json", StepInfoPathURL("has/slash"))
+	})
+}
+
+// TestPathURL_constants documents the constant URL forms. Locks them in so
+// a typo in the layout-rename refactor would surface here.
+func TestPathURL_constants(t *testing.T) {
+	assert.Equal(t, "/v2/meta.json", MetaPathURL())
+	assert.Equal(t, "/v2/index/step_ids.json", StepIDsPathURL())
+}
+
+// TestPathFS documents the filesystem-form helpers. The FS forms are what the
+// generator and validator use; lock the v2-rooted layout in.
+func TestPathFS(t *testing.T) {
+	assert.Equal(t, "v2/meta.json", MetaPathFS())
+	assert.Equal(t, "v2/index/step_ids.json", StepIDsPathFS())
+	assert.Equal(t, "v2/index/steps/git-clone/latest.json", LatestPointerPathFS("git-clone"))
+	assert.Equal(t, "v2/index/steps/git-clone/versions.json", VersionsPathFS("git-clone"))
+	assert.Equal(t, "v2/index/steps/git-clone", IndexStepDirFS("git-clone"))
+	assert.Equal(t, "v2/steps/git-clone/step-info.json", StepInfoPathFS("git-clone"))
+	assert.Equal(t, "v2/steps/git-clone/1.0.0/step.json", StepJSONPathFS("git-clone", "1.0.0"))
+	assert.Equal(t, "v2/steps/git-clone/assets", StepAssetDirFS("git-clone"))
+	assert.Equal(t, "v2/steps/git-clone/assets/icon.svg", StepAssetPathFS("git-clone", "icon.svg"))
+	assert.Equal(t, "v2/steps/git-clone", StepDirFS("git-clone"))
+}


### PR DESCRIPTION
## What & why

**PR 1.5 of the V2 steplib series** — follows PR 1 (V2 wire types + inventory generator, now merged to master). It adds a structural validator that runs on every generation, makes `steplibindex` the single source of truth for the inventory layout, and locks the wire-format and determinism contracts in tests.

In one sentence: **make invalid V2 trees structurally impossible to publish, and lock the layout + wire-format contracts in tests.**

## How

### 1. `Validate` — `steplibrary/indexgen/validate.go` (new)

Walks a V2 inventory tree (rooted at the dir containing `v2/`) and returns the structural violations (`[]ValidationError`, sorted by `(Path, Msg)` for deterministic output):

| Tier | Asserts |
|---|---|
| Presence | `v2/meta.json`, `v2/index/step_ids.json` exist + parse. |
| Schema | `format_version` matches `steplibindex.FormatVersion`; `updated_at` non-zero; `step_ids` sorted + duplicate-free. |
| Cross-file | `latest.json#latest` is in `versions.json`; each `latest_by_major[N]` is in `versions.json` and prefixed `N.`; `step_id` in `latest.json`/`versions.json` equals the id. |
| Per-version | every version string in `versions.json` has a parseable `v2/steps/<id>/<v>/step.json` with non-empty `source.git` + `source.commit`. |
| Step info | `step-info.json` is mandatory (flagged if missing); every `asset_urls` entry must be a step-relative path — absolute URLs, absolute paths, and `../` traversal are flagged — that resolves to a real file on disk. |
| Stale | any file under `v2/steps/` or `v2/index/` not consumed above is flagged; a missing or unreadable expected root dir is itself a violation. |

### 2. Publish gate

The generator validates the fully-staged tree **before** its atomic publish rename; on any violation it returns an error and leaves any existing inventory at `outputDir` untouched. On success the published inventory is guaranteed to pass `Validate`. (Keeps PR 1's `Generate` API — no Stage/Publish split.)

### 3. `steplibindex` is the single source of truth for the layout — `paths.go` (new)

Every V2 file location is one constructor returning a `Path`, used by **both** the generator (write) and the validator/reader (read), so the two can't drift:
- `Path` exposes both forms, built once from the same segment list: `FS()` — slash path under the inventory root, for `fs.FS` lookups and the generator's writer; `URL()` — absolute, with `url.PathEscape` on the dynamic id/version segments, for the HTTP reader (PR 2).
- Dynamic segments are **validated** as safe single path components: a constructor returns an error if a segment is empty, `.`/`..`, or contains a path separator or NUL — so a crafted id can't read or write outside the step's subtree.
- The generator's writer is rooted at the inventory root and emits every path through these helpers (no hand-built literals), matching what the validator reads.

## Test guarantees

| File | Locks in |
|---|---|
| `validate_test.go` | each check fires on its specific corruption (missing meta, bad format_version, unsorted step_ids, latest → missing version, wrong `latest_by_major` major, missing step-info, absolute/traversing `asset_urls`, stale files, …); a freshly generated tree passes clean. |
| `roundtrip_integration_test.go` _(build tag `integration`)_ | every `step.yml` in the real default steplib round-trips to a `models.StepModel` whose JSON is semantically equal to the generated `step.json` (`assert.JSONEq`) — the V2 wire format is lossless against the runtime struct. |
| `determinism_test.go` | two generations with identical inputs produce byte-identical trees (per-file SHA-256). |
| `paths_test.go` | the FS and URL form of every path; `url.PathEscape` of dynamic segments (space, `?`, …) and rejection of unsafe segments (empty, `.`/`..`, separators). |

## Notable decisions

- **Validation is unconditional** — no skip flag. A failure is a bug worth blocking on.
- **`steplibindex` path constructors validate dynamic segments** — an unsafe id/version is rejected with an error, never spliced into a filesystem or URL path.
- **No `latest_versions.json` catalog and no `has_executable`** — dropped in the schema; the validator and paths reflect the `v2/index` layout with `versions`/`asset_urls` as string lists.
- **Round-trip compares via `assert.JSONEq`, not `reflect.DeepEqual`** — nil vs empty slice serialize identically under the wire contract.
- **Round-trip is a build-tagged integration test** (`//go:build integration`, runs against the real steplib, wired into the CI integration step) — excluded from a normal `go test ./...`. `generate_local_test.go` stays a `RUN_STEPLIB_GEN`-gated manual tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
