### PR TITLE
refactor(steplibrary): rename Steplib→Client, trim comments, map-driven fake

### DIFF
--- a/steplibrary/fakes_test.go
+++ b/steplibrary/fakes_test.go
@@ -11,69 +11,89 @@ import (
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
 )
 
-// FakeAPI is an in-memory API implementation used as a base for test fakes
-// that embed it and selectively override methods.
-type FakeAPI struct{}
-
-func (m FakeAPI) GetAllStepIDs(_ context.Context) ([]string, error) {
-	return []string{"xcode-test", "script"}, nil
+// fakeAPI is an in-memory API implementation driven entirely by its map
+// fixtures and injectable errors. Construct the standard "script" fixtures with
+// newFakeAPI; override individual fields for table-driven and error cases.
+type fakeAPI struct {
+	ids               []string
+	listErr           error
+	latestVersions    map[string]steplibindex.LatestPointer
+	latestVersionsErr error
+	allVersions       map[string][]string
+	allVersionsErr    error
+	groupInfo         map[string]steplibindex.StepInfo
+	groupInfoErr      error
+	stepModel         map[string]models.StepModel
 }
 
-func (m FakeAPI) GetLatestStepVersions(_ context.Context, id string) (steplibindex.LatestPointer, error) {
-	versions := map[string]steplibindex.LatestPointer{
-		"script": {
-			StepID: "script",
-			Latest: "3.0.0",
-			LatestByMajor: map[string]string{
-				"1": "1.2.0",
-				"2": "2.4.1",
-				"3": "3.0.0",
+// newFakeAPI returns a fakeAPI pre-populated with the standard "script" step
+// fixtures (versions 1.0.0–3.0.0, latest 3.0.0, bitrise maintainer, a minimal
+// step model).
+func newFakeAPI() fakeAPI {
+	return fakeAPI{
+		ids: []string{"xcode-test", "script"},
+		latestVersions: map[string]steplibindex.LatestPointer{
+			"script": {
+				StepID:        "script",
+				Latest:        "3.0.0",
+				LatestByMajor: map[string]string{"1": "1.2.0", "2": "2.4.1", "3": "3.0.0"},
 			},
 		},
+		allVersions: map[string][]string{
+			"script": {"1.0.0", "1.1.5", "1.2.0", "2.0.0", "2.4.0", "2.4.1", "3.0.0"},
+		},
+		groupInfo: map[string]steplibindex.StepInfo{
+			"script": {Maintainer: "bitrise", Deprecation: nil, AssetURLs: []string{"assets/icon.svg"}},
+		},
+		stepModel: map[string]models.StepModel{
+			"script": {Title: pointers.NewStringPtr("Script"), Summary: pointers.NewStringPtr("Runs a shell script.")},
+		},
 	}
+}
 
-	v, ok := versions[id]
+func (f fakeAPI) GetAllStepIDs(_ context.Context) ([]string, error) {
+	return f.ids, f.listErr
+}
+
+func (f fakeAPI) GetLatestStepVersions(_ context.Context, id string) (steplibindex.LatestPointer, error) {
+	if f.latestVersionsErr != nil {
+		return steplibindex.LatestPointer{}, f.latestVersionsErr
+	}
+	v, ok := f.latestVersions[id]
 	if !ok {
 		return steplibindex.LatestPointer{}, errors.New("not found")
 	}
 	return v, nil
 }
 
-func (m FakeAPI) GetAllStepVersions(_ context.Context, id string) ([]string, error) {
-	versions := map[string][]string{
-		"script": {"1.0.0", "1.1.5", "1.2.0", "2.0.0", "2.4.0", "2.4.1", "3.0.0"},
+func (f fakeAPI) GetAllStepVersions(_ context.Context, id string) ([]string, error) {
+	if f.allVersionsErr != nil {
+		return nil, f.allVersionsErr
 	}
-	v, ok := versions[id]
+	v, ok := f.allVersions[id]
 	if !ok {
 		return nil, errors.New("not found")
 	}
 	return v, nil
 }
 
-func (m FakeAPI) GetStepGroupInfo(_ context.Context, id string) (steplibindex.StepInfo, error) {
-	infos := map[string]steplibindex.StepInfo{
-		"script": {
-			Maintainer:  "bitrise",
-			Deprecation: nil,
-			AssetURLs:   []string{"assets/icon.svg"},
-		},
+func (f fakeAPI) GetStepGroupInfo(_ context.Context, id string) (steplibindex.StepInfo, error) {
+	if f.groupInfoErr != nil {
+		return steplibindex.StepInfo{}, f.groupInfoErr
 	}
-	v, ok := infos[id]
+	v, ok := f.groupInfo[id]
 	if !ok {
 		return steplibindex.StepInfo{}, errors.New("not found")
 	}
 	return v, nil
 }
 
-func (m FakeAPI) GetStepModel(_ context.Context, step ResolvedStepVersion) (models.StepModel, error) {
-	if step.ID != "script" {
+func (f fakeAPI) GetStepModel(_ context.Context, step ResolvedStepVersion) (models.StepModel, error) {
+	v, ok := f.stepModel[step.ID]
+	if !ok {
 		return models.StepModel{}, errors.New("not found")
 	}
-	//nolint:exhaustruct // mock returns a minimal StepModel
-	return models.StepModel{
-		Title:   pointers.NewStringPtr("Script"),
-		Summary: pointers.NewStringPtr("Runs a shell script."),
-	}, nil
+	return v, nil
 }
 
 // fakeGetFetcher implements httpfetch.Client.Get, returning a fixed body whose

--- a/steplibrary/http_api.go
+++ b/steplibrary/http_api.go
@@ -11,9 +11,8 @@ import (
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
 )
 
-// HTTPAPI fetches the V2 inventory layout (step_ids.json, latest.json,
-// versions.json, step-info.json, step.json) over HTTP from a base URL.
-// JSON endpoints are decoded in memory and returned as structs.
+// HTTPAPI fetches the V2 inventory (step_ids/latest/versions/step-info/step.json)
+// over HTTP from a base URL.
 type HTTPAPI struct {
 	BaseURL string
 	Fetcher httpfetch.Client
@@ -70,8 +69,6 @@ func (h *HTTPAPI) GetStepGroupInfo(ctx context.Context, id string) (steplibindex
 	return out, nil
 }
 
-// GetStepModel fetches the V2 step manifest (`steps/<id>/<v>/step.json`,
-// which serializes models.StepModel) and returns the decoded model.
 func (h *HTTPAPI) GetStepModel(ctx context.Context, step ResolvedStepVersion) (models.StepModel, error) {
 	p, err := steplibindex.StepJSONPath(step.ID, step.Version)
 	if err != nil {

--- a/steplibrary/resolve_version.go
+++ b/steplibrary/resolve_version.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
 )
 
-func (s *Steplib) getStepVersionInfo(ctx context.Context, stepID, version string) (models.StepInfoModel, ResolvedStepVersion, error) {
+func (c *Client) getStepVersionInfo(ctx context.Context, stepID, version string) (models.StepInfoModel, ResolvedStepVersion, error) {
 	if stepID == "" {
 		return models.StepInfoModel{}, ResolvedStepVersion{}, errors.New("missing required input: step id")
 	}
@@ -25,32 +25,32 @@ func (s *Steplib) getStepVersionInfo(ctx context.Context, stepID, version string
 		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("invalid step version constraint: %s", version)
 	}
 
-	allSteps, err := s.api.GetAllStepIDs(ctx)
+	allSteps, err := c.api.GetAllStepIDs(ctx)
 	if err != nil {
 		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("fetching available step IDs: %w", err)
 	}
 	if !slices.Contains(allSteps, stepID) {
-		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("%s steplib does not contain %s step", s.steplibURI, stepID)
+		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("%s steplib does not contain %s step", c.steplibURI, stepID)
 	}
 
-	latestVersions, err := s.api.GetLatestStepVersions(ctx, stepID)
+	latestVersions, err := c.api.GetLatestStepVersions(ctx, stepID)
 	if err != nil {
 		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("fetching latest versions of `%s`: %w", stepID, err)
 	}
 
-	groupInfo, err := s.api.GetStepGroupInfo(ctx, stepID)
+	groupInfo, err := c.api.GetStepGroupInfo(ctx, stepID)
 	if err != nil {
 		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("fetching group info of `%s`: %w", stepID, err)
 	}
 
-	resolvedVersion, err := s.resolveVersion(ctx, stepID, version, versionConstraint, latestVersions)
+	resolvedVersion, err := c.resolveVersion(ctx, stepID, version, versionConstraint, latestVersions)
 	if err != nil {
 		return models.StepInfoModel{}, ResolvedStepVersion{}, err
 	}
 
 	//nolint:exhaustruct // Step and DefinitionPth aren't surfaced by the v2 API yet
 	return models.StepInfoModel{
-		Library:         s.steplibURI,
+		Library:         c.steplibURI,
 		ID:              stepID,
 		Version:         resolvedVersion,
 		OriginalVersion: version,
@@ -61,7 +61,7 @@ func (s *Steplib) getStepVersionInfo(ctx context.Context, stepID, version string
 
 // resolveVersion turns a parsed version constraint into a concrete version
 // string, fetching the step's version list when the constraint needs it.
-func (s *Steplib) resolveVersion(ctx context.Context, stepID, version string, constraint models.VersionConstraint, latestVersions steplibindex.LatestPointer) (string, error) {
+func (c *Client) resolveVersion(ctx context.Context, stepID, version string, constraint models.VersionConstraint, latestVersions steplibindex.LatestPointer) (string, error) {
 	switch constraint.VersionLockType {
 	case models.Latest:
 		return latestVersions.Latest, nil
@@ -70,29 +70,29 @@ func (s *Steplib) resolveVersion(ctx context.Context, stepID, version string, co
 		// Verify the pinned version actually exists; otherwise a typo'd pin
 		// surfaces later as an opaque fetch/decode error instead of a clear
 		// "no such version".
-		allVersions, err := s.api.GetAllStepVersions(ctx, stepID)
+		allVersions, err := c.api.GetAllStepVersions(ctx, stepID)
 		if err != nil {
 			return "", fmt.Errorf("fetching all versions of `%s`: %w", stepID, err)
 		}
 		if !slices.Contains(allVersions, resolved) {
-			return "", fmt.Errorf("%s steplib does not contain %s step %s version", s.steplibURI, stepID, resolved)
+			return "", fmt.Errorf("%s steplib does not contain %s step %s version", c.steplibURI, stepID, resolved)
 		}
 		return resolved, nil
 	case models.MajorLocked:
 		majorKey := strconv.FormatUint(constraint.Version.Major, 10)
 		v, ok := latestVersions.LatestByMajor[majorKey]
 		if !ok {
-			return "", fmt.Errorf("%s steplib does not contain %s step with major version %s", s.steplibURI, stepID, majorKey)
+			return "", fmt.Errorf("%s steplib does not contain %s step with major version %s", c.steplibURI, stepID, majorKey)
 		}
 		return v, nil
 	case models.MinorLocked:
-		allVersions, err := s.api.GetAllStepVersions(ctx, stepID)
+		allVersions, err := c.api.GetAllStepVersions(ctx, stepID)
 		if err != nil {
 			return "", fmt.Errorf("fetching all versions of `%s`: %w", stepID, err)
 		}
 		resolved, err := resolveMinorLocked(allVersions, constraint.Version)
 		if err != nil {
-			return "", fmt.Errorf("%s steplib: %w", s.steplibURI, err)
+			return "", fmt.Errorf("%s steplib: %w", c.steplibURI, err)
 		}
 		return resolved, nil
 	default:

--- a/steplibrary/resolve_version.go
+++ b/steplibrary/resolve_version.go
@@ -67,9 +67,8 @@ func (c *Client) resolveVersion(ctx context.Context, stepID, version string, con
 		return latestVersions.Latest, nil
 	case models.Fixed:
 		resolved := constraint.Version.String()
-		// Verify the pinned version actually exists; otherwise a typo'd pin
-		// surfaces later as an opaque fetch/decode error instead of a clear
-		// "no such version".
+		// Verify the pin exists now, so a typo fails clearly instead of as an
+		// opaque fetch error later.
 		allVersions, err := c.api.GetAllStepVersions(ctx, stepID)
 		if err != nil {
 			return "", fmt.Errorf("fetching all versions of `%s`: %w", stepID, err)
@@ -100,12 +99,11 @@ func (c *Client) resolveVersion(ctx context.Context, stepID, version string, con
 	}
 }
 
-// toStepGroupInfoModel flattens v2's nested `deprecation` object into v1's
-// `RemovalDate` + `DeprecateNotes` fields so the rest of the codebase keeps
-// reading the same model shape.
+// toStepGroupInfoModel flattens v2's nested `deprecation` object into v1's flat
+// RemovalDate + DeprecateNotes fields.
 func toStepGroupInfoModel(info steplibindex.StepInfo) models.StepGroupInfoModel {
-	// v2's asset_urls is a []string of step-relative URLs; v1's model keys them
-	// by asset filename. Rebuild that map (e.g. "assets/icon.svg" -> {"icon.svg": ...}).
+	// v2 asset_urls is a []string of step-relative URLs; v1 keys them by filename
+	// (e.g. "assets/icon.svg" -> {"icon.svg": ...}).
 	var assetURLs map[string]string
 	if len(info.AssetURLs) > 0 {
 		assetURLs = make(map[string]string, len(info.AssetURLs))

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type Steplib struct {
+type Client struct {
 	log stepman.Logger
 	// steplibURI is set by the `default_step_lib_source` property in bitrise.yml
 	steplibURI  string
@@ -22,10 +22,10 @@ type ActivateOutputPaths struct {
 	YMLPath, CodePath string
 }
 
-// New builds a Steplib. steplibURI is the steplib identity; inventoryURL is
+// New builds a Client. steplibURI is the steplib identity; inventoryURL is
 // the base URL the V2 inventory JSON is fetched from.
-func New(log stepman.Logger, steplibURI, inventoryURL string, fileManager fileutil.FileManager) *Steplib {
-	return &Steplib{
+func New(log stepman.Logger, steplibURI, inventoryURL string, fileManager fileutil.FileManager) *Client {
+	return &Client{
 		log:         log,
 		steplibURI:  steplibURI,
 		api:         NewHTTPAPI(inventoryURL, httpfetch.NewClient(log)),
@@ -33,13 +33,13 @@ func New(log stepman.Logger, steplibURI, inventoryURL string, fileManager fileut
 	}
 }
 
-func (s *Steplib) Activate(ctx context.Context, stepID, version string, outputPaths ActivateOutputPaths) (ActivatedStep, error) {
-	stepInfo, resolved, err := s.getStepVersionInfo(ctx, stepID, version)
+func (c *Client) Activate(ctx context.Context, stepID, version string, outputPaths ActivateOutputPaths) (ActivatedStep, error) {
+	stepInfo, resolved, err := c.getStepVersionInfo(ctx, stepID, version)
 	if err != nil {
 		return ActivatedStep{}, fmt.Errorf("resolve step version: %w", err)
 	}
 
-	stepModel, err := s.api.GetStepModel(ctx, resolved)
+	stepModel, err := c.api.GetStepModel(ctx, resolved)
 	if err != nil {
 		return ActivatedStep{}, fmt.Errorf("fetch step definition: %w", err)
 	}
@@ -49,7 +49,7 @@ func (s *Steplib) Activate(ctx context.Context, stepID, version string, outputPa
 		return ActivatedStep{}, fmt.Errorf("marshal step model to YAML: %w", err)
 	}
 
-	if err := s.fileManager.WriteBytes(outputPaths.YMLPath, stepYML); err != nil {
+	if err := c.fileManager.WriteBytes(outputPaths.YMLPath, stepYML); err != nil {
 		return ActivatedStep{}, fmt.Errorf("write step.yml: %w", err)
 	}
 

--- a/steplibrary/steplibrary_test.go
+++ b/steplibrary/steplibrary_test.go
@@ -74,7 +74,7 @@ func TestSteplib_getStepVersionInfo(t *testing.T) {
 		"invalid version constraint":         {stepID: "script", version: "1.2.3.4", wantErr: true},
 	}
 
-	s := &Steplib{
+	client := &Client{
 		log:         nil,
 		steplibURI:  "https://steplib.example",
 		api:         FakeAPI{},
@@ -83,7 +83,7 @@ func TestSteplib_getStepVersionInfo(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			stepInfo, resolved, gotErr := s.getStepVersionInfo(t.Context(), tc.stepID, tc.version)
+			stepInfo, resolved, gotErr := client.getStepVersionInfo(t.Context(), tc.stepID, tc.version)
 			if tc.wantErr {
 				require.Error(t, gotErr)
 				return

--- a/steplibrary/steplibrary_test.go
+++ b/steplibrary/steplibrary_test.go
@@ -54,7 +54,7 @@ func TestToStepGroupInfoModel(t *testing.T) {
 }
 
 func TestSteplib_getStepVersionInfo(t *testing.T) {
-	// FakeAPI's "script" step exposes versions 1.0.0, 1.1.5, 1.2.0, 2.0.0,
+	// newFakeAPI's "script" step exposes versions 1.0.0, 1.1.5, 1.2.0, 2.0.0,
 	// 2.4.0, 2.4.1, 3.0.0 with latest 3.0.0 and latest-by-major 1→1.2.0,
 	// 2→2.4.1, 3→3.0.0.
 	cases := map[string]struct {
@@ -77,7 +77,7 @@ func TestSteplib_getStepVersionInfo(t *testing.T) {
 	client := &Client{
 		log:         nil,
 		steplibURI:  "https://steplib.example",
-		api:         FakeAPI{},
+		api:         newFakeAPI(),
 		fileManager: nil,
 	}
 


### PR DESCRIPTION
## Summary
Ancillary cleanup of the V2 read path (PR2, #377), with no behavior change. This is the **base of a 3-PR stack** that was split out of #378:
1. **(this) ancillary** — rename + comments + test fake
2. precompiled binary download (stacks on this)
3. source-resolution consolidation (stacks on 2)

## Changes
- Rename `steplibrary.Steplib` → `Client` (avoids the `steplibrary.Steplibrary` stutter); receivers become `c`.
- Trim verbose doc comments (`HTTPAPI`, `GetStepModel`, the version resolver) to what isn't obvious from the code.
- Replace the canned `FakeAPI` test fake with a single map-driven `fakeAPI` + `newFakeAPI()` constructor, so the downstream feature PRs can override fields without a second fake type.

## Test plan
- [x] `go test ./steplibrary/...`
- [x] `golangci-lint run ./steplibrary/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)