### PR TITLE
[STEP-2437] Fix latent panic on non-existent minor/major version resolve

### DIFF
--- a/models/version_constraint.go
+++ b/models/version_constraint.go
@@ -194,6 +194,7 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 				Patch: 0,
 			}
 			latestStep := StepModel{}
+			found := false
 
 			for fullVersion, step := range stepVersions.Versions {
 				stepVersion, err := ParseSemver(fullVersion)
@@ -205,10 +206,15 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 					continue
 				}
 
-				if stepVersion.Patch > latestVersion.Patch {
+				if !found || stepVersion.Patch > latestVersion.Patch {
 					latestVersion = stepVersion
 					latestStep = step
+					found = true
 				}
+			}
+
+			if !found {
+				return StepVersionModel{}, false
 			}
 
 			return StepVersionModel{
@@ -225,6 +231,7 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 				Patch: 0,
 			}
 			latestStep := StepModel{}
+			found := false
 
 			for fullVersion, step := range stepVersions.Versions {
 				stepVersion, err := ParseSemver(fullVersion)
@@ -235,11 +242,17 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 					continue
 				}
 
-				if stepVersion.Minor > latestStepVersion.Minor ||
+				if !found ||
+					stepVersion.Minor > latestStepVersion.Minor ||
 					(stepVersion.Minor == latestStepVersion.Minor && stepVersion.Patch > latestStepVersion.Patch) {
 					latestStepVersion = stepVersion
 					latestStep = step
+					found = true
 				}
+			}
+
+			if !found {
+				return StepVersionModel{}, false
 			}
 
 			return StepVersionModel{

--- a/models/version_constraint.go
+++ b/models/version_constraint.go
@@ -194,7 +194,7 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 				Patch: 0,
 			}
 			latestStep := StepModel{}
-			found := false
+			versionFound := false
 
 			for fullVersion, step := range stepVersions.Versions {
 				stepVersion, err := ParseSemver(fullVersion)
@@ -206,14 +206,14 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 					continue
 				}
 
-				if !found || stepVersion.Patch > latestVersion.Patch {
+				if !versionFound || stepVersion.Patch > latestVersion.Patch {
 					latestVersion = stepVersion
 					latestStep = step
-					found = true
+					versionFound = true
 				}
 			}
 
-			if !found {
+			if !versionFound {
 				return StepVersionModel{}, false
 			}
 
@@ -231,7 +231,7 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 				Patch: 0,
 			}
 			latestStep := StepModel{}
-			found := false
+			versionFound := false
 
 			for fullVersion, step := range stepVersions.Versions {
 				stepVersion, err := ParseSemver(fullVersion)
@@ -242,16 +242,16 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 					continue
 				}
 
-				if !found ||
+				if !versionFound ||
 					stepVersion.Minor > latestStepVersion.Minor ||
 					(stepVersion.Minor == latestStepVersion.Minor && stepVersion.Patch > latestStepVersion.Patch) {
 					latestStepVersion = stepVersion
 					latestStep = step
-					found = true
+					versionFound = true
 				}
 			}
 
-			if !found {
+			if !versionFound {
 				return StepVersionModel{}, false
 			}
 

--- a/models/version_constraint_test.go
+++ b/models/version_constraint_test.go
@@ -250,6 +250,48 @@ func Test_latestMatchingStepVersion(t *testing.T) {
 			},
 			want1: true,
 		},
