### PR TITLE
Move ActivatedStep

### DIFF
--- a/activator/activate_ref_test.go
+++ b/activator/activate_ref_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func TestActivatePathRefStep(t *testing.T) {
 	absStepSrcDir, err := pathutil.AbsPath(stepSrcDir)
 	require.NoError(t, err)
 
-	require.Equal(t, ActivationTypePathRef, got.ActivationType)
+	require.Equal(t, steplib.ActivationTypePathRef, got.ActivationType)
 	require.Equal(t, filepath.Join(workDir, "current_step.yml"), got.StepYMLPath)
 	require.Equal(t, "path", got.StepInfo.Library)
 	require.Equal(t, absStepSrcDir, got.StepInfo.ID)
@@ -64,7 +65,7 @@ func TestActivateGitRefStep(t *testing.T) {
 	got, err := ActivateGitRefStep(TestLogger[*testing.T]{t}, id, activatedStepDir, workDir)
 	require.NoError(t, err)
 
-	require.Equal(t, ActivationTypeGitRef, got.ActivationType)
+	require.Equal(t, steplib.ActivationTypeGitRef, got.ActivationType)
 	require.Equal(t, filepath.Join(workDir, "current_step.yml"), got.StepYMLPath)
 	require.Equal(t, "git", got.StepInfo.Library)
 	require.Equal(t, srcRepoDir, got.StepInfo.ID)

--- a/activator/git_ref.go
+++ b/activator/git_ref.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/command/git"
+	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/stepman"
 )
@@ -18,10 +19,10 @@ func ActivateGitRefStep(
 	id stepid.CanonicalID,
 	activatedStepDir string,
 	workDir string,
-) (ActivatedStep, error) {
+) (steplib.ActivatedStep, error) {
 	repo, err := git.New(activatedStepDir)
 	if err != nil {
-		return ActivatedStep{},err
+		return steplib.ActivatedStep{},err
 	}
 
 	var cloneCmd *command.Model
@@ -39,26 +40,26 @@ even if the repository is open source!`)
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return ActivatedStep{},fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), cloneCmd.PrintableCommandArgs(), errors.New(out))
+			return steplib.ActivatedStep{},fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), cloneCmd.PrintableCommandArgs(), errors.New(out))
 		}
-		return ActivatedStep{},err
+		return steplib.ActivatedStep{},err
 	}
 
 	stepYMLPath := filepath.Join(workDir, "current_step.yml")
 	if err := command.CopyFile(filepath.Join(activatedStepDir, "step.yml"), stepYMLPath); err != nil {
-		return ActivatedStep{},err
+		return steplib.ActivatedStep{},err
 	}
 
 	stepInfo, err := stepman.QueryStepInfoFromGitStepDir(activatedStepDir, id.IDorURI, id.Version)
 	if err != nil {
-		return ActivatedStep{},err
+		return steplib.ActivatedStep{},err
 	}
 
-	return ActivatedStep{
+	return steplib.ActivatedStep{
 		StepInfo:         stepInfo,
 		StepYMLPath:      stepYMLPath,
 		DidStepLibUpdate: false,
-		ActivationType:   ActivationTypeGitRef,
+		ActivationType:   steplib.ActivationTypeGitRef,
 		ExecutablePath:   "",
 	}, nil
 }

--- a/activator/path_ref.go
+++ b/activator/path_ref.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/stepman"
 )
@@ -15,19 +16,19 @@ func ActivatePathRefStep(
 	id stepid.CanonicalID,
 	activatedStepDir string,
 	workDir string,
-) (ActivatedStep, error) {
+) (steplib.ActivatedStep, error) {
 	log.Debugf("Local step found: (path:%s)", id.IDorURI)
 	// id.IDorURI is a path to the step dir in this case
 	stepAbsLocalPth, err := pathutil.AbsPath(id.IDorURI)
 	if err != nil {
-		return ActivatedStep{}, err
+		return steplib.ActivatedStep{}, err
 	}
 
 	exist, err := pathutil.IsDirExists(stepAbsLocalPth)
 	if err != nil {
-		return ActivatedStep{}, fmt.Errorf("check if a directory exists at %s: %w", stepAbsLocalPth, err)
+		return steplib.ActivatedStep{}, fmt.Errorf("check if a directory exists at %s: %w", stepAbsLocalPth, err)
 	} else if !exist {
-		return ActivatedStep{}, fmt.Errorf("the provided directory doesn't exist: %s", stepAbsLocalPth)
+		return steplib.ActivatedStep{}, fmt.Errorf("the provided directory doesn't exist: %s", stepAbsLocalPth)
 	}
 
 	log.Debugf("stepAbsLocalPth: %s, stepDir:%s", stepAbsLocalPth, activatedStepDir)
@@ -35,30 +36,30 @@ func ActivatePathRefStep(
 	origStepYMLPth := filepath.Join(stepAbsLocalPth, "step.yml")
 	exist, err = pathutil.IsPathExists(origStepYMLPth)
 	if err != nil {
-		return ActivatedStep{}, fmt.Errorf("check if step.yml exists at %s: %w", origStepYMLPth, err)
+		return steplib.ActivatedStep{}, fmt.Errorf("check if step.yml exists at %s: %w", origStepYMLPth, err)
 	} else if !exist {
-		return ActivatedStep{}, fmt.Errorf("step.yml doesn't exist at %s", origStepYMLPth)
+		return steplib.ActivatedStep{}, fmt.Errorf("step.yml doesn't exist at %s", origStepYMLPth)
 	}
 
 	activatedStepYMLPath := filepath.Join(workDir, "current_step.yml")
 	if err := command.CopyFile(origStepYMLPth, activatedStepYMLPath); err != nil {
-		return ActivatedStep{}, err
+		return steplib.ActivatedStep{}, err
 	}
 
 	if err := command.CopyDir(stepAbsLocalPth, activatedStepDir, true); err != nil {
-		return ActivatedStep{}, err
+		return steplib.ActivatedStep{}, err
 	}
 
 	stepInfo, err := stepman.QueryStepInfoFromPath(stepAbsLocalPth)
 	if err != nil {
-		return ActivatedStep{}, err
+		return steplib.ActivatedStep{}, err
 	}
 
-	return ActivatedStep{
+	return steplib.ActivatedStep{
 		StepInfo:         stepInfo,
 		StepYMLPath:      activatedStepYMLPath,
 		DidStepLibUpdate: false,
-		ActivationType:   ActivationTypePathRef,
+		ActivationType:   steplib.ActivationTypePathRef,
 		ExecutablePath:   "",
 	}, nil
 }

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -39,6 +39,7 @@ func ActivateStep(stepLibURI, id, version, destination, destinationStepYML strin
 			return ActivatedStep{}, fmt.Errorf("copy step.yml: %s", err)
 		}
 
+		//nolint:exhaustruct // only the executable and activation type fields are set here, the rest are filled in by the caller
 		return ActivatedStep{
 			ExecutablePath: execPath,
 			ActivationType: ActivationTypeSteplibExecutable,
@@ -46,6 +47,7 @@ func ActivateStep(stepLibURI, id, version, destination, destinationStepYML strin
 	}
 
 	err = activateStepSource(stepCollection, stepLibURI, id, version, step, destination, destinationStepYML, log, isOfflineMode)
+	//nolint:exhaustruct // only the activation type field is set here, the rest are filled in by the caller
 	return ActivatedStep{
 		ActivationType: ActivationTypeSteplibSource,
 	}, err

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -22,28 +22,33 @@ var precompiledStepsDefaultStorageURLs = []string{
 	"https://storage.googleapis.com/bitrise-steplib-storage",
 }
 
-func ActivateStep(stepLibURI, id, version, destination, destinationStepYML string, log stepman.Logger, isOfflineMode bool) (string, error) {
+func ActivateStep(stepLibURI, id, version, destination, destinationStepYML string, log stepman.Logger, isOfflineMode bool) (ActivatedStep, error) {
 	stepCollection, err := stepman.ReadStepSpec(stepLibURI)
 	if err != nil {
-		return "", fmt.Errorf("failed to read %s steplib: %s", stepLibURI, err)
+		return ActivatedStep{}, fmt.Errorf("failed to read %s steplib: %s", stepLibURI, err)
 	}
 
 	step, version, err := queryStepMetadata(stepCollection, stepLibURI, id, version)
 	if err != nil {
-		return "", fmt.Errorf("failed to find step: %s", err)
+		return ActivatedStep{}, fmt.Errorf("failed to find step: %s", err)
 	}
 
 	execPath, err := downloadPrecompiled(log, step, id, destination)
 	if execPath != "" {
 		if err := copyStepYML(stepLibURI, id, version, destinationStepYML); err != nil {
-			return "", fmt.Errorf("copy step.yml: %s", err)
+			return ActivatedStep{}, fmt.Errorf("copy step.yml: %s", err)
 		}
 
-		return execPath, err
+		return ActivatedStep{
+			ExecutablePath: execPath,
+			ActivationType: ActivationTypeSteplibExecutable,
+		}, err
 	}
 
 	err = activateStepSource(stepCollection, stepLibURI, id, version, step, destination, destinationStepYML, log, isOfflineMode)
-	return "", err
+	return ActivatedStep{
+		ActivationType: ActivationTypeSteplibSource,
+	}, err
 }
 
 func downloadPrecompiled(log stepman.Logger, step models.StepModel, id string, destination string) (string, error) {

--- a/activator/steplib/result.go
+++ b/activator/steplib/result.go
@@ -1,4 +1,4 @@
-package activator
+package steplib
 
 import "github.com/bitrise-io/stepman/models"
 

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -18,10 +18,10 @@ func ActivateSteplibRefStep(
 	workDir string,
 	didStepLibUpdateInWorkflow bool,
 	isOfflineMode bool,
-) (ActivatedStep, error) {
+) (steplib.ActivatedStep, error) {
 	stepYMLPath := filepath.Join(workDir, "current_step.yml")
 	//nolint:exhaustruct // missing fields are added down below based on activation result
-	activationResult := ActivatedStep{
+	activationResult := steplib.ActivatedStep{
 		StepYMLPath:      stepYMLPath,
 		DidStepLibUpdate: false,
 	}
@@ -36,9 +36,9 @@ func ActivateSteplibRefStep(
 	execPath, err := steplib.ActivateStep(id.SteplibSource, id.IDorURI, stepInfo.Version, activatedStepDir, stepYMLPath, log, isOfflineMode)
 	activationResult.ExecutablePath = execPath
 	if execPath != "" {
-		activationResult.ActivationType = ActivationTypeSteplibExecutable
+		activationResult.ActivationType = steplib.ActivationTypeSteplibExecutable
 	} else {
-		activationResult.ActivationType = ActivationTypeSteplibSource
+		activationResult.ActivationType = steplib.ActivationTypeSteplibSource
 	}
 	if err != nil {
 		return activationResult, err

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -33,13 +33,9 @@ func ActivateSteplibRefStep(
 		return activationResult, err
 	}
 
-	execPath, err := steplib.ActivateStep(id.SteplibSource, id.IDorURI, stepInfo.Version, activatedStepDir, stepYMLPath, log, isOfflineMode)
-	activationResult.ExecutablePath = execPath
-	if execPath != "" {
-		activationResult.ActivationType = steplib.ActivationTypeSteplibExecutable
-	} else {
-		activationResult.ActivationType = steplib.ActivationTypeSteplibSource
-	}
+	activatedStep, err := steplib.ActivateStep(id.SteplibSource, id.IDorURI, stepInfo.Version, activatedStepDir, stepYMLPath, log, isOfflineMode)
+	activationResult.ExecutablePath = activatedStep.ExecutablePath
+	activationResult.ActivationType = activatedStep.ActivationType
 	if err != nil {
 		return activationResult, err
 	}

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/stretchr/testify/require"
 )
@@ -204,7 +205,7 @@ func BenchmarkActivateSteplibRefStep(b *testing.B) {
 				}
 
 				require.Equal(b, tmpDir+"/current_step.yml", got.StepYMLPath)
-				require.Equal(b, ActivationTypeSteplibSource, got.ActivationType)
+				require.Equal(b, steplib.ActivationTypeSteplibSource, got.ActivationType)
 				require.Equal(b, !tt.didStepLibUpdateInWorkflow, got.DidStepLibUpdate)
 				require.Equal(b, tt.id.IDorURI, got.StepInfo.ID)
 			}


### PR DESCRIPTION
- **Moved ActivatedStep to setplib package**
- Return ActivatedStep from steplib.ActivateStep. This allows to move prepareSteplibForActivation one level down, into ActivateStep. It will make API integration easier: In the steplibrary.New we do not have seperate interfaces for "prepare" and "activate". Splitting it makes less sense as the second part always depends on the first.

next:
`//nolint:exhaustruct ` is only temporary, the plan is to merge prepareSteplibForActivation into steplib.ActivateStep.