### PR TITLE
Move activator types back to activator package

### DIFF
--- a/activator/activate_ref_test.go
+++ b/activator/activate_ref_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/stepman/stepid"
-	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +43,7 @@ func TestActivatePathRefStep(t *testing.T) {
 	absStepSrcDir, err := pathutil.AbsPath(stepSrcDir)
 	require.NoError(t, err)
 
-	require.Equal(t, steplibrary.ActivationTypePathRef, got.ActivationType)
+	require.Equal(t, ActivationTypePathRef, got.ActivationType)
 	require.Equal(t, filepath.Join(workDir, "current_step.yml"), got.StepYMLPath)
 	require.Equal(t, "path", got.StepInfo.Library)
 	require.Equal(t, absStepSrcDir, got.StepInfo.ID)
@@ -65,7 +64,7 @@ func TestActivateGitRefStep(t *testing.T) {
 	got, err := ActivateGitRefStep(TestLogger[*testing.T]{t}, id, activatedStepDir, workDir)
 	require.NoError(t, err)
 
-	require.Equal(t, steplibrary.ActivationTypeGitRef, got.ActivationType)
+	require.Equal(t, ActivationTypeGitRef, got.ActivationType)
 	require.Equal(t, filepath.Join(workDir, "current_step.yml"), got.StepYMLPath)
 	require.Equal(t, "git", got.StepInfo.Library)
 	require.Equal(t, srcRepoDir, got.StepInfo.ID)

--- a/activator/git_ref.go
+++ b/activator/git_ref.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/command/git"
 	"github.com/bitrise-io/stepman/stepid"
-	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
 )
 
@@ -19,10 +18,10 @@ func ActivateGitRefStep(
 	id stepid.CanonicalID,
 	activatedStepDir string,
 	workDir string,
-) (steplibrary.ActivatedStep, error) {
+) (ActivatedStep, error) {
 	repo, err := git.New(activatedStepDir)
 	if err != nil {
-		return steplibrary.ActivatedStep{}, err
+		return ActivatedStep{},err
 	}
 
 	var cloneCmd *command.Model
@@ -40,26 +39,26 @@ even if the repository is open source!`)
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return steplibrary.ActivatedStep{}, fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), cloneCmd.PrintableCommandArgs(), errors.New(out))
+			return ActivatedStep{},fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), cloneCmd.PrintableCommandArgs(), errors.New(out))
 		}
-		return steplibrary.ActivatedStep{}, err
+		return ActivatedStep{},err
 	}
 
 	stepYMLPath := filepath.Join(workDir, "current_step.yml")
 	if err := command.CopyFile(filepath.Join(activatedStepDir, "step.yml"), stepYMLPath); err != nil {
-		return steplibrary.ActivatedStep{}, err
+		return ActivatedStep{},err
 	}
 
 	stepInfo, err := stepman.QueryStepInfoFromGitStepDir(activatedStepDir, id.IDorURI, id.Version)
 	if err != nil {
-		return steplibrary.ActivatedStep{}, err
+		return ActivatedStep{},err
 	}
 
-	return steplibrary.ActivatedStep{
+	return ActivatedStep{
 		StepInfo:         stepInfo,
 		StepYMLPath:      stepYMLPath,
 		DidStepLibUpdate: false,
-		ActivationType:   steplibrary.ActivationTypeGitRef,
+		ActivationType:   ActivationTypeGitRef,
 		ExecutablePath:   "",
 	}, nil
 }

--- a/activator/path_ref.go
+++ b/activator/path_ref.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/stepman/stepid"
-	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
 )
 
@@ -16,19 +15,19 @@ func ActivatePathRefStep(
 	id stepid.CanonicalID,
 	activatedStepDir string,
 	workDir string,
-) (steplibrary.ActivatedStep, error) {
+) (ActivatedStep, error) {
 	log.Debugf("Local step found: (path:%s)", id.IDorURI)
 	// id.IDorURI is a path to the step dir in this case
 	stepAbsLocalPth, err := pathutil.AbsPath(id.IDorURI)
 	if err != nil {
-		return steplibrary.ActivatedStep{}, err
+		return ActivatedStep{}, err
 	}
 
 	exist, err := pathutil.IsDirExists(stepAbsLocalPth)
 	if err != nil {
-		return steplibrary.ActivatedStep{}, fmt.Errorf("check if a directory exists at %s: %w", stepAbsLocalPth, err)
+		return ActivatedStep{}, fmt.Errorf("check if a directory exists at %s: %w", stepAbsLocalPth, err)
 	} else if !exist {
-		return steplibrary.ActivatedStep{}, fmt.Errorf("the provided directory doesn't exist: %s", stepAbsLocalPth)
+		return ActivatedStep{}, fmt.Errorf("the provided directory doesn't exist: %s", stepAbsLocalPth)
 	}
 
 	log.Debugf("stepAbsLocalPth: %s, stepDir:%s", stepAbsLocalPth, activatedStepDir)
@@ -36,30 +35,30 @@ func ActivatePathRefStep(
 	origStepYMLPth := filepath.Join(stepAbsLocalPth, "step.yml")
 	exist, err = pathutil.IsPathExists(origStepYMLPth)
 	if err != nil {
-		return steplibrary.ActivatedStep{}, fmt.Errorf("check if step.yml exists at %s: %w", origStepYMLPth, err)
+		return ActivatedStep{}, fmt.Errorf("check if step.yml exists at %s: %w", origStepYMLPth, err)
 	} else if !exist {
-		return steplibrary.ActivatedStep{}, fmt.Errorf("step.yml doesn't exist at %s", origStepYMLPth)
+		return ActivatedStep{}, fmt.Errorf("step.yml doesn't exist at %s", origStepYMLPth)
 	}
 
 	activatedStepYMLPath := filepath.Join(workDir, "current_step.yml")
 	if err := command.CopyFile(origStepYMLPth, activatedStepYMLPath); err != nil {
-		return steplibrary.ActivatedStep{}, err
+		return ActivatedStep{}, err
 	}
 
 	if err := command.CopyDir(stepAbsLocalPth, activatedStepDir, true); err != nil {
-		return steplibrary.ActivatedStep{}, err
+		return ActivatedStep{}, err
 	}
 
 	stepInfo, err := stepman.QueryStepInfoFromPath(stepAbsLocalPth)
 	if err != nil {
-		return steplibrary.ActivatedStep{}, err
+		return ActivatedStep{}, err
 	}
 
-	return steplibrary.ActivatedStep{
+	return ActivatedStep{
 		StepInfo:         stepInfo,
 		StepYMLPath:      activatedStepYMLPath,
 		DidStepLibUpdate: false,
-		ActivationType:   steplibrary.ActivationTypePathRef,
+		ActivationType:   ActivationTypePathRef,
 		ExecutablePath:   "",
 	}, nil
 }

--- a/activator/result.go
+++ b/activator/result.go
@@ -1,0 +1,33 @@
+package activator
+
+import "github.com/bitrise-io/stepman/models"
+
+type ActivatedStep struct {
+	StepInfo models.StepInfoModel
+
+	StepYMLPath string
+
+	ActivationType ActivationType
+
+	// ExecutablePath is a local path to the main entrypoint of the step, ready for execution.
+	// This can be an empty string if:
+	// - step was activated from a git reference (we checked out the source dir directly)
+	// - step was activated from a local path (we copied the source dir directly)
+	// - step was activated from a steplib reference, but step.yml has no entry for pre-compiled binaries (we fallback to source checkout)
+	// - step was activated from a steplib reference, but step.yml has no pre-compiled binary for the current OS+arch combo (we fallback to source checkout)
+	ExecutablePath string
+
+	// DidStepLibUpdate indicates that the local steplib cache was updated while resolving the exact step version.
+	// TODO: this is a leaky abstraction and we shouldn't signal this here, but it requires a bigger refactor.
+	// (stepman should keep track of this info in a file probably)
+	DidStepLibUpdate bool
+}
+
+type ActivationType string
+
+const (
+	ActivationTypeSteplibExecutable ActivationType = "steplib_executable"
+	ActivationTypeSteplibSource     ActivationType = "steplib_source"
+	ActivationTypePathRef           ActivationType = "path"
+	ActivationTypeGitRef            ActivationType = "git"
+)

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
-	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
 )
 
@@ -20,10 +19,10 @@ func ActivateSteplibRefStep(
 	didStepLibUpdateInWorkflow bool,
 	isOfflineMode bool,
 	stepInfoPtr *models.StepInfoModel,
-) (steplibrary.ActivatedStep, error) {
+) (ActivatedStep, error) {
 	stepYMLPath := filepath.Join(workDir, "current_step.yml")
 	//nolint:exhaustruct // missing fields are added down below based on activation result
-	activationResult := steplibrary.ActivatedStep{
+	activationResult := ActivatedStep{
 		StepYMLPath:      stepYMLPath,
 		DidStepLibUpdate: false,
 	}
@@ -37,9 +36,9 @@ func ActivateSteplibRefStep(
 	execPath, err := steplib.ActivateStep(id.SteplibSource, id.IDorURI, stepInfo.Version, activatedStepDir, stepYMLPath, log, isOfflineMode)
 	activationResult.ExecutablePath = execPath
 	if execPath != "" {
-		activationResult.ActivationType = steplibrary.ActivationTypeSteplibExecutable
+		activationResult.ActivationType = ActivationTypeSteplibExecutable
 	} else {
-		activationResult.ActivationType = steplibrary.ActivationTypeSteplibSource
+		activationResult.ActivationType = ActivationTypeSteplibSource
 	}
 	if err != nil {
 		return activationResult, err

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
-	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -206,9 +205,9 @@ func BenchmarkActivateSteplibRefStep(b *testing.B) {
 					b.Fatal("ActivateSteplibRefStep() succeeded unexpectedly")
 				}
 
-				want := steplibrary.ActivatedStep{
+				want := ActivatedStep{
 					StepYMLPath:      tmpDir + "/current_step.yml",
-					ActivationType:   steplibrary.ActivationTypeSteplibSource,
+					ActivationType:   ActivationTypeSteplibSource,
 					DidStepLibUpdate: !tt.didStepLibUpdateInWorkflow,
 				}
 				require.Equal(b, want, got)

--- a/steplibrary/result.go
+++ b/steplibrary/result.go
@@ -2,32 +2,7 @@ package steplibrary
 
 import "github.com/bitrise-io/stepman/models"
 
-type ActivatedStep struct {
-	StepInfo models.StepInfoModel
-
+type ActivateResult struct {
+	StepInfo    models.StepInfoModel
 	StepYMLPath string
-
-	ActivationType ActivationType
-
-	// ExecutablePath is a local path to the main entrypoint of the step, ready for execution.
-	// This can be an empty string if:
-	// - step was activated from a git reference (we checked out the source dir directly)
-	// - step was activated from a local path (we copied the source dir directly)
-	// - step was activated from a steplib reference, but step.yml has no entry for pre-compiled binaries (we fallback to source checkout)
-	// - step was activated from a steplib reference, but step.yml has no pre-compiled binary for the current OS+arch combo (we fallback to source checkout)
-	ExecutablePath string
-
-	// DidStepLibUpdate indicates that the local steplib cache was updated while resolving the exact step version.
-	// TODO: this is a leaky abstraction and we shouldn't signal this here, but it requires a bigger refactor.
-	// (stepman should keep track of this info in a file probably)
-	DidStepLibUpdate bool
 }
-
-type ActivationType string
-
-const (
-	ActivationTypeSteplibExecutable ActivationType = "steplib_executable"
-	ActivationTypeSteplibSource     ActivationType = "steplib_source"
-	ActivationTypePathRef           ActivationType = "path"
-	ActivationTypeGitRef            ActivationType = "git"
-)

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -33,31 +33,28 @@ func New(log stepman.Logger, steplibURI, inventoryURL string, fileManager fileut
 	}
 }
 
-func (c *Client) Activate(ctx context.Context, stepID, version string, outputPaths ActivateOutputPaths) (ActivatedStep, error) {
+func (c *Client) Activate(ctx context.Context, stepID, version string, outputPaths ActivateOutputPaths) (ActivateResult, error) {
 	stepInfo, resolved, err := c.getStepVersionInfo(ctx, stepID, version)
 	if err != nil {
-		return ActivatedStep{}, fmt.Errorf("resolve step version: %w", err)
+		return ActivateResult{}, fmt.Errorf("resolve step version: %w", err)
 	}
 
 	stepModel, err := c.api.GetStepModel(ctx, resolved)
 	if err != nil {
-		return ActivatedStep{}, fmt.Errorf("fetch step definition: %w", err)
+		return ActivateResult{}, fmt.Errorf("fetch step definition: %w", err)
 	}
 
 	stepYML, err := yaml.Marshal(stepModel)
 	if err != nil {
-		return ActivatedStep{}, fmt.Errorf("marshal step model to YAML: %w", err)
+		return ActivateResult{}, fmt.Errorf("marshal step model to YAML: %w", err)
 	}
 
 	if err := c.fileManager.WriteBytes(outputPaths.YMLPath, stepYML); err != nil {
-		return ActivatedStep{}, fmt.Errorf("write step.yml: %w", err)
+		return ActivateResult{}, fmt.Errorf("write step.yml: %w", err)
 	}
 
-	return ActivatedStep{
-		StepInfo:         stepInfo,
-		StepYMLPath:      outputPaths.YMLPath,
-		ExecutablePath:   "",
-		ActivationType:   ActivationTypeSteplibSource,
-		DidStepLibUpdate: false, // deprecated
+	return ActivateResult{
+		StepInfo:    stepInfo,
+		StepYMLPath: outputPaths.YMLPath,
 	}, nil
 }


### PR DESCRIPTION
PR #377 intentionally moved `ActivatedStep` / `ActivationType` into `steplibrary` as part of the V2 read path. That worked at the time, but when trying to establish a clean `activator` → `steplibrary` dependency direction, it immediately creates an import cycle — \`steplibrary\` owns the result type that \`activator\` needs to return.

This PR resolves that by separating concerns properly:
- `ActivatedStep` / `ActivationType` move back to `activator` where they belong — they describe the outcome of activation, not of a fetch
- `steplibrary.Activate` returns a minimal `ActivateResult` (only `StepInfo` + `StepYMLPath`) — the fetch/data layer exposes only what it actually produces
- `activator` can now import `steplibrary` without a cycle; `steplibrary` has no dependency on `activator`