+		{
+			name: "Lock Minor version - only a patch-0 version exists (must still match)",
+			requiredVersion: VersionConstraint{
+				VersionLockType: MinorLocked,
+				Version: Semver{
+					Major: 1,
+					Minor: 2,
+				},
+			},
+			stepVersions: stepGroup,
+			want: StepVersionModel{
+				Step:                   step,
+				Version:                "1.2.0",
+				LatestAvailableVersion: "2.0.0",
+			},
+			want1: true,
+		},
+		{
+			name: "Lock Minor version - no matching version",
+			requiredVersion: VersionConstraint{
+				VersionLockType: MinorLocked,
+				Version: Semver{
+					Major: 1,
+					Minor: 9,
+				},
+			},
+			stepVersions: stepGroup,
+			want:         StepVersionModel{},
+			want1:        false,
+		},
+		{
+			name: "Lock Major version - no matching version",
+			requiredVersion: VersionConstraint{
+				VersionLockType: MajorLocked,
+				Version: Semver{
+					Major: 9,
+				},
+			},
+			stepVersions: stepGroup,
+			want:         StepVersionModel{},
+			want1:        false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/version_constraint_test.go
+++ b/models/version_constraint_test.go
@@ -292,6 +292,59 @@ func Test_latestMatchingStepVersion(t *testing.T) {
 			want:         StepVersionModel{},
 			want1:        false,
 		},
+		{
+			name: "Fixed version - not present",
+			requiredVersion: VersionConstraint{
+				VersionLockType: Fixed,
+				Version:         Semver{Major: 9, Minor: 9, Patch: 9},
+			},
+			stepVersions: stepGroup,
+			want:         StepVersionModel{},
+			want1:        false,
+		},
+		{
+			name: "Lock Minor version - skips unparseable version keys",
+			requiredVersion: VersionConstraint{
+				VersionLockType: MinorLocked,
+				Version:         Semver{Major: 1, Minor: 1},
+			},
+			stepVersions: StepGroupModel{
+				Versions:            map[string]StepModel{"garbage": step, "1.1.2": step},
+				LatestVersionNumber: "1.1.2",
+			},
+			want: StepVersionModel{
+				Step:                   step,
+				Version:                "1.1.2",
+				LatestAvailableVersion: "1.1.2",
+			},
+			want1: true,
+		},
+		{
+			name: "Lock Major version - skips unparseable version keys",
+			requiredVersion: VersionConstraint{
+				VersionLockType: MajorLocked,
+				Version:         Semver{Major: 2},
+			},
+			stepVersions: StepGroupModel{
+				Versions:            map[string]StepModel{"not.semver.x": step, "2.3.4": step},
+				LatestVersionNumber: "2.3.4",
+			},
+			want: StepVersionModel{
+				Step:                   step,
+				Version:                "2.3.4",
+				LatestAvailableVersion: "2.3.4",
+			},
+			want1: true,
+		},
+		{
+			name: "Non-locked constraint (Latest) falls through to not-found",
+			requiredVersion: VersionConstraint{
+				VersionLockType: Latest,
+			},
+			stepVersions: stepGroup,
+			want:         StepVersionModel{},
+			want1:        false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What

`models.latestMatchingStepVersion` returned `versionFound=true` with an **empty** `StepModel{}` and a fabricated `<major>.<minor>.0` version for `MinorLocked`/`MajorLocked` constraints that matched **no** available version — unlike the `Fixed` case, which correctly returns `false`. This makes the two cases return `false` when nothing matches.

## Why

For a non-existent minor/major (e.g. `git-clone@8.99`, `@99`) the empty step propagates: `GetStepVersion → (empty, found=true)` → `ReadStepVersionInfo` doesn't error → `QueryStepInfoFromLibrary` returns `stepInfo{Version:"8.99.0", Step: empty}` → `prepareStepLibForActivation` succeeds → `ActivateStep` runs with the fabricated version.

Today it doesn't crash only because the legacy `ActivateStep` re-resolves `"8.99.0"` via `queryStepMetadata` as an **exact** lookup, which misses cleanly. That mask is fragile — remove the redundant re-resolution and the empty `Step` reaches `activateStepSource`, which dereferences `step.Source.Commit` → **nil-pointer panic**. This removes the latent panic at its source: a non-existent minor/major now fails at resolution (`"collection doesn't contain step (<id>) with version: <v>"`) before `ActivateStep`. Valid minor/major locks are unchanged.

Also fixes a related bug in the same loops: an `X.Y.0`-only match was skipped (`patch 0 > 0` is false) and returned as an empty "found" step.

## Reproducer

Root cause, against a lib that only has `8.4.x`, resolving a non-existent minor `8.99` (no network):

```go
coll := models.StepCollectionModel{Steps: map[string]models.StepGroupModel{
    "git-clone": {Versions: map[string]models.StepModel{"8.4.2": {Source: &models.StepSourceModel{}}}, LatestVersionNumber: "8.4.2"},
}}
sv, _, versionFound := coll.GetStepVersion("git-clone", "8.99")
_ = sv.Step.Source.Commit // activateStepSource dereferences this
```

| | `versionFound` | `sv.Step.Source` | result |
|---|---|---|---|
| before | `true`  | `<nil>` | `panic: nil pointer dereference` |
| after  | `false` | `<nil>` | clean not-found, no deref |

### Actual CLI error (`bitrise run` of `git-clone@8.99`)

On the current wiring the exact re-lookup keeps it from panicking either way, but the message improves — before it reports the fabricated `8.99.0`; after it reports the version the user actually requested and fails earlier (at resolution):

**Before:**
```
Preparing Step (git-clone@8.99) failed: activate steplib step: failed to find step: https://github.com/bitrise-io/bitrise-steplib.git steplib does not contain git-clone step 8.99.0 version
```

**After:**
```
Preparing Step (git-clone@8.99) failed: activate steplib step: query steplib step info: read step information: collection doesn't contain step (git-clone) with version: 8.99
```

### Full flow — current wiring (legacy path): panic is **masked / latent**

```
ActivateSteplibRefStep("git-clone@8.99")
 └ prepareStepLibForActivation
    └ QueryStepInfoFromLibrary → ReadStepVersionInfo → GetStepVersion("8.99")
       └ latestMatchingStepVersion(MinorLocked 8.99)
            before → (StepModel{} /*empty*/, true)      after → (StepModel{}, false)
       before: versionFound=true → stepInfo{Version:"8.99.0", Step:<empty>}, err=nil
       after : versionFound=false → ReadStepVersionInfo errors → prepareStepLibForActivation errors
    before: (stepInfo, nil)        after: returns error → ActivateSteplibRefStep exits cleanly ✓
 └ ActivateStep(id, version="8.99.0")                        [reached only before the fix]
    └ queryStepMetadata(id, "8.99.0") → GetStep → ParseRequiredVersion ⇒ Fixed
        → latestMatchingStepVersion(Fixed "8.99.0") → not present → (empty, false)
        → error "does not contain git-clone step 8.99.0 version"      ← MASK: exact re-lookup catches it
    → ActivateStep returns error ✓   (no panic; panic is latent)
```

### Full flow — integration PR direction (use the resolved step directly, drop the re-resolution): **panics without this fix**

The integration PR (#392) already feeds the resolved `stepInfo.Step` straight into activation on its v2/API branch (`stepModel = stepInfo.Step`, no `queryStepMetadata`), and flags unifying the legacy source path the same way (TODOs in `activate.go`). Once the legacy path stops re-resolving:

```
ActivateSteplibRefStep("git-clone@8.99")
 └ prepareStepLibForActivation → stepInfo{Version:"8.99.0", Step:<empty>}, err=nil    (before fix)
       after fix → errors here → clean, no panic ✓
 └ ActivateStep(..., stepInfo.Step)         ← resolved step used directly, MASK GONE
    └ downloadPrecompiled(step=<empty>) → step.Executables == nil → ""
    └ activateStepSource(step=<empty>, "8.99.0")
        └ stepman.DownloadStep(..., step.Source.Commit, …)   step.Source == nil
             before fix → PANIC: nil pointer dereference
             after  fix → unreachable
```

So this fix is the prerequisite that keeps both the current flow and the refactored flow panic-free.

## Changes

- `models/version_constraint.go` — `MinorLocked`/`MajorLocked` track a `found` flag and return `versionFound=false` when nothing matches (mirroring `Fixed`); select the first match so `X.Y.0`-only versions resolve.
- `models/version_constraint_test.go` — cases for non-existent minor (`1.9`) / major (`9`) → not found, and an `X.Y.0`-only minor (`1.2`) → resolves.

## Testing

- `go test ./models/...` green (new + existing cases).
- `go build ./...`, `go vet ./...` clean; `activator`, `activator/steplib`, `steplibrary`, `stepman`, `cli` unit tests pass.
- Blast radius: every `GetStep`/`GetStepVersion` caller already treats `versionFound=false` as not-found, so the change is strictly more correct for each.
