### PR TITLE
Removed pointer param output from ActivateSteplibRef

### DIFF
--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -18,7 +18,6 @@ func ActivateSteplibRefStep(
 	workDir string,
 	didStepLibUpdateInWorkflow bool,
 	isOfflineMode bool,
-	stepInfoPtr *models.StepInfoModel,
 ) (ActivatedStep, error) {
 	stepYMLPath := filepath.Join(workDir, "current_step.yml")
 	//nolint:exhaustruct // missing fields are added down below based on activation result
@@ -44,16 +43,6 @@ func ActivateSteplibRefStep(
 	if err != nil {
 		return activationResult, err
 	}
-
-	// TODO: this is sketchy, we should clean this up, but this pointer originates in the CLI codebase
-	stepInfoPtr.ID = stepInfo.ID
-	if stepInfoPtr.Step.Title == nil || *stepInfoPtr.Step.Title == "" {
-		stepInfoPtr.Step.Title = pointers.NewStringPtr(stepInfo.ID)
-	}
-	stepInfoPtr.Version = stepInfo.Version
-	stepInfoPtr.LatestVersion = stepInfo.LatestVersion
-	stepInfoPtr.OriginalVersion = stepInfo.OriginalVersion
-	stepInfoPtr.GroupInfo = stepInfo.GroupInfo
 
 	return activationResult, nil
 }

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/stretchr/testify/require"
 )
@@ -193,8 +192,7 @@ func BenchmarkActivateSteplibRefStep(b *testing.B) {
 					b.Errorf("failed to create dir for step.yml: %s", err)
 				}
 
-				stepInfoPtr := new(models.StepInfoModel)
-				got, gotErr := ActivateSteplibRefStep(logger, tt.id, stepYMLCopyPth, tmpDir, tt.didStepLibUpdateInWorkflow, tt.isOfflineMode, stepInfoPtr)
+				got, gotErr := ActivateSteplibRefStep(logger, tt.id, stepYMLCopyPth, tmpDir, tt.didStepLibUpdateInWorkflow, tt.isOfflineMode)
 				if gotErr != nil {
 					if !tt.wantErr {
 						b.Errorf("ActivateSteplibRefStep() failed: %v", gotErr)
@@ -205,12 +203,10 @@ func BenchmarkActivateSteplibRefStep(b *testing.B) {
 					b.Fatal("ActivateSteplibRefStep() succeeded unexpectedly")
 				}
 
-				want := ActivatedStep{
-					StepYMLPath:      tmpDir + "/current_step.yml",
-					ActivationType:   ActivationTypeSteplibSource,
-					DidStepLibUpdate: !tt.didStepLibUpdateInWorkflow,
-				}
-				require.Equal(b, want, got)
+				require.Equal(b, tmpDir+"/current_step.yml", got.StepYMLPath)
+				require.Equal(b, ActivationTypeSteplibSource, got.ActivationType)
+				require.Equal(b, !tt.didStepLibUpdateInWorkflow, got.DidStepLibUpdate)
+				require.Equal(b, tt.id.IDorURI, got.StepInfo.ID)
 			}
 		})
 	}


### PR DESCRIPTION
Stepman cleanups continue, before API integration.
Already updated CLI: https://github.com/bitrise-io/bitrise/pull/1277
We can now remove the unused param.
One final CLI cleanup remains due to the changed signature.