### PR TITLE
Add disk cache for precompiled step binaries

### DIFF
--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -82,6 +82,8 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	}
 	stepModel := stepInfo.Step
 	version := stepInfo.Version
+	resolvedID := id
+	resolvedID.Version = version
 
 	// Place the step.yml at destinationStepYML once, up front.
 	if !useSteplibAPI {
@@ -94,7 +96,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 		}
 	}
 
-	execPath, err := downloadPrecompiled(log, stepModel, id, destination, fetcher, opts)
+	execPath, err := downloadPrecompiled(log, stepModel, resolvedID, destination, fetcher, opts)
 	if execPath != "" {
 		return ResolvedStep{ExecPath: execPath, StepInfo: stepInfo}, err
 	}
@@ -127,7 +129,7 @@ func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.Ca
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(context.Background(), fetcher, id.IDorURI, executableForPlatform, destination, log, opts.storageURLs())
+			execPath, err := activateStepExecutable(context.Background(), fetcher, id.IDorURI, id.Version, platform, executableForPlatform, destination, log, opts.storageURLs())
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -129,7 +129,7 @@ func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.Ca
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(context.Background(), fetcher, id.IDorURI, id.Version, platform, executableForPlatform, destination, log, opts.storageURLs())
+			execPath, err := activateStepExecutable(context.Background(), fetcher, id.SteplibSource, id.IDorURI, id.Version, platform, executableForPlatform, destination, log, opts.storageURLs())
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 

--- a/activator/steplib/activate_executable.go
+++ b/activator/steplib/activate_executable.go
@@ -2,12 +2,17 @@ package steplib
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/bitrise-io/go-utils/v2/fileutil"
 	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepman"
