### PR TITLE
refactor: consolidate V1 source resolution into stepman.GetStepSourceDir

### DIFF
--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -45,7 +45,7 @@ func ActivateStep(stepLibURI, id, version, destination, destinationStepYML strin
 			log.Infof("No prebuilt executable found for %s, fallback to step source activation", platform)
 		}
 	}
-	err = activateStepSource(stepCollection, stepLibURI, id, version, step, destination, destinationStepYML, log, isOfflineMode)
+	err = activateStepSource(stepCollection, stepLibURI, id, version, destination, destinationStepYML, log, isOfflineMode)
 	return "", err
 }
 

--- a/activator/steplib/activate_source.go
+++ b/activator/steplib/activate_source.go
@@ -1,6 +1,7 @@
 package steplib
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -13,33 +14,17 @@ import (
 func activateStepSource(
 	stepLib models.StepCollectionModel,
 	stepLibURI, id, version string,
-	step models.StepModel,
 	destination string,
 	stepYMLDestination string,
 	log stepman.Logger,
 	isOfflineMode bool,
 ) error {
-	route, found := stepman.ReadRoute(stepLibURI)
-	if !found {
-		return fmt.Errorf("no route found for %s steplib", stepLibURI)
+	stepCacheDir, err := stepman.GetStepSourceDir(stepLibURI, id, version, log, isOfflineMode)
+	if errors.Is(err, stepman.ErrStepSourceNotCached) {
+		return fmt.Errorf("download step: %s", collectOfflineAvailableStepVersions(stepLib, stepLibURI, id, log))
 	}
-
-	stepCacheDir := stepman.GetStepCacheDirPath(route, id, version)
-	stepCacheDirExists, err := pathutil.IsPathExists(stepCacheDir)
 	if err != nil {
-		return fmt.Errorf("failed to check if %s path exist: %s", stepCacheDir, err)
-	}
-
-	if !stepCacheDirExists {
-		if isOfflineMode {
-			errMsg := collectOfflineAvailableStepVersions(stepLib, stepLibURI, id, log)
-			return fmt.Errorf("download step: %s", errMsg)
-		}
-
-		err := stepman.DownloadStep(stepLibURI, stepLib, id, version, step.Source.Commit, log)
-		if err != nil {
-			return fmt.Errorf("download failed: %s", err)
-		}
+		return err
 	}
 
 	if err := copyStep(stepCacheDir, destination); err != nil {

--- a/steplibrary/fakes_test.go
+++ b/steplibrary/fakes_test.go
@@ -152,6 +152,17 @@ func (f fakeGetFetcher) DownloadWithHash(_ context.Context, _, _, _ string) erro
 	return errors.New("DownloadWithHash not used")
 }
 
+// stubSource is a sourceProvider that returns a fixed dir/err, standing in for
+// the V1-cache-backed v1Source in activation tests.
+type stubSource struct {
+	dir string
+	err error
+}
+
+func (s stubSource) stepSourceDir(context.Context, ResolvedStepVersion) (string, error) {
+	return s.dir, s.err
+}
+
 // errReadCloser wraps a reader and returns closeErr from Close.
 type errReadCloser struct {
 	io.Reader
@@ -163,6 +174,18 @@ func (e errReadCloser) Close() error { return e.closeErr }
 func sha256OfBytes(b []byte) string {
 	h := sha256.Sum256(b)
 	return "sha256-" + hex.EncodeToString(h[:])
+}
+
+// writeSeedDir creates a directory containing a single step source file, used
+// as a stand-in for the V1 cache dir that getStepSourceDir returns.
+func writeSeedDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create seed dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "step.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
 }
 
 // testLogger routes stepman log output to t.Log: quiet on success, surfaced on failure.

--- a/steplibrary/precompiled_test.go
+++ b/steplibrary/precompiled_test.go
@@ -76,6 +76,48 @@ func TestSteplib_Activate_Precompiled(t *testing.T) {
 		"downloader URL = %q, want suffix %q", dl.gotURL, executables[currentPlatform()].StorageURI)
 }
 
+func TestSteplib_Activate_PrecompiledHashMismatch_FallsBackToSource(t *testing.T) {
+	payload := []byte("bad-bytes")
+
+	executables := models.Executables{
+		currentPlatform(): models.Executable{
+			StorageURI: "steps/script/3.0.0/bin/script-" + currentPlatform(),
+			Hash:       "sha256-deadbeef", // intentional mismatch
+		},
+	}
+	//nolint:exhaustruct
+	stepModel := models.StepModel{
+		Title:       strPtr("Script"),
+		Executables: &executables,
+	}
+
+	// Seed a real source dir for the fallback path.
+	tmpDir := t.TempDir()
+	sourceDir := filepath.Join(tmpDir, "source-step")
+	writeSeedDir(t, sourceDir)
+
+	api := newFakeAPI()
+	api.stepModel = map[string]models.StepModel{"script": stepModel}
+
+	outDir := t.TempDir()
+	client := &Client{
+		log:         testLogger{t},
+		steplibURI:  "https://github.com/bitrise-io/bitrise-steplib.git",
+		api:         api,
+		fileManager: fileutil.NewFileManager(),
+		fetcher:     &fakeFetcher{payload: payload},
+		source:      stubSource{dir: sourceDir},
+	}
+
+	got, gotErr := client.Activate(context.Background(), "script", "", ActivateOutputPaths{
+		YMLPath:  filepath.Join(outDir, "current_step.yml"),
+		CodePath: filepath.Join(outDir, "code"),
+	})
+	require.NoError(t, gotErr, "Activate")
+	assert.Empty(t, got.ExecutablePath, "want empty ExecutablePath (precompiled failed → source path)")
+	assert.Equal(t, "steplib_source", string(got.ActivationType), "ActivationType")
+}
+
 // pointers returns a pointer to the given string. Avoids importing
 // go-utils/pointers just for a single helper.
 func strPtr(s string) *string { return &s }

--- a/steplibrary/source.go
+++ b/steplibrary/source.go
@@ -1,0 +1,25 @@
+package steplibrary
+
+import (
+	"context"
+
+	"github.com/bitrise-io/stepman/stepman"
+)
+
+// sourceProvider resolves the local directory holding a step's extracted
+// source for a resolved version. Client depends on this interface so the
+// source layer can be faked in tests without a function field.
+type sourceProvider interface {
+	stepSourceDir(ctx context.Context, step ResolvedStepVersion) (string, error)
+}
+
+// v1Source resolves step source through stepman's V1 on-disk cache.
+type v1Source struct {
+	steplibURI    string
+	isOfflineMode bool
+	log           stepman.Logger
+}
+
+func (p v1Source) stepSourceDir(_ context.Context, step ResolvedStepVersion) (string, error) {
+	return stepman.GetStepSourceDir(p.steplibURI, step.ID, step.Version, p.log, p.isOfflineMode)
+}

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -17,21 +17,24 @@ type Client struct {
 	api         API
 	fileManager fileutil.FileManager
 	fetcher     httpfetch.Client
+	source      sourceProvider
 }
 
 type ActivateOutputPaths struct {
 	YMLPath, CodePath string
 }
 
-// New builds a Client. steplibURI is the steplib identity; inventoryURL is the
-// base URL the V2 inventory JSON is fetched from.
-func New(log stepman.Logger, steplibURI, inventoryURL string, fileManager fileutil.FileManager) *Client {
+// New builds a Client. steplibURI is the steplib identity (used for the V1
+// cache and source fallback); inventoryURL is the base URL the V2 inventory
+// JSON is fetched from.
+func New(log stepman.Logger, steplibURI, inventoryURL string, isOfflineMode bool, fileManager fileutil.FileManager) *Client {
 	return &Client{
 		log:         log,
 		steplibURI:  steplibURI,
 		api:         NewHTTPAPI(inventoryURL, httpfetch.NewClient(log)),
 		fileManager: fileManager,
 		fetcher:     httpfetch.NewClient(log),
+		source:      v1Source{steplibURI: steplibURI, isOfflineMode: isOfflineMode, log: log},
 	}
 }
 
@@ -47,7 +50,8 @@ func (c *Client) Activate(ctx context.Context, stepID, version string, outputPat
 	}
 
 	// Prefer the precompiled binary for the current platform when the experiment
-	// is enabled and the step publishes one; on any failure fall back to source.
+	// is enabled and the step publishes one; fall back to source on any failure
+	// so a single broken executable can't block activation.
 	execPath := ""
 	if PrecompiledStepsEnabled() {
 		if executable, platform, ok := ResolveExecutable(stepModel); ok {
@@ -57,6 +61,16 @@ func (c *Client) Activate(ctx context.Context, stepID, version string, outputPat
 			} else {
 				execPath = path
 			}
+		}
+	}
+
+	if execPath == "" {
+		srcDir, err := c.source.stepSourceDir(ctx, resolved)
+		if err != nil {
+			return ActivatedStep{}, fmt.Errorf("resolve step source: %w", err)
+		}
+		if err := c.fileManager.CopyDir(srcDir, outputPaths.CodePath, &fileutil.CopyOptions{Overwrite: true}); err != nil {
+			return ActivatedStep{}, fmt.Errorf("copy step source %s to %s: %w", srcDir, outputPaths.CodePath, err)
 		}
 	}
 

--- a/steplibrary/steplibrary_test.go
+++ b/steplibrary/steplibrary_test.go
@@ -1,13 +1,151 @@
 package steplibrary
 
 import (
+	"context"
+	"errors"
+	"path/filepath"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/v2/fileutil"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSteplib_Activate(t *testing.T) {
+	tmpDir := t.TempDir()
+	sourceDir := filepath.Join(tmpDir, "source-step")
+	writeSeedDir(t, sourceDir)
+
+	givenScriptOnly := newFakeAPI()
+
+	cases := map[string]struct {
+		api         API
+		stepID      string
+		version     string
+		wantVersion string
+		wantLatest  string
+		wantErr     string
+	}{
+		"empty step id returns validation error": {
+			api:     fakeAPI{},
+			stepID:  "",
+			wantErr: "missing required input",
+		},
+		"step not in collection": {
+			api:     fakeAPI{ids: []string{"script"}},
+			stepID:  "xcode-test",
+			wantErr: "steplib does not contain xcode-test step",
+		},
+		"invalid version constraint": {
+			api:     givenScriptOnly,
+			stepID:  "script",
+			version: "not-a-version",
+			wantErr: "invalid step version constraint",
+		},
+		"empty version resolves to latest": {
+			api:         givenScriptOnly,
+			stepID:      "script",
+			version:     "",
+			wantVersion: "3.0.0",
+			wantLatest:  "3.0.0",
+		},
+		"fixed version resolves to requested": {
+			api:         givenScriptOnly,
+			stepID:      "script",
+			version:     "1.2.0",
+			wantVersion: "1.2.0",
+			wantLatest:  "3.0.0",
+		},
+		"fixed version not in steplib errors": {
+			api:     givenScriptOnly,
+			stepID:  "script",
+			version: "9.9.9",
+			wantErr: "does not contain script step 9.9.9 version",
+		},
+		"major-locked resolves via latest_by_major": {
+			api:         givenScriptOnly,
+			stepID:      "script",
+			version:     "2",
+			wantVersion: "2.4.1",
+			wantLatest:  "3.0.0",
+		},
+		"major-locked with unknown major errors": {
+			api:     givenScriptOnly,
+			stepID:  "script",
+			version: "99",
+			wantErr: "does not contain script step with major version 99",
+		},
+		"minor-locked resolves to highest matching patch": {
+			api:         givenScriptOnly,
+			stepID:      "script",
+			version:     "1.1",
+			wantVersion: "1.1.5",
+			wantLatest:  "3.0.0",
+		},
+		"minor-locked with no matching minor errors": {
+			api:     givenScriptOnly,
+			stepID:  "script",
+			version: "1.9",
+			wantErr: "no version matches 1.9.x",
+		},
+		"list error propagates": {
+			api:     fakeAPI{listErr: errors.New("boom")},
+			stepID:  "script",
+			wantErr: "fetching available step IDs",
+		},
+		"latest versions error propagates": {
+			api: fakeAPI{
+				ids:               []string{"script"},
+				latestVersionsErr: errors.New("kaboom"),
+			},
+			stepID:  "script",
+			wantErr: "fetching latest versions of `script`",
+		},
+		"group info error propagates": {
+			api: fakeAPI{
+				ids: []string{"script"},
+				latestVersions: map[string]steplibindex.LatestPointer{
+					"script": {StepID: "script", Latest: "3.0.0"},
+				},
+				groupInfoErr: errors.New("infoboom"),
+			},
+			stepID:  "script",
+			wantErr: "fetching group info of `script`",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := &Client{
+				log:         testLogger{t},
+				steplibURI:  "https://github.com/bitrise-io/bitrise-steplib.git",
+				api:         tc.api,
+				fileManager: fileutil.NewFileManager(),
+				source:      stubSource{dir: sourceDir},
+			}
+			outDir := t.TempDir()
+			outPaths := ActivateOutputPaths{
+				YMLPath:  filepath.Join(outDir, "current_step.yml"),
+				CodePath: filepath.Join(outDir, "code"),
+			}
+			got, gotErr := client.Activate(context.Background(), tc.stepID, tc.version, outPaths)
+			if tc.wantErr != "" {
+				require.Errorf(t, gotErr, "Activate(%q, %q)", tc.stepID, tc.version)
+				assert.Containsf(t, gotErr.Error(), tc.wantErr, "Activate(%q, %q) error message", tc.stepID, tc.version)
+				return
+			}
+			require.NoErrorf(t, gotErr, "Activate(%q, %q)", tc.stepID, tc.version)
+			assert.Equal(t, tc.stepID, got.StepInfo.ID, "StepInfo.ID")
+			assert.Equal(t, tc.wantVersion, got.StepInfo.Version, "StepInfo.Version")
+			assert.Equal(t, tc.wantLatest, got.StepInfo.LatestVersion, "StepInfo.LatestVersion")
+			assert.Equal(t, tc.version, got.StepInfo.OriginalVersion, "StepInfo.OriginalVersion")
+			assert.Equal(t, "bitrise", got.StepInfo.GroupInfo.Maintainer, "StepInfo.GroupInfo.Maintainer")
+			assert.Equal(t, "assets/icon.svg", got.StepInfo.GroupInfo.AssetURLs["icon.svg"], "StepInfo.GroupInfo.AssetURLs[icon.svg]")
+		})
+	}
+}
 
 func TestToStepGroupInfoModel(t *testing.T) {
 	cases := map[string]struct {

--- a/stepman/source.go
+++ b/stepman/source.go
@@ -1,0 +1,56 @@
+package stepman
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+// ErrStepSourceNotCached is returned by GetStepSourceDir in offline mode when
+// the requested version isn't already in the local cache. Callers may match it
+// via errors.Is to build a richer message.
+var ErrStepSourceNotCached = errors.New("step source not available in the local cache and offline mode is set")
+
+// GetStepSourceDir returns the local cache directory holding the extracted
+// source for id@version of the steplib at uri, downloading it via DownloadStep
+// (zip+git fallback, retries, commit verification) if absent. The cache is
+// immutable per version, so an existing dir is returned as-is. In offline mode
+// a missing version returns an error wrapping ErrStepSourceNotCached.
+func GetStepSourceDir(uri, id, version string, log Logger, isOfflineMode bool) (string, error) {
+	route, found := ReadRoute(uri)
+	if !found {
+		return "", fmt.Errorf("no route found for %s steplib", uri)
+	}
+	cacheDir := GetStepCacheDirPath(route, id, version)
+
+	exists, err := pathutil.IsPathExists(cacheDir)
+	if err != nil {
+		return "", fmt.Errorf("check if %s exists: %w", cacheDir, err)
+	}
+	if exists {
+		return cacheDir, nil
+	}
+
+	if isOfflineMode {
+		return "", fmt.Errorf("%s@%s: %w", id, version, ErrStepSourceNotCached)
+	}
+
+	collection, err := ReadStepSpec(uri)
+	if err != nil {
+		return "", fmt.Errorf("read steplib spec for %s: %w", uri, err)
+	}
+	step, stepFound, versionFound := collection.GetStep(id, version)
+	if !stepFound || !versionFound {
+		return "", fmt.Errorf("%s steplib does not contain %s@%s", uri, id, version)
+	}
+	commit := ""
+	if step.Source != nil {
+		commit = step.Source.Commit
+	}
+
+	if err := DownloadStep(uri, collection, id, version, commit, log); err != nil {
+		return "", fmt.Errorf("download step %s@%s: %w", id, version, err)
+	}
+	return cacheDir, nil
+}


### PR DESCRIPTION
## Summary
Adds the **V1 source fallback** to V2 activation and consolidates source resolution into one shared `stepman` helper used by both the V2 reader and the legacy activator. Final PR of the stack (on #385).

## Commits
1. **add** `stepman.GetStepSourceDir` (+ `ErrStepSourceNotCached`) — the V1 cache-resolve-or-download dance (`ReadRoute`/`GetStepCacheDirPath`/`ReadStepSpec`/`DownloadStep`).
2. **steplibrary** — `Client.Activate` falls back to source when no precompiled binary is used: resolve via a `sourceProvider` (`v1Source`, delegating to `GetStepSourceDir`) and copy into the work dir. Adds the `source` field + `isOfflineMode` to `New`, and the source/fallback tests.
3. **activator/steplib** — `activateStepSource` delegates to the shared helper too; the rich offline cached-versions error is preserved via `errors.Is(ErrStepSourceNotCached)`. Drops the now-unused `step` param.

`stepman` stays a leaf package (imports neither `steplibrary` nor `activator`).

## Test plan
- [x] `go test ./...`, `golangci-lint run ./stepman/... ./steplibrary/... ./activator/...`
- [x] `TestSteplib_Activate`, `TestSteplib_Activate_PrecompiledHashMismatch_FallsBackToSource`

🤖 Generated with [Claude Code](https://claude.com/claude-code)