### PR TITLE
[STEP-2437] V2-native step source activation (no SetupLibrary)

### DIFF
--- a/_tests/activation/activation_test.go
+++ b/_tests/activation/activation_test.go
@@ -177,13 +177,9 @@ func TestSteplibActivation(t *testing.T) {
 	})
 }
 
-// TestSteplibActivation_V2SourceFreshEnv proves review finding #1 is fixed: the
-// V2 source fallback no longer requires the local steplib to be set up. It runs
-// in its own fresh $HOME (no prior v1 activation provisioned ~/.stepman), then
-// activates a source step over the API. Before the fix this failed in
-// ReadStepSpec ("no route found"); now the source is downloaded from the
-// API-provided git source, with no SetupLibrary.
-func TestSteplibActivation_V2SourceFreshEnv(t *testing.T) {
+// TestSteplibActivation_APISourceFreshEnv tests that API can fetch source even
+// if git steplib was never cloned. It sets up a clean $HOME.
+func TestSteplibActivation_APISourceFreshEnv(t *testing.T) {
 	t.Setenv("HOME", t.TempDir()) // fresh: ~/.stepman is not set up
 
 	id := steplibStep("git-clone", "8.5.0")

--- a/_tests/activation/activation_test.go
+++ b/_tests/activation/activation_test.go
@@ -184,13 +184,13 @@ func TestSteplibActivation_APISourceFreshEnv(t *testing.T) {
 
 	id := steplibStep("git-clone", "8.5.0")
 	r := activate(t, v2Source, id, false, false)
-	logResult(t, "v2-source (fresh env, no SetupLibrary)", r)
+	logResult(t, "api-source (fresh env, no SetupLibrary)", r)
 
-	require.NoError(t, r.err, "v2 source activation must work without the local steplib set up")
+	require.NoError(t, r.err, "api source activation must work without the git cloned steplib set up")
 	assert.Equal(t, activator.ActivationTypeSteplibSource, r.activated.ActivationType)
 	assert.Empty(t, r.activated.ExecutablePath)
 	// It must not have gone through the v1 StepLib setup/update path.
 	for _, e := range r.logs {
-		assert.NotContains(t, e.msg, "updating StepLib", "v2 source must not set up/update the v1 StepLib")
+		assert.NotContains(t, e.msg, "updating StepLib", "api source must not set up/update the git cloned StepLib")
 	}
 }

--- a/_tests/activation/activation_test.go
+++ b/_tests/activation/activation_test.go
@@ -176,3 +176,25 @@ func TestSteplibActivation(t *testing.T) {
 		require.NoError(t, on.err)
 	})
 }
