### PR TITLE
Extract copyStepYML.

### DIFF
--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -39,9 +39,13 @@ func ActivateStep(stepLibURI, id, version, destination, destinationStepYML strin
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(stepLibURI, id, version, executableForPlatform, destination, destinationStepYML)
+			execPath, err := activateStepExecutable(id, executableForPlatform, destination)
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
+
+				if err := copyStepYML(stepLibURI, id, version, destinationStepYML); err != nil {
+					return "", fmt.Errorf("copy step.yml: %s", err)
+				}
 				return execPath, nil
 			}
 			log.Warnf("Failed to download step executable, fallback to step source activation: %s", err)

--- a/activator/steplib/activate_executable.go
+++ b/activator/steplib/activate_executable.go
@@ -16,12 +16,9 @@ import (
 )
 
 func activateStepExecutable(
-	stepLibURI string,
 	stepID string,
-	version string,
 	executable models.Executable,
 	destinationDir string,
-	destinationStepYML string,
 ) (string, error) {
 	body, err := downloadExecutable(executable)
 	if err != nil {
@@ -63,10 +60,6 @@ func activateStepExecutable(
 	err = os.Chmod(path, 0755)
 	if err != nil {
 		return "", fmt.Errorf("set executable permission on file: %s", err)
-	}
-
-	if err := copyStepYML(stepLibURI, stepID, version, destinationStepYML); err != nil {
-		return "", fmt.Errorf("copy step.yml: %s", err)
 	}
 
 	return path, nil


### PR DESCRIPTION
Preparing for integrating Steplib API. We have to make small cleanup first.

Extracted copyStepYML from activate StepExecutable. This allows to make copy conditional later on, and simplified activateStepExecutable signature.