@@ -16,23 +21,68 @@ import (
 func activateStepExecutable(
 	ctx context.Context,
 	fetcher httpfetch.Client,
-	stepID string,
+	stepID, version, platform string,
 	executable models.Executable,
 	destinationDir string,
 	logger stepman.Logger,
 	storageURLs []string,
 ) (string, error) {
-	path := filepath.Join(destinationDir, stepID)
+	cachePath, err := stepExecutableCachePath(stepID, version, platform)
+	if err != nil {
+		return "", fmt.Errorf("executable cache path: %w", err)
+	}
 
-	if err := downloadExecutable(ctx, fetcher, executable, path, logger, storageURLs); err != nil {
+	expectedHash, err := parseExpectedHash(executable.Hash)
+	if err != nil {
+		return "", fmt.Errorf("parse expected hash: %w", err)
+	}
+
+	needsDownload := false
+	switch err := validateHash(cachePath, expectedHash); {
+	case err == nil:
+		logger.Debugf("Disk cache hit for %s@%s", stepID, version)
+	case errors.Is(err, fs.ErrNotExist):
+		needsDownload = true
+		logger.Debugf("Disk cache miss for %s@%s", stepID, version)
+	default:
+		logger.Warnf("Cached step executable failed validation, re-downloading: %s", err)
+		if rmErr := os.Remove(cachePath); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+			logger.Warnf("Failed to remove invalid cache entry %s: %s", cachePath, rmErr)
+		}
+		needsDownload = true
+	}
+
+	if needsDownload {
+		if err := downloadExecutable(ctx, fetcher, executable, expectedHash, cachePath, logger, storageURLs); err != nil {
+			return "", err
+		}
+		if err := os.Chmod(cachePath, 0755); err != nil {
+			return "", fmt.Errorf("set executable permission on file: %s", err)
+		}
+	}
+
+	// Instead of returning the cache path, copy the executable to the destination dir.
+	// Bitrise CLI runs in a wide variety of environments, including user-provided container images.
+	// We can't make assumptions about the cache directory's path and availability, especially when
+	// mounted across containers with different usernames, filesystems, etc.
+	destPath := filepath.Join(destinationDir, stepID)
+	if err := os.MkdirAll(destinationDir, 0o755); err != nil {
+		return "", fmt.Errorf("create destination dir: %w", err)
+	}
+	if err := fileutil.NewFileManager().CopyFile(cachePath, destPath, &fileutil.CopyOptions{Overwrite: true}); err != nil {
+		return "", fmt.Errorf("copy cached executable to destination: %w", err)
+	}
+
+	return destPath, nil
+}
+
+func stepExecutableCachePath(stepID, version, platform string) (string, error) {
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
 		return "", err
 	}
-
-	if err := os.Chmod(path, 0755); err != nil {
-		return "", fmt.Errorf("set executable permission on file: %s", err)
-	}
-
-	return path, nil
+	base := filepath.Join(userCacheDir, "bitrise", "steps", "executables")
+	return filepath.Join(base, stepID, version, platform, stepID), nil
 }
 
 func buildDownloadURLs(bases []string, executable models.Executable) ([]string, error) {
@@ -56,21 +106,23 @@ func buildDownloadURLs(bases []string, executable models.Executable) ([]string, 
 	return urls, nil
 }
 
-func downloadExecutable(ctx context.Context, fetcher httpfetch.Client, executable models.Executable, destPath string, logger stepman.Logger, storageURLs []string) error {
+func downloadExecutable(ctx context.Context, fetcher httpfetch.Client, executable models.Executable, expectedHash, destPath string, logger stepman.Logger, storageURLs []string) error {
 	urls, err := buildDownloadURLs(storageURLs, executable)
 	if err != nil {
 		return err
 	}
-	return downloadFromURLs(ctx, fetcher, urls, destPath, executable.Hash, logger)
+
+	return downloadFromURLs(ctx, fetcher, urls, destPath, expectedHash, logger)
 }
 
-// downloadFromURLs tries each URL in order via fetcher, verifying executable.Hash
-// on each attempt; a mismatch or failure falls through to the next mirror, logging
-// each failed attempt so a mirror silently degrading isn't invisible on fallback success.
-func downloadFromURLs(ctx context.Context, fetcher httpfetch.Client, urls []string, destPath, hash string, logger stepman.Logger) error {
+// downloadFromURLs tries each URL in order via fetcher, verifying the expected
+// hash on each attempt; a mismatch or failure falls through to the next mirror,
+// logging each failed attempt so a mirror silently degrading isn't invisible on
+// fallback success.
+func downloadFromURLs(ctx context.Context, fetcher httpfetch.Client, urls []string, destPath, expectedSHA256 string, logger stepman.Logger) error {
 	var errs []error
 	for _, url := range urls {
-		err := fetcher.DownloadWithHash(ctx, destPath, url, hash)
+		err := fetcher.DownloadWithHash(ctx, destPath, url, expectedSHA256)
 		if err == nil {
 			return nil
 		}
@@ -80,4 +132,33 @@ func downloadFromURLs(ctx context.Context, fetcher httpfetch.Client, urls []stri
 		errs = append(errs, fmt.Errorf("%s: %w", url, err))
 	}
 	return fmt.Errorf("failed to download executable: %w", errors.Join(errs...))
+}
+
+func parseExpectedHash(hash string) (string, error) {
+	if hash == "" {
+		return "", fmt.Errorf("hash is empty")
+	}
+	if !strings.HasPrefix(hash, "sha256-") {
+		return "", fmt.Errorf("only SHA256 hashes supported at this time, make sure to prefix the hash with `sha256-`. Found hash value: %s", hash)
+	}
+	return strings.TrimPrefix(hash, "sha256-"), nil
+}
+
+func validateHash(filePath string, expectedHexHash string) error {
+	reader, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+
+	h := sha256.New()
+	_, err = io.Copy(h, reader)
+	if err != nil {
+		return fmt.Errorf("calculate hash: %w", err)
+	}
+	actualHash := hex.EncodeToString(h.Sum(nil))
+	if actualHash != expectedHexHash {
+		return fmt.Errorf("hash mismatch: expected sha256-%s, got sha256-%s", expectedHexHash, actualHash)
+	}
+	return nil
 }

--- a/activator/steplib/activate_executable.go
+++ b/activator/steplib/activate_executable.go
@@ -21,13 +21,13 @@ import (
 func activateStepExecutable(
 	ctx context.Context,
 	fetcher httpfetch.Client,
-	stepID, version, platform string,
+	steplibSource, stepID, version, platform string,
 	executable models.Executable,
 	destinationDir string,
 	logger stepman.Logger,
 	storageURLs []string,
 ) (string, error) {
-	cachePath, err := stepExecutableCachePath(stepID, version, platform)
+	cachePath, err := stepExecutableCachePath(steplibSource, stepID, version, platform)
 	if err != nil {
 		return "", fmt.Errorf("executable cache path: %w", err)
 	}
@@ -76,13 +76,23 @@ func activateStepExecutable(
 	return destPath, nil
 }
 
-func stepExecutableCachePath(stepID, version, platform string) (string, error) {
+func stepExecutableCachePath(steplibSource, stepID, version, platform string) (string, error) {
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		return "", err
 	}
 	base := filepath.Join(userCacheDir, "bitrise", "steps", "executables")
-	return filepath.Join(base, stepID, version, platform, stepID), nil
+
+	// A step ID is only unique within its StepLib, so the steplib source must be part
+	// of the cache key too, otherwise two libraries could publish different
+	// binaries under the same ID/version/platform and overwrite each other's
+	// cache entry.
+	// Hash the steplib string rather than using it as a path segment directly:
+	// steplibSource is typically a URL, and filepath.Join+Clean would collapse
+	// any ".." in it (path traversal), while characters like ":" in "https://"
+	// aren't valid in a Windows path segment.
+	sourceKey := sha256.Sum256([]byte(steplibSource))
+	return filepath.Join(base, hex.EncodeToString(sourceKey[:]), stepID, version, platform, stepID), nil
 }
 
 func buildDownloadURLs(bases []string, executable models.Executable) ([]string, error) {

--- a/activator/steplib/activate_executable.go
+++ b/activator/steplib/activate_executable.go
@@ -41,6 +41,13 @@ func activateStepExecutable(
 	switch err := validateHash(cachePath, expectedHash); {
 	case err == nil:
 		logger.Debugf("Disk cache hit for %s@%s", stepID, version)
+		// A concurrent activation, or one interrupted between the download's
+		// atomic publish and the chmod below, can leave a hash-valid cache
+		// entry that isn't executable yet. Repair the mode on every hit so
+		// such an entry doesn't stay broken forever.
+		if err := os.Chmod(cachePath, 0755); err != nil {
+			return "", fmt.Errorf("set executable permission on file: %s", err)
+		}
 	case errors.Is(err, fs.ErrNotExist):
 		needsDownload = true
 		logger.Debugf("Disk cache miss for %s@%s", stepID, version)
@@ -71,6 +78,12 @@ func activateStepExecutable(
 	}
 	if err := fileutil.NewFileManager().CopyFile(cachePath, destPath, &fileutil.CopyOptions{Overwrite: true}); err != nil {
 		return "", fmt.Errorf("copy cached executable to destination: %w", err)
+	}
+	// CopyFile preserves the source file's mode. A concurrent activation can replace
+	// cachePath between our copy and its own chmod, so the copied file's mode isn't
+	// guaranteed to be executable even though we chmod cachePath above.
+	if err := os.Chmod(destPath, 0755); err != nil {
+		return "", fmt.Errorf("set executable permission on destination file: %w", err)
 	}
 
 	return destPath, nil

--- a/activator/steplib/activate_executable_test.go
+++ b/activator/steplib/activate_executable_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -207,7 +208,7 @@ func TestActivateStepExecutable(t *testing.T) {
 		fake := newFakeExecutableFetcher(t)
 		destDir := t.TempDir()
 
-		path, err := activateStepExecutable(ctx, fake, "hello-step", "2.0.0", "linux-amd64",
+		path, err := activateStepExecutable(ctx, fake, "https://github.com/bitrise-io/bitrise-steplib.git", "hello-step", "2.0.0", "linux-amd64",
 			models.Executable{StorageURI: storageURI, Hash: hash}, destDir, logger, DefaultPrecompiledStorageURLs)
 		require.NoError(t, err)
 
@@ -223,7 +224,7 @@ func TestActivateStepExecutable(t *testing.T) {
 		redirectCacheDir(t)
 		fake := newFakeExecutableFetcher(t)
 
-		_, err := activateStepExecutable(ctx, fake, "hello-step", "2.0.0", "linux-amd64",
+		_, err := activateStepExecutable(ctx, fake, "https://github.com/bitrise-io/bitrise-steplib.git", "hello-step", "2.0.0", "linux-amd64",
 			models.Executable{StorageURI: storageURI, Hash: hash}, t.TempDir(), logger,
 			[]string{"https://custom.example.com"})
 		require.NoError(t, err)
@@ -259,7 +260,7 @@ func TestActivateStepExecutableCache(t *testing.T) {
 
 		executable := models.Executable{StorageURI: "steps/step1.bin", Hash: sha256Hash(content)}
 		destDir := t.TempDir()
-		path, err := activateStepExecutable(ctx, fetcher, "step1", "1.0.0", "linux-amd64", executable, destDir, logger, storageURLs)
+		path, err := activateStepExecutable(ctx, fetcher, "https://github.com/bitrise-io/bitrise-steplib.git", "step1", "1.0.0", "linux-amd64", executable, destDir, logger, storageURLs)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, atomic.LoadInt32(&hits))
 		require.Equal(t, filepath.Join(destDir, "step1"), path)
@@ -268,7 +269,7 @@ func TestActivateStepExecutableCache(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, content, got)
 
-		cachePath, err := stepExecutableCachePath("step1", "1.0.0", "linux-amd64")
+		cachePath, err := stepExecutableCachePath("https://github.com/bitrise-io/bitrise-steplib.git", "step1", "1.0.0", "linux-amd64")
 		require.NoError(t, err)
 		require.FileExists(t, cachePath, "a successful download must populate the shared cache")
 	})
@@ -283,13 +284,13 @@ func TestActivateStepExecutableCache(t *testing.T) {
 		})
 
 		executable := models.Executable{StorageURI: "steps/step2.bin", Hash: sha256Hash(content)}
-		firstPath, err := activateStepExecutable(ctx, fetcher, "step2", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
+		firstPath, err := activateStepExecutable(ctx, fetcher, "https://github.com/bitrise-io/bitrise-steplib.git", "step2", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, atomic.LoadInt32(&hits))
 
 		// A second, independent destination dir: the cache is shared, but each
 		// activation still gets its own served copy.
-		secondPath, err := activateStepExecutable(ctx, fetcher, "step2", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
+		secondPath, err := activateStepExecutable(ctx, fetcher, "https://github.com/bitrise-io/bitrise-steplib.git", "step2", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, atomic.LoadInt32(&hits), "second activation must not hit the network")
 		require.NotEqual(t, firstPath, secondPath, "each activation gets its own destination copy")
@@ -311,18 +312,53 @@ func TestActivateStepExecutableCache(t *testing.T) {
 		})
 
 		executable := models.Executable{StorageURI: "steps/step3.bin", Hash: sha256Hash(content)}
-		cachePath, err := stepExecutableCachePath("step3", "1.0.0", "linux-amd64")
+		cachePath, err := stepExecutableCachePath("https://github.com/bitrise-io/bitrise-steplib.git", "step3", "1.0.0", "linux-amd64")
 		require.NoError(t, err)
 		require.NoError(t, os.MkdirAll(filepath.Dir(cachePath), 0755))
 		require.NoError(t, os.WriteFile(cachePath, []byte("corrupted"), 0644))
 
-		path, err := activateStepExecutable(ctx, fetcher, "step3", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
+		path, err := activateStepExecutable(ctx, fetcher, "https://github.com/bitrise-io/bitrise-steplib.git", "step3", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, atomic.LoadInt32(&hits))
 
 		got, err := os.ReadFile(path)
 		require.NoError(t, err)
 		require.Equal(t, content, got)
+	})
+
+	t.Run("different steplib sources for the same step ID/version/platform get separate cache entries", func(t *testing.T) {
+		redirectCacheDir(t)
+		contentA := []byte("library A's binary")
+		contentB := []byte("library B's binary")
+		fetcher, storageURLs := newExecutableTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "a-only") {
+				_, _ = w.Write(contentA)
+				return
+			}
+			_, _ = w.Write(contentB)
+		})
+
+		executableA := models.Executable{StorageURI: "steps/a-only.bin", Hash: sha256Hash(contentA)}
+		executableB := models.Executable{StorageURI: "steps/b-only.bin", Hash: sha256Hash(contentB)}
+
+		pathA, err := activateStepExecutable(ctx, fetcher, "https://github.com/example/library-a.git", "shared-step", "1.0.0", "linux-amd64", executableA, t.TempDir(), logger, storageURLs)
+		require.NoError(t, err)
+		pathB, err := activateStepExecutable(ctx, fetcher, "https://github.com/example/library-b.git", "shared-step", "1.0.0", "linux-amd64", executableB, t.TempDir(), logger, storageURLs)
+		require.NoError(t, err)
+
+		cachePathA, err := stepExecutableCachePath("https://github.com/example/library-a.git", "shared-step", "1.0.0", "linux-amd64")
+		require.NoError(t, err)
+		cachePathB, err := stepExecutableCachePath("https://github.com/example/library-b.git", "shared-step", "1.0.0", "linux-amd64")
+		require.NoError(t, err)
+		require.NotEqual(t, cachePathA, cachePathB, "different libraries must not share a cache path for the same step ID/version/platform")
+
+		gotA, err := os.ReadFile(pathA)
+		require.NoError(t, err)
+		require.Equal(t, contentA, gotA)
+
+		gotB, err := os.ReadFile(pathB)
+		require.NoError(t, err)
+		require.Equal(t, contentB, gotB)
 	})
 
 	t.Run("concurrent activations for the same key do not corrupt the cache", func(t *testing.T) {
@@ -345,7 +381,7 @@ func TestActivateStepExecutableCache(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				paths[i], errs[i] = activateStepExecutable(ctx, fetcher, "step4", "1.0.0", "linux-amd64", executable, destDirs[i], logger, storageURLs)
+				paths[i], errs[i] = activateStepExecutable(ctx, fetcher, "https://github.com/bitrise-io/bitrise-steplib.git", "step4", "1.0.0", "linux-amd64", executable, destDirs[i], logger, storageURLs)
 			}(i)
 		}
 		wg.Wait()

--- a/activator/steplib/activate_executable_test.go
+++ b/activator/steplib/activate_executable_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/log"
@@ -20,6 +22,95 @@ import (
 func sha256Hash(b []byte) string {
 	sum := sha256.Sum256(b)
 	return "sha256-" + hex.EncodeToString(sum[:])
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func redirectCacheDir(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", "")
+}
+
+func TestValidateHash(t *testing.T) {
+	tests := []struct {
+		name         string
+		filePath     string
+		expectedHash string
+		expectedErr  error
+	}{
+		{
+			name:         "Valid hash",
+			filePath:     "testdata/file.txt",
+			expectedHash: "f2040af3939f5033be8ca9b363055b3e53107c4688ba39b71d4529869a9cc9b2",
+			expectedErr:  nil,
+		},
+		{
+			name:         "Hash mismatch",
+			filePath:     "testdata/file.txt",
+			expectedHash: "1234567890abcdef",
+			expectedErr:  fmt.Errorf("hash mismatch: expected sha256-1234567890abcdef, got sha256-f2040af3939f5033be8ca9b363055b3e53107c4688ba39b71d4529869a9cc9b2"),
+		},
+		{
+			name:         "Nonexistent file",
+			filePath:     "testdata/nonexistent.txt",
+			expectedHash: "3b6b4f1e2e8b8a9e4f7a4b5e6c7d8e9f",
+			expectedErr:  fmt.Errorf("open testdata/nonexistent.txt: no such file or directory"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHash(tt.filePath, tt.expectedHash)
+			if tt.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestParseExpectedHash(t *testing.T) {
+	tests := []struct {
+		name        string
+		hash        string
+		expectedHex string
+		expectedErr error
+	}{
+		{
+			name:        "Valid hash",
+			hash:        "sha256-f2040af3939f5033be8ca9b363055b3e53107c4688ba39b71d4529869a9cc9b2",
+			expectedHex: "f2040af3939f5033be8ca9b363055b3e53107c4688ba39b71d4529869a9cc9b2",
+		},
+		{
+			name:        "Empty hash",
+			hash:        "",
+			expectedErr: fmt.Errorf("hash is empty"),
+		},
+		{
+			name:        "Invalid hash type",
+			hash:        "md5-3b6b4f1e2e8b8a9e4f7a4b5e6c7d8e9f",
+			expectedErr: fmt.Errorf("only SHA256 hashes supported at this time, make sure to prefix the hash with `sha256-`. Found hash value: md5-3b6b4f1e2e8b8a9e4f7a4b5e6c7d8e9f"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hexHash, err := parseExpectedHash(tt.hash)
+			if tt.expectedErr == nil {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedHex, hexHash)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedErr.Error(), err.Error())
+			}
+		})
+	}
 }
 
 func TestBuildDownloadURLs(t *testing.T) {
@@ -105,10 +196,6 @@ func TestBuildDownloadURLs(t *testing.T) {
 	}
 }
 
-// TestActivateStepExecutable covers the URL assembly and hash threading between
-// activateStepExecutable → downloadExecutable and the fetcher, using a fake
-// fetcher so no bytes are transferred. The download loop itself (mirror fallback,
-// hash verification) is covered by TestDownloadFromURLs.
 func TestActivateStepExecutable(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewDefaultLogger(false)
@@ -116,23 +203,27 @@ func TestActivateStepExecutable(t *testing.T) {
 	const hash = "sha256-1111111111111111111111111111111111111111111111111111111111111111"
 
 	t.Run("default bases: first mirror + StorageURI, hash threaded through", func(t *testing.T) {
+		redirectCacheDir(t)
 		fake := newFakeExecutableFetcher(t)
 		destDir := t.TempDir()
 
-		path, err := activateStepExecutable(ctx, fake, "hello-step",
+		path, err := activateStepExecutable(ctx, fake, "hello-step", "2.0.0", "linux-amd64",
 			models.Executable{StorageURI: storageURI, Hash: hash}, destDir, logger, DefaultPrecompiledStorageURLs)
 		require.NoError(t, err)
 
-		require.Equal(t, filepath.Join(destDir, "hello-step"), path)
+		require.Equal(t, filepath.Join(destDir, "hello-step"), path, "the served path must live under the caller's destination dir, not the cache")
 		require.FileExists(t, path)
 		require.Equal(t, DefaultPrecompiledStorageURLs[0]+"/"+storageURI, fake.calledURL)
-		require.Equal(t, hash, fake.calledHash)
+		hexHash, err := parseExpectedHash(hash)
+		require.NoError(t, err)
+		require.Equal(t, hexHash, fake.calledHash, "the fetcher sees a bare hex digest, not the \"sha256-\" tagged form")
 	})
 
 	t.Run("configured storage URLs win over the defaults", func(t *testing.T) {
+		redirectCacheDir(t)
 		fake := newFakeExecutableFetcher(t)
 
-		_, err := activateStepExecutable(ctx, fake, "hello-step",
+		_, err := activateStepExecutable(ctx, fake, "hello-step", "2.0.0", "linux-amd64",
 			models.Executable{StorageURI: storageURI, Hash: hash}, t.TempDir(), logger,
 			[]string{"https://custom.example.com"})
 		require.NoError(t, err)
@@ -141,12 +232,139 @@ func TestActivateStepExecutable(t *testing.T) {
 	})
 }
 
+// newExecutableTestServer spins up a self-signed TLS test server (the download
+// path enforces https) and returns a real httpfetch.Client configured to trust
+// its certificate, plus a storageURLs slice pointing at it - so
+// activateStepExecutable's real download path can be exercised without
+// depending on OS-specific system cert trust behavior.
+func newExecutableTestServer(t *testing.T, handler http.HandlerFunc) (httpfetch.Client, []string) {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	return httpfetch.NewWithClient(server.Client()), []string{server.URL}
+}
+
+func TestActivateStepExecutableCache(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewDefaultLogger(false)
+
+	t.Run("cache miss downloads and populates the cache", func(t *testing.T) {
+		redirectCacheDir(t)
+		var hits int32
+		content := []byte("step binary contents v1")
+		fetcher, storageURLs := newExecutableTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			_, _ = w.Write(content)
+		})
+
+		executable := models.Executable{StorageURI: "steps/step1.bin", Hash: sha256Hash(content)}
+		destDir := t.TempDir()
+		path, err := activateStepExecutable(ctx, fetcher, "step1", "1.0.0", "linux-amd64", executable, destDir, logger, storageURLs)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, atomic.LoadInt32(&hits))
+		require.Equal(t, filepath.Join(destDir, "step1"), path)
+
+		got, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, content, got)
+
+		cachePath, err := stepExecutableCachePath("step1", "1.0.0", "linux-amd64")
+		require.NoError(t, err)
+		require.FileExists(t, cachePath, "a successful download must populate the shared cache")
+	})
+
+	t.Run("cache hit skips the download", func(t *testing.T) {
+		redirectCacheDir(t)
+		var hits int32
+		content := []byte("step binary contents v2")
+		fetcher, storageURLs := newExecutableTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			_, _ = w.Write(content)
+		})
+
+		executable := models.Executable{StorageURI: "steps/step2.bin", Hash: sha256Hash(content)}
+		firstPath, err := activateStepExecutable(ctx, fetcher, "step2", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, atomic.LoadInt32(&hits))
+
+		// A second, independent destination dir: the cache is shared, but each
+		// activation still gets its own served copy.
+		secondPath, err := activateStepExecutable(ctx, fetcher, "step2", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, atomic.LoadInt32(&hits), "second activation must not hit the network")
+		require.NotEqual(t, firstPath, secondPath, "each activation gets its own destination copy")
+
+		firstContent, err := os.ReadFile(firstPath)
+		require.NoError(t, err)
+		secondContent, err := os.ReadFile(secondPath)
+		require.NoError(t, err)
+		require.Equal(t, firstContent, secondContent)
+	})
+
+	t.Run("corrupt cache entry is detected and re-downloaded", func(t *testing.T) {
+		redirectCacheDir(t)
+		var hits int32
+		content := []byte("step binary contents v3")
+		fetcher, storageURLs := newExecutableTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			_, _ = w.Write(content)
+		})
+
+		executable := models.Executable{StorageURI: "steps/step3.bin", Hash: sha256Hash(content)}
+		cachePath, err := stepExecutableCachePath("step3", "1.0.0", "linux-amd64")
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(filepath.Dir(cachePath), 0755))
+		require.NoError(t, os.WriteFile(cachePath, []byte("corrupted"), 0644))
+
+		path, err := activateStepExecutable(ctx, fetcher, "step3", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, atomic.LoadInt32(&hits))
+
+		got, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, content, got)
+	})
+
+	t.Run("concurrent activations for the same key do not corrupt the cache", func(t *testing.T) {
+		redirectCacheDir(t)
+		content := []byte("step binary contents v4")
+		fetcher, storageURLs := newExecutableTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(content)
+		})
+
+		executable := models.Executable{StorageURI: "steps/step4.bin", Hash: sha256Hash(content)}
+		const n = 10
+		destDirs := make([]string, n)
+		for i := range n {
+			destDirs[i] = t.TempDir()
+		}
+		var wg sync.WaitGroup
+		paths := make([]string, n)
+		errs := make([]error, n)
+		for i := range n {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				paths[i], errs[i] = activateStepExecutable(ctx, fetcher, "step4", "1.0.0", "linux-amd64", executable, destDirs[i], logger, storageURLs)
+			}(i)
+		}
+		wg.Wait()
+
+		for i := range n {
+			require.NoError(t, errs[i])
+			got, err := os.ReadFile(paths[i])
+			require.NoError(t, err)
+			require.Equal(t, content, got)
+		}
+	})
+}
+
 func TestDownloadFromURLs(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewDefaultLogger(false)
 	fetcher := httpfetch.NewClient(logger)
 	payload := []byte("primary payload")
-	hash := sha256Hash(payload)
+	hash := sha256Hex(payload)
 
 	t.Run("primary succeeds, secondary is not called", func(t *testing.T) {
 		secondaryHits := 0

--- a/activator/steplib/activate_executable_test.go
+++ b/activator/steplib/activate_executable_test.go
@@ -326,6 +326,29 @@ func TestActivateStepExecutableCache(t *testing.T) {
 		require.Equal(t, content, got)
 	})
 
+	t.Run("cache entry with valid content but wrong mode is repaired, not just trusted", func(t *testing.T) {
+		redirectCacheDir(t)
+		content := []byte("step binary contents v3b")
+		fetcher, storageURLs := newExecutableTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("must not re-download when the cached content is already valid")
+		})
+
+		executable := models.Executable{StorageURI: "steps/step3b.bin", Hash: sha256Hash(content)}
+		cachePath, err := stepExecutableCachePath("https://github.com/bitrise-io/bitrise-steplib.git", "step3b", "1.0.0", "linux-amd64")
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(filepath.Dir(cachePath), 0755))
+		// Simulate a cache hit landing between the download's atomic publish
+		// and the mode fixup: correct content, wrong (non-executable) mode.
+		require.NoError(t, os.WriteFile(cachePath, content, 0600))
+
+		path, err := activateStepExecutable(ctx, fetcher, "https://github.com/bitrise-io/bitrise-steplib.git", "step3b", "1.0.0", "linux-amd64", executable, t.TempDir(), logger, storageURLs)
+		require.NoError(t, err)
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0755), info.Mode().Perm(), "cache hit must repair the executable mode")
+	})
+
 	t.Run("different steplib sources for the same step ID/version/platform get separate cache entries", func(t *testing.T) {
 		redirectCacheDir(t)
 		contentA := []byte("library A's binary")

--- a/activator/steplib/activate_test.go
+++ b/activator/steplib/activate_test.go
@@ -92,6 +92,7 @@ func TestActivateStep_NoExecutable_ActivatesSource(t *testing.T) {
 // source. The binary transfer is faked; asserting the download URL/hash is the
 // job of activate_executable_test.go.
 func TestActivateStep_ChoosesExecutable(t *testing.T) {
+	redirectCacheDir(t)
 	platform := runtime.GOOS + "-" + runtime.GOARCH
 	srv := serveHelloStepInventoryWithExecutables(t, &models.Executables{
 		platform: models.Executable{
@@ -110,7 +111,7 @@ func TestActivateStep_ChoosesExecutable(t *testing.T) {
 	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, library, newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
-	assert.Equal(t, filepath.Join(destination, "hello-step"), resolved.ExecPath)
+	assert.Equal(t, filepath.Join(destination, "hello-step"), resolved.ExecPath, "executable activation must serve the path from the caller's destination dir, not the shared cache")
 	require.FileExists(t, resolved.ExecPath)
 	require.NoFileExists(t, filepath.Join(destination, "activated_marker.txt"),
 		"executable activation must not fall back to source")
@@ -119,6 +120,7 @@ func TestActivateStep_ChoosesExecutable(t *testing.T) {
 // If the executable download fails, ActivateStep falls back to source activation
 // rather than erroring.
 func TestActivateStep_ExecutableDownloadFails_FallsBackToSource(t *testing.T) {
+	redirectCacheDir(t)
 	platform := runtime.GOOS + "-" + runtime.GOARCH
 	srv := serveHelloStepInventoryWithExecutables(t, &models.Executables{
 		platform: models.Executable{

--- a/activator/steplib/helpers_test.go
+++ b/activator/steplib/helpers_test.go
@@ -170,6 +170,10 @@ func (f *fakeExecutableFetcher) DownloadWithHash(_ context.Context, destPath, ur
 	if f.downloadErr != nil {
 		return f.downloadErr
 	}
+	// Mirrors the real httpfetch.Client, which creates destPath's parent dirs.
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return err
+	}
 	return os.WriteFile(destPath, []byte("stub binary"), 0o644)
 }
 

--- a/activator/steplib/testdata/file.txt
+++ b/activator/steplib/testdata/file.txt
@@ -1,0 +1,1 @@
+hash verification test

--- a/internal/httpfetch/httpfetch.go
+++ b/internal/httpfetch/httpfetch.go
@@ -31,9 +31,9 @@ type Client interface {
 	// the final path.
 	Download(ctx context.Context, destPath, url string) error
 	// DownloadWithHash behaves like Download but also verifies that the
-	// downloaded content matches expectedHash ("sha256-<hex>"). The temp file
-	// is removed and an error is returned if the hash does not match, so a
-	// mismatched file never appears at destPath.
+	// downloaded content's SHA256 digest, hex-encoded, matches expectedHash.
+	// The temp file is removed and an error is returned if the digest does
+	// not match, so a mismatched file never appears at destPath.
 	DownloadWithHash(ctx context.Context, destPath, url, expectedHash string) error
 }
 
@@ -114,9 +114,9 @@ func (c *client) DownloadWithHash(ctx context.Context, destPath, url, expectedHa
 }
 
 // download fetches url into a temp file alongside destPath and atomically
-// renames it into place. When expectedHash is non-empty the content is verified
-// against it ("sha256-<hex>") before the rename, so a mismatched or partial
-// file never lands at destPath.
+// renames it into place. When expectedHash is non-empty, the content's SHA256
+// digest (hex-encoded) is verified against it before the rename, so a
+// mismatched or partial file never lands at destPath.
 func (c *client) download(ctx context.Context, destPath, url, expectedHash string) error {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 		return fmt.Errorf("create dest dir for %s: %w", destPath, err)
@@ -131,7 +131,7 @@ func (c *client) download(ctx context.Context, destPath, url, expectedHash strin
 	defer func() { _ = os.Remove(tmpPath) }()
 
 	if expectedHash != "" && hash != expectedHash {
-		return fmt.Errorf("hash mismatch (%s) expected %s, got %s", url, expectedHash, hash)
+		return fmt.Errorf("SHA256 hash mismatch (%s): expected %s, got %s", url, expectedHash, hash)
 	}
 	if err := os.Rename(tmpPath, destPath); err != nil {
 		return fmt.Errorf("rename %s to %s: %w", tmpPath, destPath, err)
@@ -140,7 +140,7 @@ func (c *client) download(ctx context.Context, destPath, url, expectedHash strin
 }
 
 // fetchToTemp streams url into a new temp file under dir and returns its path
-// and sha256 hash ("sha256-<hex>"). On error the temp file is removed and
+// and its SHA256 digest, hex-encoded. On error the temp file is removed and
 // path/hash are empty; on success the caller owns cleanup.
 func (c *client) fetchToTemp(ctx context.Context, dir, url string) (path string, hash string, err error) {
 	// Place the temp file alongside destPath so the final rename stays on
@@ -178,5 +178,5 @@ func (c *client) fetchToTemp(ctx context.Context, dir, url string) (path string,
 	if _, copyErr := io.Copy(io.MultiWriter(tmp, h), body); copyErr != nil {
 		return "", "", fmt.Errorf("write to %s: %w", tmp.Name(), copyErr)
 	}
-	return tmp.Name(), "sha256-" + hex.EncodeToString(h.Sum(nil)), nil
+	return tmp.Name(), hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/httpfetch/httpfetch_test.go
+++ b/internal/httpfetch/httpfetch_test.go
@@ -18,7 +18,7 @@ import (
 
 func sha256Hash(b []byte) string {
 	sum := sha256.Sum256(b)
-	return "sha256-" + hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:])
 }
 
 func newClient() Client {


### PR DESCRIPTION
### Why

There is no caching of (binary) step activations at the moment. Even in ephemeral CI environments, one workflow could reference the same step multiple times, fetching the binary for every execution.

### What

Building on top of #410, cache step binary downloads into `os.UserCacheDir()`.


Update: tested with integrating this PR into the CLI: https://github.com/bitrise-io/bitrise/pull/1354

### Decisions

- Responsibility of `httpfetch` vs `activator/steplib`: `httpfetch` should not be aware of our `sha256-xxxx` checksum prefix, it should work on explicitly SHA256 hashes. Handling of that `sha256-xxx` prefix is now the responsiblity of `activator/steplib`.
- No content-addressing. Step binaries are immutable per `(stepID, version, platform)`, so that triple is a sufficient cache key. There is no need to introduce content-addressing.
- No cache cleanup. Entries are written to `os.UserCacheDir()`, so they get periodically cleaned up. If this becomes an issue, we can add our own cleanup logic later.
- Hash is re-validated on every cache hit, not just at write time.

**Do not return cached executable path directly, copy into step destination dir**: Bitrise CLI runs in a wide variety of environments, including user-provided container images. We can't make assumptions about the cache directory's path and availability, especially when mounted across containers with different usernames, filesystems, etc. 

I looked into what it would take to safely use the per-user cache dir in all execution environments, and there are two issues that complicate things:
1. In the old Linux CI stack environments, Bitrise CLI runs inside a main container, and might execute steps in a "sidecar" container, all through the host's Docker daemon socket. User-level cache dir paths are not necessarily consistent across these 3 environments.
2. `$BITRISE_DOCKER_MOUNT_OVERRIDES` exists as an escape hatch, and the "step destination dir" is actually mounted across all 3 environments via this. We could add one more mount path, but this is already a bit hacky, and would require coordinating changes and rollouts across 3 systems (stepman, CLI, DEN)