+
+// TestSteplibActivation_V2SourceFreshEnv proves review finding #1 is fixed: the
+// V2 source fallback no longer requires the local steplib to be set up. It runs
+// in its own fresh $HOME (no prior v1 activation provisioned ~/.stepman), then
+// activates a source step over the API. Before the fix this failed in
+// ReadStepSpec ("no route found"); now the source is downloaded from the
+// API-provided git source, with no SetupLibrary.
+func TestSteplibActivation_V2SourceFreshEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // fresh: ~/.stepman is not set up
+
+	id := steplibStep("git-clone", "8.5.0")
+	r := activate(t, v2Source, id, false, false)
+	logResult(t, "v2-source (fresh env, no SetupLibrary)", r)
+
+	require.NoError(t, r.err, "v2 source activation must work without the local steplib set up")
+	assert.Equal(t, activator.ActivationTypeSteplibSource, r.activated.ActivationType)
+	assert.Empty(t, r.activated.ExecutablePath)
+	// It must not have gone through the v1 StepLib setup/update path.
+	for _, e := range r.logs {
+		assert.NotContains(t, e.msg, "updating StepLib", "v2 source must not set up/update the v1 StepLib")
+	}
+}

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -73,39 +73,9 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	// The returns below carry the already-resolved StepInfo even on error, so the
 	// caller can surface the step id/version in its error logs.
 	if libraryAPI != nil {
-		// V2: activate the source without requiring the local steplib to be set up.
-		// Reuse the V1 cache if present; otherwise download from the inventory's
-		// locations (zip fast path, git fallback). Locations are fetched only on
-		// the download path, so offline mode and a cache hit do no network.
-		var commit, sourceGit string
-		if stepModel.Source != nil {
-			commit = stepModel.Source.Commit
-			sourceGit = stepModel.Source.Git
-		}
-
-		if reused, err := reuseCachedStepSource(id.SteplibSource, id.IDorURI, version, destination); err != nil {
+		// V2: activate the source over the API, without setting up the local steplib.
+		if err := activateStepSourceV2(libraryAPI, id.SteplibSource, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
-		} else if reused {
-			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
-		}
-
-		if isOfflineMode {
-			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("%s@%s: %w", id.IDorURI, version, ErrStepSourceNotCached)
-		}
-
-		if sourceGit == "" {
-			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("step %s@%s has no source git URL to download from", id.IDorURI, version)
-		}
-
-		locations, err := libraryAPI.StepDownloadLocations(context.Background(), id.IDorURI, version, sourceGit)
-		if err != nil {
-			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("resolve download locations for %s@%s: %s", id.IDorURI, version, err)
-		}
-		if len(locations) == 0 {
-			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("step %s@%s has no download location", id.IDorURI, version)
-		}
-		if err := stepman.DownloadStepArchive(destination, locations, id.IDorURI, version, commit, log); err != nil {
-			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("download step source %s@%s: %s", id.IDorURI, version, err)
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
 	}

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -75,7 +75,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	if libraryAPI != nil {
 		// V2: activate the source from the API-resolved step model, without
 		// requiring the local steplib to be set up. Reuses the V1 cache if present.
-		if err := stepman.ActivateStepSourceFromModel(id.SteplibSource, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
+		if err := activateStepSourceFromModel(id.SteplibSource, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -74,7 +74,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	// caller can surface the step id/version in its error logs.
 	if libraryAPI != nil {
 		// V2: activate the source over the API, without setting up the local steplib.
-		if err := activateStepSourceV2(libraryAPI, id.SteplibSource, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
+		if err := activateStepSourceWithAPI(libraryAPI, id.SteplibSource, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -74,8 +74,18 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	// caller can surface the step id/version in its error logs.
 	if libraryAPI != nil {
 		// V2: activate the source from the API-resolved step model, without
-		// requiring the local steplib to be set up. Reuses the V1 cache if present.
-		if err := activateStepSourceFromModel(id.SteplibSource, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
+		// requiring the local steplib to be set up. Reuses the V1 cache if present,
+		// otherwise downloads via the inventory's locations (zip fast path, git
+		// fallback), resolved lazily so offline mode does no network.
+		var commit, sourceGit string
+		if stepModel.Source != nil {
+			commit = stepModel.Source.Commit
+			sourceGit = stepModel.Source.Git
+		}
+		resolveLocations := func() ([]models.DownloadLocationModel, error) {
+			return libraryAPI.StepDownloadLocations(context.Background(), id.IDorURI, version, sourceGit)
+		}
+		if err := activateStepSourceFromModel(id.SteplibSource, id.IDorURI, version, commit, resolveLocations, destination, log, isOfflineMode); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -74,7 +74,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	// caller can surface the step id/version in its error logs.
 	if libraryAPI != nil {
 		// V2: activate the source over the API, without setting up the local steplib.
-		if err := activateStepSourceWithAPI(libraryAPI, id.SteplibSource, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
+		if err := activateStepSourceWithAPI(libraryAPI, id.SteplibSource, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -70,13 +70,18 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 
 	// Fall back to step source activation.
 	//
-	// TODO: source activation reads the local steplib spec, so it only works when
-	// the local steplib was set up — i.e. the legacy path. With the steplib API
-	// enabled the local steplib isn't prepared, so this breaks; decoupling source
-	// activation from the local spec is a follow-up.
-	//
 	// The returns below carry the already-resolved StepInfo even on error, so the
 	// caller can surface the step id/version in its error logs.
+	if libraryAPI != nil {
+		// V2: activate the source from the API-resolved step model, without
+		// requiring the local steplib to be set up. Reuses the V1 cache if present.
+		if err := stepman.ActivateStepSourceFromModel(id.SteplibSource, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
+		}
+		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
+	}
+
+	// V1: the local steplib was already set up by prepareStepLibForActivation.
 	stepCollection, err := stepman.ReadStepSpec(id.SteplibSource)
 	if err != nil {
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("failed to read %s steplib: %s", id.SteplibSource, err)

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -55,7 +55,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	// Place the step.yml at destinationStepYML once, up front.
 	if libraryAPI == nil {
 		if err := copyStepYML(id.SteplibSource, id.IDorURI, version, destinationStepYML); err != nil {
-			return ResolvedStep{ExecPath: "", StepInfo: models.StepInfoModel{}}, fmt.Errorf("copy step.yml: %s", err)
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("copy step.yml: %s", err)
 		}
 	} else {
 		if err := writeStepYML(stepInfo.Step, destinationStepYML); err != nil {
@@ -69,18 +69,15 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	}
 
 	// Fall back to step source activation.
-	//
-	// The returns below carry the already-resolved StepInfo even on error, so the
-	// caller can surface the step id/version in its error logs.
 	if libraryAPI != nil {
-		// V2: activate the source over the API, without setting up the local steplib.
+		// activate the source over the API, without git clone
 		if err := activateStepSourceWithAPI(libraryAPI, id.SteplibSource, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
 	}
 
-	// V1: the local steplib was already set up by prepareStepLibForActivation.
+	// using git cloned steplib
 	stepCollection, err := stepman.ReadStepSpec(id.SteplibSource)
 	if err != nil {
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("failed to read %s steplib: %s", id.SteplibSource, err)

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -93,6 +93,10 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("%s@%s: %w", id.IDorURI, version, ErrStepSourceNotCached)
 		}
 
+		if sourceGit == "" {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("step %s@%s has no source git URL to download from", id.IDorURI, version)
+		}
+
 		locations, err := libraryAPI.StepDownloadLocations(context.Background(), id.IDorURI, version, sourceGit)
 		if err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("resolve download locations for %s@%s: %s", id.IDorURI, version, err)

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -73,20 +73,35 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	// The returns below carry the already-resolved StepInfo even on error, so the
 	// caller can surface the step id/version in its error logs.
 	if libraryAPI != nil {
-		// V2: activate the source from the API-resolved step model, without
-		// requiring the local steplib to be set up. Reuses the V1 cache if present,
-		// otherwise downloads via the inventory's locations (zip fast path, git
-		// fallback), resolved lazily so offline mode does no network.
+		// V2: activate the source without requiring the local steplib to be set up.
+		// Reuse the V1 cache if present; otherwise download from the inventory's
+		// locations (zip fast path, git fallback). Locations are fetched only on
+		// the download path, so offline mode and a cache hit do no network.
 		var commit, sourceGit string
 		if stepModel.Source != nil {
 			commit = stepModel.Source.Commit
 			sourceGit = stepModel.Source.Git
 		}
-		resolveLocations := func() ([]models.DownloadLocationModel, error) {
-			return libraryAPI.StepDownloadLocations(context.Background(), id.IDorURI, version, sourceGit)
-		}
-		if err := activateStepSourceFromModel(id.SteplibSource, id.IDorURI, version, commit, resolveLocations, destination, log, isOfflineMode); err != nil {
+
+		if reused, err := reuseCachedStepSource(id.SteplibSource, id.IDorURI, version, destination); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
+		} else if reused {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
+		}
+
+		if isOfflineMode {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("%s@%s: %w", id.IDorURI, version, ErrStepSourceNotCached)
+		}
+
+		locations, err := libraryAPI.StepDownloadLocations(context.Background(), id.IDorURI, version, sourceGit)
+		if err != nil {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("resolve download locations for %s@%s: %s", id.IDorURI, version, err)
+		}
+		if len(locations) == 0 {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("step %s@%s has no download location", id.IDorURI, version)
+		}
+		if err := stepman.DownloadStepArchive(destination, locations, id.IDorURI, version, commit, log); err != nil {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("download step source %s@%s: %s", id.IDorURI, version, err)
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
 	}

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -29,7 +29,7 @@ func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, id, version strin
 		return fmt.Errorf("step %s@%s has no download location", id, version)
 	}
 
-	if err := stepman.DownloadStepArchive(destDir, locations, id, version, source.Commit, log); err != nil {
+	if err := stepman.DownloadStepSourceArchive(destDir, locations, id, version, source.Commit, log); err != nil {
 		return fmt.Errorf("download step source %s@%s: %s", id, version, err)
 	}
 	return nil

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
@@ -17,13 +16,7 @@ var ErrStepSourceNotCached = errors.New("step source not available in the local 
 
 // activateStepSourceWithAPI materializes id@version's source into destDir
 // without cloning a git steplib.
-func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, uri, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
-	if reused, err := reuseCachedStepSource(uri, id, version, destDir); err != nil {
-		return err
-	} else if reused {
-		return nil
-	}
-
+func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
 	if isOfflineMode {
 		return fmt.Errorf("%s@%s: %w", id, version, ErrStepSourceNotCached)
 	}
@@ -32,8 +25,7 @@ func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, uri, id, version 
 		return fmt.Errorf("step %s@%s has no source git URL to download from", id, version)
 	}
 
-	// The source download locations are fetched only if no cache hit and not offline mode
-	locations, err := libraryAPI.StepDownloadLocations(context.Background(), id, version, source.Git)
+	locations, err := libraryAPI.StepSourceDownloadLocations(context.Background(), id, version, source.Git)
 	if err != nil {
 		return fmt.Errorf("resolve download locations for %s@%s: %s", id, version, err)
 	}
@@ -45,23 +37,4 @@ func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, uri, id, version 
 		return fmt.Errorf("download step source %s@%s: %s", id, version, err)
 	}
 	return nil
-}
-
-// reuseCachedStepSource copies the V1 on-disk cache for id@version into destDir
-// when it is populated, reporting whether it did. This is the only steplib
-// lookup on the V2 path and is optional: a missing route just means "not cached".
-func reuseCachedStepSource(uri, id, version, destDir string) (bool, error) {
-	route, found := stepman.ReadRoute(uri)
-	if !found {
-		return false, nil
-	}
-	cacheDir := stepman.GetStepCacheDirPath(route, id, version)
-	exists, err := pathutil.IsPathExists(cacheDir)
-	if err != nil {
-		return false, fmt.Errorf("check if %s exists: %s", cacheDir, err)
-	}
-	if !exists {
-		return false, nil
-	}
-	return true, copyStep(cacheDir, destDir)
 }

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -8,8 +8,8 @@ import (
 	"github.com/bitrise-io/stepman/stepman"
 )
 
-// ErrStepSourceNotCached is returned on the V2 source path in offline mode when
-// the step source is not in the local cache. Match it with errors.Is.
+// ErrStepSourceNotCached is returned (wrapped) on the V2 source path in offline
+// mode when the step source is not in the local cache.
 var ErrStepSourceNotCached = errors.New("step source not available in the local cache and offline mode is set")
 
 // reuseCachedStepSource copies the V1 on-disk cache for id@version into destDir

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -1,4 +1,4 @@
-package stepman
+package steplib
 
 import (
 	"errors"
@@ -8,25 +8,23 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/stepman"
 )
 
-// ErrStepSourceNotCached is returned by ActivateStepSourceFromModel in offline
-// mode when the step source isn't already in the local cache. Callers may match
-// it via errors.Is to build a richer message.
+// ErrStepSourceNotCached is returned by activateStepSourceFromModel in offline
+// mode when the step source is not in the local cache. Match it with errors.Is.
 var ErrStepSourceNotCached = errors.New("step source not available in the local cache and offline mode is set")
 
-// ActivateStepSourceFromModel materializes the source for id@version into destDir
-// without requiring the local steplib to be set up (no ReadStepSpec/SetupLibrary).
-// It reuses the V1 on-disk cache when it is already populated; otherwise it
-// downloads the source from the passed step source (git URL + commit), which the
-// caller obtained from the V2 API. In offline mode a missing local cache returns
-// an error wrapping ErrStepSourceNotCached.
-func ActivateStepSourceFromModel(uri, id, version string, source *models.StepSourceModel, destDir string, log Logger, isOfflineMode bool) error {
-	// Reuse the V1 on-disk cache when it's already populated (e.g. a prior V1
-	// activation, or a warm cache). This is the only place the local steplib is
-	// consulted, and it's optional — a missing route just means "not cached".
-	if route, found := ReadRoute(uri); found {
-		cacheDir := GetStepCacheDirPath(route, id, version)
+// activateStepSourceFromModel materializes id@version's source into destDir
+// without setting up the local steplib (no ReadStepSpec/SetupLibrary). It reuses
+// the V1 on-disk cache when already populated; otherwise it downloads from the
+// given source (git URL + commit, as returned by the V2 API). Offline with no
+// cache returns ErrStepSourceNotCached.
+func activateStepSourceFromModel(uri, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
+	// Reuse the V1 cache when populated. This is the only steplib lookup, and it
+	// is optional: a missing route just means "not cached".
+	if route, found := stepman.ReadRoute(uri); found {
+		cacheDir := stepman.GetStepCacheDirPath(route, id, version)
 		if exists, err := pathutil.IsPathExists(cacheDir); err != nil {
 			return fmt.Errorf("check if %s exists: %s", cacheDir, err)
 		} else if exists {
@@ -43,7 +41,7 @@ func ActivateStepSourceFromModel(uri, id, version string, source *models.StepSou
 	}
 
 	locations := []models.DownloadLocationModel{{Type: "git", Src: source.Git}}
-	if err := downloadStepArchive(destDir, locations, id, version, source.Commit, log); err != nil {
+	if err := stepman.DownloadStepArchive(destDir, locations, id, version, source.Commit, log); err != nil {
 		return fmt.Errorf("download step source %s@%s: %s", id, version, err)
 	}
 	return nil

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -14,7 +14,7 @@ import (
 // without cloning a git steplib.
 func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
 	if isOfflineMode {
-		return fmt.Errorf("%s@%s: %w", id, version, errors.New("offline mode is not supported with Steplib API"))
+		return errors.New("offline mode is not supported with Steplib API")
 	}
 
 	if source == nil || source.Git == "" {

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -1,16 +1,54 @@
 package steplib
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
 )
 
 // ErrStepSourceNotCached is returned (wrapped) on the V2 source path in offline
 // mode when the step source is not in the local cache.
 var ErrStepSourceNotCached = errors.New("step source not available in the local cache and offline mode is set")
+
+// activateStepSourceV2 materializes id@version's source into destDir over the
+// steplib API, without setting up the local steplib. It reuses the V1 on-disk
+// cache when present; otherwise it downloads from the inventory's locations (zip
+// fast path, git fallback). The inventory locations are fetched only on the
+// download path, so offline mode and a cache hit do no network. Offline with no
+// cache returns ErrStepSourceNotCached.
+func activateStepSourceV2(libraryAPI *steplibrary.Client, uri, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
+	if reused, err := reuseCachedStepSource(uri, id, version, destDir); err != nil {
+		return err
+	} else if reused {
+		return nil
+	}
+
+	if isOfflineMode {
+		return fmt.Errorf("%s@%s: %w", id, version, ErrStepSourceNotCached)
+	}
+
+	if source == nil || source.Git == "" {
+		return fmt.Errorf("step %s@%s has no source git URL to download from", id, version)
+	}
+
+	locations, err := libraryAPI.StepDownloadLocations(context.Background(), id, version, source.Git)
+	if err != nil {
+		return fmt.Errorf("resolve download locations for %s@%s: %s", id, version, err)
+	}
+	if len(locations) == 0 {
+		return fmt.Errorf("step %s@%s has no download location", id, version)
+	}
+
+	if err := stepman.DownloadStepArchive(destDir, locations, id, version, source.Commit, log); err != nil {
+		return fmt.Errorf("download step source %s@%s: %s", id, version, err)
+	}
+	return nil
+}
 
 // reuseCachedStepSource copies the V1 on-disk cache for id@version into destDir
 // when it is populated, reporting whether it did. This is the only steplib

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -5,47 +5,28 @@ import (
 	"fmt"
 
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepman"
 )
 
-// ErrStepSourceNotCached is returned by activateStepSourceFromModel in offline
-// mode when the step source is not in the local cache. Match it with errors.Is.
+// ErrStepSourceNotCached is returned on the V2 source path in offline mode when
+// the step source is not in the local cache. Match it with errors.Is.
 var ErrStepSourceNotCached = errors.New("step source not available in the local cache and offline mode is set")
 
-// activateStepSourceFromModel materializes id@version's source into destDir
-// without setting up the local steplib (no ReadStepSpec/SetupLibrary). It reuses
-// the V1 on-disk cache when already populated; otherwise it downloads from the
-// locations resolveLocations returns (zip fast path + git fallback, as built
-// from the V2 API), verifying commit for the git clone. resolveLocations is
-// called lazily so offline mode does no network. Offline with no cache returns
-// ErrStepSourceNotCached.
-func activateStepSourceFromModel(uri, id, version, commit string, resolveLocations func() ([]models.DownloadLocationModel, error), destDir string, log stepman.Logger, isOfflineMode bool) error {
-	// Reuse the V1 cache when populated. This is the only steplib lookup, and it
-	// is optional: a missing route just means "not cached".
-	if route, found := stepman.ReadRoute(uri); found {
-		cacheDir := stepman.GetStepCacheDirPath(route, id, version)
-		if exists, err := pathutil.IsPathExists(cacheDir); err != nil {
-			return fmt.Errorf("check if %s exists: %s", cacheDir, err)
-		} else if exists {
-			return copyStep(cacheDir, destDir)
-		}
+// reuseCachedStepSource copies the V1 on-disk cache for id@version into destDir
+// when it is populated, reporting whether it did. This is the only steplib
+// lookup on the V2 path and is optional: a missing route just means "not cached".
+func reuseCachedStepSource(uri, id, version, destDir string) (bool, error) {
+	route, found := stepman.ReadRoute(uri)
+	if !found {
+		return false, nil
 	}
-
-	if isOfflineMode {
-		return fmt.Errorf("%s@%s: %w", id, version, ErrStepSourceNotCached)
-	}
-
-	locations, err := resolveLocations()
+	cacheDir := stepman.GetStepCacheDirPath(route, id, version)
+	exists, err := pathutil.IsPathExists(cacheDir)
 	if err != nil {
-		return fmt.Errorf("resolve download locations for %s@%s: %s", id, version, err)
+		return false, fmt.Errorf("check if %s exists: %s", cacheDir, err)
 	}
-	if len(locations) == 0 {
-		return fmt.Errorf("step %s@%s has no download location", id, version)
+	if !exists {
+		return false, nil
 	}
-
-	if err := stepman.DownloadStepArchive(destDir, locations, id, version, commit, log); err != nil {
-		return fmt.Errorf("download step source %s@%s: %s", id, version, err)
-	}
-	return nil
+	return true, copyStep(cacheDir, destDir)
 }

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -16,9 +16,11 @@ var ErrStepSourceNotCached = errors.New("step source not available in the local 
 // activateStepSourceFromModel materializes id@version's source into destDir
 // without setting up the local steplib (no ReadStepSpec/SetupLibrary). It reuses
 // the V1 on-disk cache when already populated; otherwise it downloads from the
-// given source (git URL + commit, as returned by the V2 API). Offline with no
-// cache returns ErrStepSourceNotCached.
-func activateStepSourceFromModel(uri, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
+// locations resolveLocations returns (zip fast path + git fallback, as built
+// from the V2 API), verifying commit for the git clone. resolveLocations is
+// called lazily so offline mode does no network. Offline with no cache returns
+// ErrStepSourceNotCached.
+func activateStepSourceFromModel(uri, id, version, commit string, resolveLocations func() ([]models.DownloadLocationModel, error), destDir string, log stepman.Logger, isOfflineMode bool) error {
 	// Reuse the V1 cache when populated. This is the only steplib lookup, and it
 	// is optional: a missing route just means "not cached".
 	if route, found := stepman.ReadRoute(uri); found {
@@ -34,12 +36,15 @@ func activateStepSourceFromModel(uri, id, version string, source *models.StepSou
 		return fmt.Errorf("%s@%s: %w", id, version, ErrStepSourceNotCached)
 	}
 
-	if source == nil || source.Git == "" {
-		return fmt.Errorf("step %s@%s has no source git URL to download from", id, version)
+	locations, err := resolveLocations()
+	if err != nil {
+		return fmt.Errorf("resolve download locations for %s@%s: %s", id, version, err)
+	}
+	if len(locations) == 0 {
+		return fmt.Errorf("step %s@%s has no download location", id, version)
 	}
 
-	locations := []models.DownloadLocationModel{{Type: "git", Src: source.Git}}
-	if err := stepman.DownloadStepArchive(destDir, locations, id, version, source.Commit, log); err != nil {
+	if err := stepman.DownloadStepArchive(destDir, locations, id, version, commit, log); err != nil {
 		return fmt.Errorf("download step source %s@%s: %s", id, version, err)
 	}
 	return nil

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -15,13 +15,9 @@ import (
 // mode when the step source is not in the local cache.
 var ErrStepSourceNotCached = errors.New("step source not available in the local cache and offline mode is set")
 
-// activateStepSourceV2 materializes id@version's source into destDir over the
-// steplib API, without setting up the local steplib. It reuses the V1 on-disk
-// cache when present; otherwise it downloads from the inventory's locations (zip
-// fast path, git fallback). The inventory locations are fetched only on the
-// download path, so offline mode and a cache hit do no network. Offline with no
-// cache returns ErrStepSourceNotCached.
-func activateStepSourceV2(libraryAPI *steplibrary.Client, uri, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
+// activateStepSourceWithAPI materializes id@version's source into destDir
+// without cloning a git steplib.
+func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, uri, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
 	if reused, err := reuseCachedStepSource(uri, id, version, destDir); err != nil {
 		return err
 	} else if reused {
@@ -36,6 +32,7 @@ func activateStepSourceV2(libraryAPI *steplibrary.Client, uri, id, version strin
 		return fmt.Errorf("step %s@%s has no source git URL to download from", id, version)
 	}
 
+	// The source download locations are fetched only if no cache hit and not offline mode
 	locations, err := libraryAPI.StepDownloadLocations(context.Background(), id, version, source.Git)
 	if err != nil {
 		return fmt.Errorf("resolve download locations for %s@%s: %s", id, version, err)

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -10,15 +10,11 @@ import (
 	"github.com/bitrise-io/stepman/stepman"
 )
 
-// ErrStepSourceNotCached is returned (wrapped) on the V2 source path in offline
-// mode when the step source is not in the local cache.
-var ErrStepSourceNotCached = errors.New("step source not available in the local cache and offline mode is set")
-
 // activateStepSourceWithAPI materializes id@version's source into destDir
 // without cloning a git steplib.
 func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
 	if isOfflineMode {
-		return fmt.Errorf("%s@%s: %w", id, version, ErrStepSourceNotCached)
+		return fmt.Errorf("%s@%s: %w", id, version, errors.New("offline mode is not supported with Steplib API"))
 	}
 
 	if source == nil || source.Git == "" {

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -3,9 +3,7 @@ package steplib
 import (
 	"errors"
 	"fmt"
-	"os"
 
-	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepman"
@@ -28,7 +26,7 @@ func activateStepSourceFromModel(uri, id, version string, source *models.StepSou
 		if exists, err := pathutil.IsPathExists(cacheDir); err != nil {
 			return fmt.Errorf("check if %s exists: %s", cacheDir, err)
 		} else if exists {
-			return copyStepDir(cacheDir, destDir)
+			return copyStep(cacheDir, destDir)
 		}
 	}
 
@@ -43,20 +41,6 @@ func activateStepSourceFromModel(uri, id, version string, source *models.StepSou
 	locations := []models.DownloadLocationModel{{Type: "git", Src: source.Git}}
 	if err := stepman.DownloadStepArchive(destDir, locations, id, version, source.Commit, log); err != nil {
 		return fmt.Errorf("download step source %s@%s: %s", id, version, err)
-	}
-	return nil
-}
-
-func copyStepDir(src, dst string) error {
-	if exists, err := pathutil.IsPathExists(dst); err != nil {
-		return fmt.Errorf("check if %s exists: %s", dst, err)
-	} else if !exists {
-		if err := os.MkdirAll(dst, 0777); err != nil {
-			return fmt.Errorf("create dir %s: %s", dst, err)
-		}
-	}
-	if err := command.CopyDir(src+"/", dst, true); err != nil {
-		return fmt.Errorf("copy %s to %s: %s", src, dst, err)
 	}
 	return nil
 }

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -3,10 +3,12 @@ package activator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/stepman/stepid"
+	"github.com/bitrise-io/stepman/stepman"
 	"github.com/stretchr/testify/require"
 )
 
@@ -173,6 +175,79 @@ func TestActivateSteplibRefStep(t *testing.T) {
 			exists, err := pathutil.IsPathExists(got.StepYMLPath)
 			require.NoError(t, err)
 			require.True(t, exists, "step.yml should be copied into the work dir")
+		})
+	}
+}
+
+// TestActivateSteplibRefStep_APIEnabled covers the v2 (steplib API) activation
+// path. Each case runs in a fresh $HOME with the API flag on, so a passing run
+// proves v2 resolves and activates against the hosted inventory without the
+// local steplib being set up — the dependency the v1-first integration matrix
+// masks. It also asserts no v1 steplib route was created.
+func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
+	const steplib = "https://github.com/bitrise-io/bitrise-steplib.git"
+
+	tests := []struct {
+		name        string
+		id          stepid.CanonicalID
+		wantVersion string // exact concrete version; empty when only wantPrefix is checked
+		wantPrefix  string
+		wantErr     bool
+	}{
+		{
+			name:        "Exact version activates from source over the API",
+			id:          stepid.CanonicalID{SteplibSource: steplib, IDorURI: "git-clone", Version: "8.5.0"},
+			wantVersion: "8.5.0",
+		},
+		{
+			name:       "Minor version lock resolves to a concrete version",
+			id:         stepid.CanonicalID{SteplibSource: steplib, IDorURI: "git-clone", Version: "8.4"},
+			wantPrefix: "8.4.",
+		},
+		{
+			name:    "Non-existent version fails",
+			id:      stepid.CanonicalID{SteplibSource: steplib, IDorURI: "git-clone", Version: "99.99.99"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir()) // fresh: the v1 steplib is not set up
+			t.Setenv("BITRISE_STEPLIB_API_ENABLE", "true")
+			t.Setenv("BITRISE_EXPERIMENT_PRECOMPILED_STEPS", "false")
+
+			activatedStepDir := t.TempDir()
+			workDir := t.TempDir()
+
+			got, err := ActivateSteplibRefStep(TestLogger[*testing.T]{t}, tt.id, activatedStepDir, workDir, false, false)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			require.Equal(t, tt.id.IDorURI, got.StepInfo.ID)
+			require.Equal(t, tt.id.Version, got.StepInfo.OriginalVersion)
+			if tt.wantVersion != "" {
+				require.Equal(t, tt.wantVersion, got.StepInfo.Version)
+			}
+			if tt.wantPrefix != "" {
+				require.True(t, strings.HasPrefix(got.StepInfo.Version, tt.wantPrefix),
+					"resolved version %q should start with %q", got.StepInfo.Version, tt.wantPrefix)
+			}
+			require.Equal(t, ActivationTypeSteplibSource, got.ActivationType)
+			require.Empty(t, got.ExecutablePath)
+			require.False(t, got.DidStepLibUpdate)
+
+			require.Equal(t, filepath.Join(workDir, "current_step.yml"), got.StepYMLPath)
+			exists, err := pathutil.IsPathExists(got.StepYMLPath)
+			require.NoError(t, err)
+			require.True(t, exists, "current_step.yml should be written into the work dir")
+
+			// V2 must not have set up the v1 local steplib.
+			_, found := stepman.ReadRoute(steplib)
+			require.False(t, found, "v2 activation must not set up the v1 steplib")
 		})
 	}
 }

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -179,11 +179,10 @@ func TestActivateSteplibRefStep(t *testing.T) {
 	}
 }
 
-// TestActivateSteplibRefStep_APIEnabled covers the v2 (steplib API) activation
+// TestActivateSteplibRefStep_APIEnabled covers steplib API activation
 // path. Each case runs in a fresh $HOME with the API flag on, so a passing run
-// proves v2 resolves and activates against the hosted inventory without the
-// local steplib being set up — the dependency the v1-first integration matrix
-// masks. It also asserts no v1 steplib route was created.
+// proves API resolves and activates against the hosted inventory without the
+// git cloned steplib being set up
 func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 	const steplib = "https://github.com/bitrise-io/bitrise-steplib.git"
 
@@ -213,7 +212,7 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir()) // fresh: the v1 steplib is not set up
+			t.Setenv("HOME", t.TempDir()) // fresh: the git cloned steplib is not set up
 			t.Setenv("BITRISE_STEPLIB_API_ENABLE", "true")
 			t.Setenv("BITRISE_EXPERIMENT_PRECOMPILED_STEPS", "false")
 
@@ -245,7 +244,7 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, exists, "current_step.yml should be written into the work dir")
 
-			// V2 must not have set up the v1 local steplib.
+			// API route must not have set up the git cloned steplib.
 			_, found := stepman.ReadRoute(steplib)
 			require.False(t, found, "v2 activation must not set up the v1 steplib")
 		})

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -317,28 +317,34 @@ func (collection StepCollectionModel) GetDownloadLocations(id, version string) (
 		return []DownloadLocationModel{}, errors.New("missing Source property")
 	}
 
-	locations := []DownloadLocationModel{}
-	for _, downloadLocation := range collection.DownloadLocations {
-		switch downloadLocation.Type {
-		case "zip":
-			url := downloadLocation.Src + id + "/" + version + "/step.zip"
-			location := DownloadLocationModel{
-				Type: downloadLocation.Type,
-				Src:  url,
-			}
-			locations = append(locations, location)
-		case "git":
-			location := DownloadLocationModel{
-				Type: downloadLocation.Type,
-				Src:  step.Source.Git,
-			}
-			locations = append(locations, location)
-		default:
-			return []DownloadLocationModel{}, fmt.Errorf("invalid download location (%#v) for step (%#v)", downloadLocation, id)
-		}
+	locations, err := BuildStepDownloadLocations(collection.DownloadLocations, id, version, step.Source.Git)
+	if err != nil {
+		return []DownloadLocationModel{}, err
 	}
 	if len(locations) < 1 {
 		return []DownloadLocationModel{}, fmt.Errorf("no download location found for step (%#v)", id)
+	}
+	return locations, nil
+}
+
+// BuildStepDownloadLocations resolves the concrete source download locations for
+// id@version from the steplib's base locations (steplib.yml / the V2 meta.json),
+// preserving their order: a "zip" base becomes <base>/<id>/<version>/step.zip and
+// a "git" base becomes the step's own source git URL (skipped when empty). An
+// unknown location type is an error.
+func BuildStepDownloadLocations(baseLocations []DownloadLocationModel, id, version, sourceGit string) ([]DownloadLocationModel, error) {
+	locations := []DownloadLocationModel{}
+	for _, base := range baseLocations {
+		switch base.Type {
+		case "zip":
+			locations = append(locations, DownloadLocationModel{Type: "zip", Src: base.Src + id + "/" + version + "/step.zip"})
+		case "git":
+			if sourceGit != "" {
+				locations = append(locations, DownloadLocationModel{Type: "git", Src: sourceGit})
+			}
+		default:
+			return nil, fmt.Errorf("invalid download location type %q for step %s", base.Type, id)
+		}
 	}
 	return locations, nil
 }

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -317,7 +317,7 @@ func (collection StepCollectionModel) GetDownloadLocations(id, version string) (
 		return []DownloadLocationModel{}, errors.New("missing Source property")
 	}
 
-	locations, err := BuildStepDownloadLocations(collection.DownloadLocations, id, version, step.Source.Git)
+	locations, err := BuildStepSourceDownloadLocations(collection.DownloadLocations, id, version, step.Source.Git)
 	if err != nil {
 		return []DownloadLocationModel{}, err
 	}
@@ -327,9 +327,9 @@ func (collection StepCollectionModel) GetDownloadLocations(id, version string) (
 	return locations, nil
 }
 
-// BuildStepDownloadLocations resolves a priority order of source download locations for
+// BuildStepSourceDownloadLocations resolves a priority order of source download locations for
 // an exact step version.
-func BuildStepDownloadLocations(baseLocations []DownloadLocationModel, id, version, repoURL string) ([]DownloadLocationModel, error) {
+func BuildStepSourceDownloadLocations(baseLocations []DownloadLocationModel, id, version, repoURL string) ([]DownloadLocationModel, error) {
 	locations := []DownloadLocationModel{}
 	for _, base := range baseLocations {
 		switch base.Type {

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -327,20 +327,17 @@ func (collection StepCollectionModel) GetDownloadLocations(id, version string) (
 	return locations, nil
 }
 
-// BuildStepDownloadLocations resolves the concrete source download locations for
-// id@version from the steplib's base locations (steplib.yml / the V2 meta.json),
-// preserving their order: a "zip" base becomes <base>/<id>/<version>/step.zip and
-// a "git" base becomes the step's own source git URL (skipped when empty). An
-// unknown location type is an error.
-func BuildStepDownloadLocations(baseLocations []DownloadLocationModel, id, version, sourceGit string) ([]DownloadLocationModel, error) {
+// BuildStepDownloadLocations resolves a priority order of source download locations for
+// an exact step version.
+func BuildStepDownloadLocations(baseLocations []DownloadLocationModel, id, version, repoURL string) ([]DownloadLocationModel, error) {
 	locations := []DownloadLocationModel{}
 	for _, base := range baseLocations {
 		switch base.Type {
 		case "zip":
 			locations = append(locations, DownloadLocationModel{Type: "zip", Src: base.Src + id + "/" + version + "/step.zip"})
 		case "git":
-			if sourceGit != "" {
-				locations = append(locations, DownloadLocationModel{Type: "git", Src: sourceGit})
+			if repoURL != "" {
+				locations = append(locations, DownloadLocationModel{Type: "git", Src: repoURL})
 			}
 		default:
 			return nil, fmt.Errorf("invalid download location type %q for step %s", base.Type, id)

--- a/steplibrary/api.go
+++ b/steplibrary/api.go
@@ -23,8 +23,8 @@ type API interface {
 	// GetStepModel fetches the V2 per-version step manifest (mirrors
 	// `steps/<id>/<version>/step.json`, which serializes models.StepModel).
 	GetStepModel(ctx context.Context, step ResolvedStepVersion) (models.StepModel, error)
-	// GetDownloadLocations returns the inventory-wide base download locations
+	// GetStepSourceDownloadLocations returns the inventory-wide base download locations
 	// (mirrors meta.json's download_locations): a zip base and a git marker,
 	// from which per-step source URLs are built.
-	GetDownloadLocations(ctx context.Context) ([]models.DownloadLocationModel, error)
+	GetStepSourceDownloadLocations(ctx context.Context) ([]models.DownloadLocationModel, error)
 }

--- a/steplibrary/api.go
+++ b/steplibrary/api.go
@@ -23,4 +23,8 @@ type API interface {
 	// GetStepModel fetches the V2 per-version step manifest (mirrors
 	// `steps/<id>/<version>/step.json`, which serializes models.StepModel).
 	GetStepModel(ctx context.Context, step ResolvedStepVersion) (models.StepModel, error)
+	// GetDownloadLocations returns the inventory-wide base download locations
+	// (mirrors meta.json's download_locations): a zip base and a git marker,
+	// from which per-step source URLs are built.
+	GetDownloadLocations(ctx context.Context) ([]models.DownloadLocationModel, error)
 }

--- a/steplibrary/fakes_test.go
+++ b/steplibrary/fakes_test.go
@@ -15,17 +15,17 @@ import (
 // fixtures and injectable errors. Construct the standard "script" fixtures with
 // newFakeAPI; override individual fields for table-driven and error cases.
 type fakeAPI struct {
-	ids                  []string
-	listErr              error
-	latestVersions       map[string]steplibindex.LatestPointer
-	latestVersionsErr    error
-	allVersions          map[string][]string
-	allVersionsErr       error
-	groupInfo            map[string]steplibindex.StepInfo
-	groupInfoErr         error
-	stepModel            map[string]models.StepModel
-	downloadLocations    []models.DownloadLocationModel
-	downloadLocationsErr error
+	ids                            []string
+	listErr                        error
+	latestVersions                 map[string]steplibindex.LatestPointer
+	latestVersionsErr              error
+	allVersions                    map[string][]string
+	allVersionsErr                 error
+	groupInfo                      map[string]steplibindex.StepInfo
+	groupInfoErr                   error
+	stepModel                      map[string]models.StepModel
+	stepSourceDownloadLocations    []models.DownloadLocationModel
+	stepSourceDownloadLocationsErr error
 }
 
 // newFakeAPI returns a fakeAPI pre-populated with the standard "script" step
@@ -50,7 +50,7 @@ func newFakeAPI() fakeAPI {
 		stepModel: map[string]models.StepModel{
 			"script": {Title: pointers.NewStringPtr("Script"), Summary: pointers.NewStringPtr("Runs a shell script.")},
 		},
-		downloadLocations: []models.DownloadLocationModel{
+		stepSourceDownloadLocations: []models.DownloadLocationModel{
 			{Type: "zip", Src: "https://cdn.example/step-archives/"},
 			{Type: "git", Src: "source/git"},
 		},
@@ -103,7 +103,7 @@ func (f fakeAPI) GetStepModel(_ context.Context, step ResolvedStepVersion) (mode
 }
 
 func (f fakeAPI) GetStepSourceDownloadLocations(_ context.Context) ([]models.DownloadLocationModel, error) {
-	return f.downloadLocations, f.downloadLocationsErr
+	return f.stepSourceDownloadLocations, f.stepSourceDownloadLocationsErr
 }
 
 // fakeGetFetcher implements httpfetch.Client.Get, returning a fixed body whose

--- a/steplibrary/fakes_test.go
+++ b/steplibrary/fakes_test.go
@@ -15,12 +15,12 @@ import (
 // fixtures and injectable errors. Construct the standard "script" fixtures with
 // newFakeAPI; override individual fields for table-driven and error cases.
 type fakeAPI struct {
-	ids               []string
-	listErr           error
-	latestVersions    map[string]steplibindex.LatestPointer
-	latestVersionsErr error
-	allVersions       map[string][]string
-	allVersionsErr    error
+	ids                  []string
+	listErr              error
+	latestVersions       map[string]steplibindex.LatestPointer
+	latestVersionsErr    error
+	allVersions          map[string][]string
+	allVersionsErr       error
 	groupInfo            map[string]steplibindex.StepInfo
 	groupInfoErr         error
 	stepModel            map[string]models.StepModel
@@ -102,7 +102,7 @@ func (f fakeAPI) GetStepModel(_ context.Context, step ResolvedStepVersion) (mode
 	return v, nil
 }
 
-func (f fakeAPI) GetDownloadLocations(_ context.Context) ([]models.DownloadLocationModel, error) {
+func (f fakeAPI) GetStepSourceDownloadLocations(_ context.Context) ([]models.DownloadLocationModel, error) {
 	return f.downloadLocations, f.downloadLocationsErr
 }
 

--- a/steplibrary/fakes_test.go
+++ b/steplibrary/fakes_test.go
@@ -21,9 +21,11 @@ type fakeAPI struct {
 	latestVersionsErr error
 	allVersions       map[string][]string
 	allVersionsErr    error
-	groupInfo         map[string]steplibindex.StepInfo
-	groupInfoErr      error
-	stepModel         map[string]models.StepModel
+	groupInfo            map[string]steplibindex.StepInfo
+	groupInfoErr         error
+	stepModel            map[string]models.StepModel
+	downloadLocations    []models.DownloadLocationModel
+	downloadLocationsErr error
 }
 
 // newFakeAPI returns a fakeAPI pre-populated with the standard "script" step
@@ -47,6 +49,10 @@ func newFakeAPI() fakeAPI {
 		},
 		stepModel: map[string]models.StepModel{
 			"script": {Title: pointers.NewStringPtr("Script"), Summary: pointers.NewStringPtr("Runs a shell script.")},
+		},
+		downloadLocations: []models.DownloadLocationModel{
+			{Type: "zip", Src: "https://cdn.example/step-archives/"},
+			{Type: "git", Src: "source/git"},
 		},
 	}
 }
@@ -94,6 +100,10 @@ func (f fakeAPI) GetStepModel(_ context.Context, step ResolvedStepVersion) (mode
 		return models.StepModel{}, errors.New("not found")
 	}
 	return v, nil
+}
+
+func (f fakeAPI) GetDownloadLocations(_ context.Context) ([]models.DownloadLocationModel, error) {
+	return f.downloadLocations, f.downloadLocationsErr
 }
 
 // fakeGetFetcher implements httpfetch.Client.Get, returning a fixed body whose

--- a/steplibrary/http_api.go
+++ b/steplibrary/http_api.go
@@ -81,7 +81,7 @@ func (h *HTTPAPI) GetStepModel(ctx context.Context, step ResolvedStepVersion) (m
 	return out, nil
 }
 
-func (h *HTTPAPI) GetDownloadLocations(ctx context.Context) ([]models.DownloadLocationModel, error) {
+func (h *HTTPAPI) GetStepSourceDownloadLocations(ctx context.Context) ([]models.DownloadLocationModel, error) {
 	var out steplibindex.Meta
 	if err := h.fetchJSON(ctx, steplibindex.MetaPath().URL(), &out); err != nil {
 		return nil, err

--- a/steplibrary/http_api.go
+++ b/steplibrary/http_api.go
@@ -81,6 +81,14 @@ func (h *HTTPAPI) GetStepModel(ctx context.Context, step ResolvedStepVersion) (m
 	return out, nil
 }
 
+func (h *HTTPAPI) GetDownloadLocations(ctx context.Context) ([]models.DownloadLocationModel, error) {
+	var out steplibindex.Meta
+	if err := h.fetchJSON(ctx, steplibindex.MetaPath().URL(), &out); err != nil {
+		return nil, err
+	}
+	return out.DownloadLocations, nil
+}
+
 func (h *HTTPAPI) fetchJSON(ctx context.Context, path string, dst any) (err error) {
 	body, err := h.Fetcher.Get(ctx, h.BaseURL+path)
 	if err != nil {

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -51,20 +51,5 @@ func (c *Client) StepDownloadLocations(ctx context.Context, id, version, sourceG
 	if err != nil {
 		return nil, fmt.Errorf("fetch download locations: %w", err)
 	}
-
-	var locations []models.DownloadLocationModel
-	for _, base := range bases {
-		switch base.Type {
-		case "zip":
-			locations = append(locations, models.DownloadLocationModel{
-				Type: "zip",
-				Src:  base.Src + id + "/" + version + "/step.zip",
-			})
-		case "git":
-			if sourceGit != "" {
-				locations = append(locations, models.DownloadLocationModel{Type: "git", Src: sourceGit})
-			}
-		}
-	}
-	return locations, nil
+	return models.BuildStepDownloadLocations(bases, id, version, sourceGit)
 }

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -47,5 +47,5 @@ func (c *Client) StepSourceDownloadLocations(ctx context.Context, id, version, s
 	if err != nil {
 		return nil, fmt.Errorf("fetch download locations: %w", err)
 	}
-	return models.BuildStepDownloadLocations(bases, id, version, sourceGit)
+	return models.BuildStepSourceDownloadLocations(bases, id, version, sourceGit)
 }

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -40,3 +40,31 @@ func (c *Client) FetchStepMetadata(ctx context.Context, stepRef stepid.Canonical
 
 	return stepInfo, nil
 }
+
+// StepDownloadLocations resolves the concrete source download locations for
+// id@version from the inventory's base locations (meta.json download_locations),
+// preserving their order: a "zip" base becomes <base>/<id>/<version>/step.zip and
+// a "git" base becomes the step's own source git URL. For the bitrise steplib zip
+// comes first, so callers try the zip fast path before falling back to a git clone.
+func (c *Client) StepDownloadLocations(ctx context.Context, id, version, sourceGit string) ([]models.DownloadLocationModel, error) {
+	bases, err := c.api.GetDownloadLocations(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch download locations: %w", err)
+	}
+
+	var locations []models.DownloadLocationModel
+	for _, base := range bases {
+		switch base.Type {
+		case "zip":
+			locations = append(locations, models.DownloadLocationModel{
+				Type: "zip",
+				Src:  base.Src + id + "/" + version + "/step.zip",
+			})
+		case "git":
+			if sourceGit != "" {
+				locations = append(locations, models.DownloadLocationModel{Type: "git", Src: sourceGit})
+			}
+		}
+	}
+	return locations, nil
+}

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -41,11 +41,7 @@ func (c *Client) FetchStepMetadata(ctx context.Context, stepRef stepid.Canonical
 	return stepInfo, nil
 }
 
-// StepDownloadLocations resolves the concrete source download locations for
-// id@version from the inventory's base locations (meta.json download_locations),
-// preserving their order: a "zip" base becomes <base>/<id>/<version>/step.zip and
-// a "git" base becomes the step's own source git URL. For the bitrise steplib zip
-// comes first, so callers try the zip fast path before falling back to a git clone.
+// StepDownloadLocations returns a priority order of step source zip download locations
 func (c *Client) StepDownloadLocations(ctx context.Context, id, version, sourceGit string) ([]models.DownloadLocationModel, error) {
 	bases, err := c.api.GetDownloadLocations(ctx)
 	if err != nil {

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -41,8 +41,8 @@ func (c *Client) FetchStepMetadata(ctx context.Context, stepRef stepid.Canonical
 	return stepInfo, nil
 }
 
-// StepDownloadLocations returns a priority order of step source zip download locations
-func (c *Client) StepDownloadLocations(ctx context.Context, id, version, sourceGit string) ([]models.DownloadLocationModel, error) {
+// StepSourceDownloadLocations returns a priority order of step source zip download locations
+func (c *Client) StepSourceDownloadLocations(ctx context.Context, id, version, sourceGit string) ([]models.DownloadLocationModel, error) {
 	bases, err := c.api.GetDownloadLocations(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fetch download locations: %w", err)

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -43,7 +43,7 @@ func (c *Client) FetchStepMetadata(ctx context.Context, stepRef stepid.Canonical
 
 // StepSourceDownloadLocations returns a priority order of step source zip download locations
 func (c *Client) StepSourceDownloadLocations(ctx context.Context, id, version, sourceGit string) ([]models.DownloadLocationModel, error) {
-	bases, err := c.api.GetDownloadLocations(ctx)
+	bases, err := c.api.GetStepSourceDownloadLocations(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fetch download locations: %w", err)
 	}

--- a/steplibrary/steplibrary_test.go
+++ b/steplibrary/steplibrary_test.go
@@ -124,3 +124,25 @@ func TestResolveMinorLocked(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_StepDownloadLocations(t *testing.T) {
+	api := newFakeAPI() // zip base "https://cdn.example/step-archives/" + git marker
+	c := &Client{api: api} //nolint:exhaustruct // only api is needed
+
+	t.Run("zip first, git fallback with the step's own git URL", func(t *testing.T) {
+		got, err := c.StepDownloadLocations(t.Context(), "git-clone", "8.5.0", "https://github.com/x/steps-git-clone.git")
+		require.NoError(t, err)
+		require.Equal(t, []models.DownloadLocationModel{
+			{Type: "zip", Src: "https://cdn.example/step-archives/git-clone/8.5.0/step.zip"},
+			{Type: "git", Src: "https://github.com/x/steps-git-clone.git"},
+		}, got)
+	})
+
+	t.Run("git location is omitted when the step has no source git URL", func(t *testing.T) {
+		got, err := c.StepDownloadLocations(t.Context(), "git-clone", "8.5.0", "")
+		require.NoError(t, err)
+		require.Equal(t, []models.DownloadLocationModel{
+			{Type: "zip", Src: "https://cdn.example/step-archives/git-clone/8.5.0/step.zip"},
+		}, got)
+	})
+}

--- a/steplibrary/steplibrary_test.go
+++ b/steplibrary/steplibrary_test.go
@@ -125,7 +125,7 @@ func TestResolveMinorLocked(t *testing.T) {
 	}
 }
 
-func TestClient_StepDownloadLocations(t *testing.T) {
+func TestClient_StepSourceDownloadLocations(t *testing.T) {
 	api := newFakeAPI()    // zip base "https://cdn.example/step-archives/" + git marker
 	c := &Client{api: api} //nolint:exhaustruct // only api is needed
 

--- a/steplibrary/steplibrary_test.go
+++ b/steplibrary/steplibrary_test.go
@@ -126,11 +126,11 @@ func TestResolveMinorLocked(t *testing.T) {
 }
 
 func TestClient_StepDownloadLocations(t *testing.T) {
-	api := newFakeAPI() // zip base "https://cdn.example/step-archives/" + git marker
+	api := newFakeAPI()    // zip base "https://cdn.example/step-archives/" + git marker
 	c := &Client{api: api} //nolint:exhaustruct // only api is needed
 
 	t.Run("zip first, git fallback with the step's own git URL", func(t *testing.T) {
-		got, err := c.StepDownloadLocations(t.Context(), "git-clone", "8.5.0", "https://github.com/x/steps-git-clone.git")
+		got, err := c.StepSourceDownloadLocations(t.Context(), "git-clone", "8.5.0", "https://github.com/x/steps-git-clone.git")
 		require.NoError(t, err)
 		require.Equal(t, []models.DownloadLocationModel{
 			{Type: "zip", Src: "https://cdn.example/step-archives/git-clone/8.5.0/step.zip"},
@@ -139,7 +139,7 @@ func TestClient_StepDownloadLocations(t *testing.T) {
 	})
 
 	t.Run("git location is omitted when the step has no source git URL", func(t *testing.T) {
-		got, err := c.StepDownloadLocations(t.Context(), "git-clone", "8.5.0", "")
+		got, err := c.StepSourceDownloadLocations(t.Context(), "git-clone", "8.5.0", "")
 		require.NoError(t, err)
 		require.Equal(t, []models.DownloadLocationModel{
 			{Type: "zip", Src: "https://cdn.example/step-archives/git-clone/8.5.0/step.zip"},

--- a/stepman/source.go
+++ b/stepman/source.go
@@ -1,0 +1,64 @@
+package stepman
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/stepman/models"
+)
+
+// ErrStepSourceNotCached is returned by ActivateStepSourceFromModel in offline
+// mode when the step source isn't already in the local cache. Callers may match
+// it via errors.Is to build a richer message.
+var ErrStepSourceNotCached = errors.New("step source not available in the local cache and offline mode is set")
+
+// ActivateStepSourceFromModel materializes the source for id@version into destDir
+// without requiring the local steplib to be set up (no ReadStepSpec/SetupLibrary).
+// It reuses the V1 on-disk cache when it is already populated; otherwise it
+// downloads the source from the passed step source (git URL + commit), which the
+// caller obtained from the V2 API. In offline mode a missing local cache returns
+// an error wrapping ErrStepSourceNotCached.
+func ActivateStepSourceFromModel(uri, id, version string, source *models.StepSourceModel, destDir string, log Logger, isOfflineMode bool) error {
+	// Reuse the V1 on-disk cache when it's already populated (e.g. a prior V1
+	// activation, or a warm cache). This is the only place the local steplib is
+	// consulted, and it's optional — a missing route just means "not cached".
+	if route, found := ReadRoute(uri); found {
+		cacheDir := GetStepCacheDirPath(route, id, version)
+		if exists, err := pathutil.IsPathExists(cacheDir); err != nil {
+			return fmt.Errorf("check if %s exists: %s", cacheDir, err)
+		} else if exists {
+			return copyStepDir(cacheDir, destDir)
+		}
+	}
+
+	if isOfflineMode {
+		return fmt.Errorf("%s@%s: %w", id, version, ErrStepSourceNotCached)
+	}
+
+	if source == nil || source.Git == "" {
+		return fmt.Errorf("step %s@%s has no source git URL to download from", id, version)
+	}
+
+	locations := []models.DownloadLocationModel{{Type: "git", Src: source.Git}}
+	if err := downloadStepArchive(destDir, locations, id, version, source.Commit, log); err != nil {
+		return fmt.Errorf("download step source %s@%s: %s", id, version, err)
+	}
+	return nil
+}
+
+func copyStepDir(src, dst string) error {
+	if exists, err := pathutil.IsPathExists(dst); err != nil {
+		return fmt.Errorf("check if %s exists: %s", dst, err)
+	} else if !exists {
+		if err := os.MkdirAll(dst, 0777); err != nil {
+			return fmt.Errorf("create dir %s: %s", dst, err)
+		}
+	}
+	if err := command.CopyDir(src+"/", dst, true); err != nil {
+		return fmt.Errorf("copy %s to %s: %s", src, dst, err)
+	}
+	return nil
+}

--- a/stepman/util.go
+++ b/stepman/util.go
@@ -124,11 +124,19 @@ func DownloadStep(collectionURI string, collection models.StepCollectionModel, i
 		return nil
 	}
 
+	return downloadStepArchive(stepPth, downloadLocations, id, version, commithash, log)
+}
+
+// downloadStepArchive fetches a step's source into destDir from the given download
+// locations (zip or git), verifying the git commit. Locations are tried in order;
+// it returns an error only if all of them fail. It does not touch the steplib
+// route or cache, so it works for both the V1 (local spec) and V2 (API) paths.
+func downloadStepArchive(destDir string, downloadLocations []models.DownloadLocationModel, id, version, commithash string, log Logger) error {
 	for _, downloadLocation := range downloadLocations {
 		switch downloadLocation.Type {
 		case "zip":
 			err := retry.Times(2).Wait(3 * time.Second).Try(func(attempt uint) error {
-				return command.DownloadAndUnZIP(downloadLocation.Src, stepPth)
+				return command.DownloadAndUnZIP(downloadLocation.Src, destDir)
 			})
 
 			if err != nil {
@@ -138,7 +146,7 @@ func DownloadStep(collectionURI string, collection models.StepCollectionModel, i
 			}
 		case "git":
 			err := retry.Times(2).Wait(3 * time.Second).Try(func(attempt uint) error {
-				repo, err := git.New(stepPth)
+				repo, err := git.New(destDir)
 				if err != nil {
 					return err
 				}

--- a/stepman/util.go
+++ b/stepman/util.go
@@ -127,10 +127,12 @@ func DownloadStep(collectionURI string, collection models.StepCollectionModel, i
 	return DownloadStepArchive(stepPth, downloadLocations, id, version, commithash, log)
 }
 
-// DownloadStepArchive fetches a step's source into destDir from the given download
-// locations (zip or git), verifying the git commit. Locations are tried in order;
-// it returns an error only if all of them fail. It does not touch the steplib
-// route or cache, so it works for both the V1 (local spec) and V2 (API) paths.
+// DownloadStepArchive fetches a step's source into destDir from the given
+// download locations, tried in order; it returns an error only if all of them
+// fail. A "git" location is cloned at the version tag and verified against
+// commithash; a "zip" location is trusted as served (commithash applies only to
+// git). It does not touch the steplib route or cache, so it serves both the V1
+// (local spec) and V2 (API) paths.
 func DownloadStepArchive(destDir string, downloadLocations []models.DownloadLocationModel, id, version, commithash string, log Logger) error {
 	for _, downloadLocation := range downloadLocations {
 		switch downloadLocation.Type {

--- a/stepman/util.go
+++ b/stepman/util.go
@@ -124,16 +124,13 @@ func DownloadStep(collectionURI string, collection models.StepCollectionModel, i
 		return nil
 	}
 
-	return DownloadStepArchive(stepPth, downloadLocations, id, version, commithash, log)
+	return DownloadStepSourceArchive(stepPth, downloadLocations, id, version, commithash, log)
 }
 
-// DownloadStepArchive fetches a step's source into destDir from the given
-// download locations, tried in order; it returns an error only if all of them
-// fail. A "git" location is cloned at the version tag and verified against
-// commithash; a "zip" location is trusted as served (commithash applies only to
-// git). It does not touch the steplib route or cache, so it serves both the V1
-// (local spec) and V2 (API) paths.
-func DownloadStepArchive(destDir string, downloadLocations []models.DownloadLocationModel, id, version, commithash string, log Logger) error {
+// DownloadStepSourceArchive fetches a step's source into destDir from the given
+// download locations in priority order.
+// commithash applies only to git source.
+func DownloadStepSourceArchive(destDir string, downloadLocations []models.DownloadLocationModel, id, version, commithash string, log Logger) error {
 	for _, downloadLocation := range downloadLocations {
 		switch downloadLocation.Type {
 		case "zip":

--- a/stepman/util.go
+++ b/stepman/util.go
@@ -124,14 +124,14 @@ func DownloadStep(collectionURI string, collection models.StepCollectionModel, i
 		return nil
 	}
 
-	return downloadStepArchive(stepPth, downloadLocations, id, version, commithash, log)
+	return DownloadStepArchive(stepPth, downloadLocations, id, version, commithash, log)
 }
 
-// downloadStepArchive fetches a step's source into destDir from the given download
+// DownloadStepArchive fetches a step's source into destDir from the given download
 // locations (zip or git), verifying the git commit. Locations are tried in order;
 // it returns an error only if all of them fail. It does not touch the steplib
 // route or cache, so it works for both the V1 (local spec) and V2 (API) paths.
-func downloadStepArchive(destDir string, downloadLocations []models.DownloadLocationModel, id, version, commithash string, log Logger) error {
+func DownloadStepArchive(destDir string, downloadLocations []models.DownloadLocationModel, id, version, commithash string, log Logger) error {
 	for _, downloadLocation := range downloadLocations {
 		switch downloadLocation.Type {
 		case "zip":


### PR DESCRIPTION
Follow-up to #392. Fixes step source download on the API activation path. It did not run *SetupLibrary*, so source fallback *activateStepSource* failed in a fresh environment (git steplib not cloned) with `no route found`. We do not add *SetupLibrary* as it would reintroduce the latency of git steplib clone.

Instead, we download the step source to a temp location. We reuse the step source download code from V1 (extracting where needed). The source "download locations" also stays the same, but now is returned by the API, as git steplib is not guaranteed to be cloned.

## Trade-offs (interim, follow-ups)

- **Caching:** API path does not cache step source archive locally. A dedicated V2 source cache is a follow-up.
