### PR TITLE
return stepInfo in ActivatedStep

### DIFF
--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -29,6 +29,7 @@ func ActivateSteplibRefStep(
 
 	stepInfo, didUpdate, err := prepareStepLibForActivation(log, id, didStepLibUpdateInWorkflow, isOfflineMode)
 	activationResult.DidStepLibUpdate = didUpdate
+	activationResult.StepInfo = stepInfo
 	if err != nil {
 		return activationResult, err
 	}


### PR DESCRIPTION
return stepInfo in ActivatedStep. This allows to remove the TODO workaround in next change.