### PR TITLE
refactor(steplib): route precompiled-binary downloads through internal/httpfetch

### DIFF
--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/v2/fileutil"
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/steplibrary"
@@ -96,7 +97,7 @@ func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.Ca
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(id.IDorURI, executableForPlatform, destination, log)
+			execPath, err := activateStepExecutable(context.Background(), httpfetch.NewClient(log), id.IDorURI, executableForPlatform, destination, log)
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 

--- a/activator/steplib/activate_executable.go
+++ b/activator/steplib/activate_executable.go
@@ -1,97 +1,37 @@
 package steplib
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
+	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepman"
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 func activateStepExecutable(
+	ctx context.Context,
+	fetcher httpfetch.Client,
 	stepID string,
 	executable models.Executable,
 	destinationDir string,
 	logger stepman.Logger,
 ) (string, error) {
-	body, err := downloadExecutable(executable, logger)
-	if err != nil {
+	path := filepath.Join(destinationDir, stepID)
+
+	if err := downloadExecutable(ctx, fetcher, executable, path, logger); err != nil {
 		return "", err
 	}
-	defer func() {
-		if err := body.Close(); err != nil {
-			logger.Warnf("Failed to close response body: %s\n", err)
-		}
-	}()
 
-	err = os.MkdirAll(destinationDir, 0755)
-	if err != nil {
-		return "", fmt.Errorf("create directory %s: %w", destinationDir, err)
-	}
-
-	path := filepath.Join(destinationDir, stepID)
-	file, err := os.Create(path)
-	if err != nil {
-		return "", fmt.Errorf("create file %s: %w", path, err)
-	}
-	defer func() {
-		err := file.Close()
-		if err != nil {
-			logger.Warnf("Failed to close file %s: %s\n", path, err)
-		}
-	}()
-
-	_, err = io.Copy(file, body)
-	if err != nil {
-		return "", fmt.Errorf("download to %s: %w", path, err)
-	}
-
-	err = validateHash(path, executable.Hash)
-	if err != nil {
-		return "", fmt.Errorf("validate hash: %s", err)
-	}
-
-	err = os.Chmod(path, 0755)
-	if err != nil {
+	if err := os.Chmod(path, 0755); err != nil {
 		return "", fmt.Errorf("set executable permission on file: %s", err)
 	}
 
 	return path, nil
-}
-
-func validateHash(filePath string, expectedHash string) error {
-	if expectedHash == "" {
-		return fmt.Errorf("hash is empty")
-	}
-
-	if !strings.HasPrefix(expectedHash, "sha256-") {
-		return fmt.Errorf("only SHA256 hashes supported at this time, make sure to prefix the hash with `sha256-`. Found hash value: %s", expectedHash)
-	}
-
-	expectedHash = strings.TrimPrefix(expectedHash, "sha256-")
-
-	reader, err := os.Open(filePath)
-	if err != nil {
-		return err
-	}
-
-	h := sha256.New()
-	_, err = io.Copy(h, reader)
-	if err != nil {
-		return fmt.Errorf("calculate hash: %w", err)
-	}
-	actualHash := hex.EncodeToString(h.Sum(nil))
-	if actualHash != expectedHash {
-		return fmt.Errorf("hash mismatch: expected sha256-%s, got sha256-%s", expectedHash, actualHash)
-	}
-	return nil
 }
 
 func buildDownloadURLs(bases []string, executable models.Executable) ([]string, error) {
@@ -115,7 +55,7 @@ func buildDownloadURLs(bases []string, executable models.Executable) ([]string, 
 	return urls, nil
 }
 
-func downloadExecutable(executable models.Executable, logger stepman.Logger) (io.ReadCloser, error) {
+func downloadExecutable(ctx context.Context, fetcher httpfetch.Client, executable models.Executable, destPath string, logger stepman.Logger) error {
 	bases := precompiledStepsDefaultStorageURLs
 	if override := os.Getenv(precompiledStepsStorageURLsEnv); override != "" {
 		bases = strings.Split(override, ",")
@@ -123,29 +63,23 @@ func downloadExecutable(executable models.Executable, logger stepman.Logger) (io
 
 	urls, err := buildDownloadURLs(bases, executable)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return downloadFromURLs(urls, logger)
+	return downloadFromURLs(ctx, fetcher, urls, executable.Hash, destPath, logger)
 }
 
-func downloadFromURLs(urls []string, logger stepman.Logger) (io.ReadCloser, error) {
+// downloadFromURLs tries each URL in order via fetcher, verifying executable.Hash
+// on each attempt; a mismatch or failure falls through to the next mirror, logging
+// each failed attempt so a mirror silently degrading isn't invisible on fallback success.
+func downloadFromURLs(ctx context.Context, fetcher httpfetch.Client, urls []string, hash, destPath string, logger stepman.Logger) error {
 	var errs []error
 	for _, url := range urls {
-		resp, err := retryablehttp.Get(url)
-		if err == nil && resp.StatusCode < 400 {
-			return resp.Body, nil
+		err := fetcher.DownloadWithHash(ctx, destPath, url, hash)
+		if err == nil {
+			return nil
 		}
-
-		if err != nil {
-			logger.Warnf("Failed to download step from %s: %s\n", url, err)
-			errs = append(errs, fmt.Errorf("%s: %w", url, err))
-		} else {
-			if closeErr := resp.Body.Close(); closeErr != nil {
-				logger.Warnf("Failed to close response body: %s\n", closeErr)
-			}
-			logger.Warnf("Storage returned status %d for %s\n", resp.StatusCode, url)
-			errs = append(errs, fmt.Errorf("%s: status %d", url, resp.StatusCode))
-		}
+		logger.Warnf("Failed to download step executable from %s: %s", url, err)
+		errs = append(errs, fmt.Errorf("%s: %w", url, err))
 	}
-	return nil, fmt.Errorf("failed to download executable: %w", errors.Join(errs...))
+	return fmt.Errorf("failed to download executable: %w", errors.Join(errs...))
 }

--- a/activator/steplib/activate_executable.go
+++ b/activator/steplib/activate_executable.go
@@ -65,20 +65,22 @@ func downloadExecutable(ctx context.Context, fetcher httpfetch.Client, executabl
 	if err != nil {
 		return err
 	}
-	return downloadFromURLs(ctx, fetcher, urls, executable.Hash, destPath, logger)
+	return downloadFromURLs(ctx, fetcher, urls, destPath, executable.Hash, logger)
 }
 
 // downloadFromURLs tries each URL in order via fetcher, verifying executable.Hash
 // on each attempt; a mismatch or failure falls through to the next mirror, logging
 // each failed attempt so a mirror silently degrading isn't invisible on fallback success.
-func downloadFromURLs(ctx context.Context, fetcher httpfetch.Client, urls []string, hash, destPath string, logger stepman.Logger) error {
+func downloadFromURLs(ctx context.Context, fetcher httpfetch.Client, urls []string, destPath, hash string, logger stepman.Logger) error {
 	var errs []error
 	for _, url := range urls {
 		err := fetcher.DownloadWithHash(ctx, destPath, url, hash)
 		if err == nil {
 			return nil
 		}
-		logger.Warnf("Failed to download step executable from %s: %s", url, err)
+		// err already names the failing URL (fetcher wraps it in the underlying
+		// GET/status/hash-mismatch error), so it isn't repeated here.
+		logger.Warnf("Failed to download step executable: %s", err)
 		errs = append(errs, fmt.Errorf("%s: %w", url, err))
 	}
 	return fmt.Errorf("failed to download executable: %w", errors.Join(errs...))

--- a/activator/steplib/activate_executable_test.go
+++ b/activator/steplib/activate_executable_test.go
@@ -124,7 +124,7 @@ func TestDownloadFromURLs(t *testing.T) {
 		defer secondary.Close()
 
 		destPath := filepath.Join(t.TempDir(), "executable")
-		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, destPath, hash, logger)
 		require.NoError(t, err)
 		require.Equal(t, 0, secondaryHits)
 
@@ -144,7 +144,7 @@ func TestDownloadFromURLs(t *testing.T) {
 		defer secondary.Close()
 
 		destPath := filepath.Join(t.TempDir(), "executable")
-		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, destPath, hash, logger)
 		require.NoError(t, err)
 
 		got, err := os.ReadFile(destPath)
@@ -163,7 +163,7 @@ func TestDownloadFromURLs(t *testing.T) {
 		defer secondary.Close()
 
 		destPath := filepath.Join(t.TempDir(), "executable")
-		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, destPath, hash, logger)
 		require.NoError(t, err)
 
 		got, err := os.ReadFile(destPath)
@@ -182,7 +182,7 @@ func TestDownloadFromURLs(t *testing.T) {
 		defer secondary.Close()
 
 		destPath := filepath.Join(t.TempDir(), "executable")
-		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, destPath, hash, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to download executable")
 		require.Contains(t, err.Error(), primary.URL)
@@ -202,7 +202,7 @@ func TestDownloadFromURLs(t *testing.T) {
 		defer secondary.Close()
 
 		destPath := filepath.Join(t.TempDir(), "executable")
-		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, destPath, hash, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to download executable")
 		require.Contains(t, err.Error(), "hash mismatch")

--- a/activator/steplib/activate_executable_test.go
+++ b/activator/steplib/activate_executable_test.go
@@ -1,67 +1,25 @@
 package steplib
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateHash(t *testing.T) {
-	tests := []struct {
-		name         string
-		filePath     string
-		expectedHash string
-		expectedErr  error
-	}{
-		{
-			name:         "Valid hash",
-			filePath:     "testdata/file.txt",
-			expectedHash: "sha256-f2040af3939f5033be8ca9b363055b3e53107c4688ba39b71d4529869a9cc9b2",
-			expectedErr:  nil,
-		},
-		{
-			name:         "Hash mismatch",
-			filePath:     "testdata/file.txt",
-			expectedHash: "sha256-1234567890abcdef",
-			expectedErr:  fmt.Errorf("hash mismatch: expected sha256-1234567890abcdef, got sha256-f2040af3939f5033be8ca9b363055b3e53107c4688ba39b71d4529869a9cc9b2"),
-		},
-		{
-			name:         "Nonexistent file",
-			filePath:     "testdata/nonexistent.txt",
-			expectedHash: "sha256-3b6b4f1e2e8b8a9e4f7a4b5e6c7d8e9f",
-			expectedErr:  fmt.Errorf("open testdata/nonexistent.txt: no such file or directory"),
-		},
-		{
-			name:         "Empty hash",
-			filePath:     "testdata/file.txt",
-			expectedHash: "",
-			expectedErr:  fmt.Errorf("hash is empty"),
-		},
-		{
-			name:         "Invalid hash type",
-			filePath:     "testdata/file.txt",
-			expectedHash: "md5-3b6b4f1e2e8b8a9e4f7a4b5e6c7d8e9f",
-			expectedErr:  fmt.Errorf("only SHA256 hashes supported at this time, make sure to prefix the hash with `sha256-`. Found hash value: md5-3b6b4f1e2e8b8a9e4f7a4b5e6c7d8e9f"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateHash(tt.filePath, tt.expectedHash)
-			if tt.expectedErr == nil {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				require.Equal(t, tt.expectedErr.Error(), err.Error())
-			}
-		})
-	}
+func sha256Hash(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256-" + hex.EncodeToString(sum[:])
 }
 
 func TestBuildDownloadURLs(t *testing.T) {
@@ -147,12 +105,17 @@ func TestBuildDownloadURLs(t *testing.T) {
 	}
 }
 
-
 func TestDownloadFromURLs(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewDefaultLogger(false)
+	fetcher := httpfetch.NewClient(logger)
+	payload := []byte("primary payload")
+	hash := sha256Hash(payload)
+
 	t.Run("primary succeeds, secondary is not called", func(t *testing.T) {
 		secondaryHits := 0
 		primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("from primary"))
+			_, _ = w.Write(payload)
 		}))
 		defer primary.Close()
 		secondary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -160,14 +123,14 @@ func TestDownloadFromURLs(t *testing.T) {
 		}))
 		defer secondary.Close()
 
-		body, err := downloadFromURLs([]string{primary.URL, secondary.URL}, log.NewDefaultLogger(false))
+		destPath := filepath.Join(t.TempDir(), "executable")
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
 		require.NoError(t, err)
-		defer func() { _ = body.Close() }()
-
-		b, err := io.ReadAll(body)
-		require.NoError(t, err)
-		require.Equal(t, "from primary", string(b))
 		require.Equal(t, 0, secondaryHits)
+
+		got, err := os.ReadFile(destPath)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
 	})
 
 	t.Run("primary 404 falls back to secondary", func(t *testing.T) {
@@ -176,17 +139,36 @@ func TestDownloadFromURLs(t *testing.T) {
 		}))
 		defer primary.Close()
 		secondary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("from secondary"))
+			_, _ = w.Write(payload)
 		}))
 		defer secondary.Close()
 
-		body, err := downloadFromURLs([]string{primary.URL, secondary.URL}, log.NewDefaultLogger(false))
+		destPath := filepath.Join(t.TempDir(), "executable")
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
 		require.NoError(t, err)
-		defer func() { _ = body.Close() }()
 
-		b, err := io.ReadAll(body)
+		got, err := os.ReadFile(destPath)
 		require.NoError(t, err)
-		require.Equal(t, "from secondary", string(b))
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("primary hash mismatch falls back to secondary", func(t *testing.T) {
+		primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("corrupted"))
+		}))
+		defer primary.Close()
+		secondary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(payload)
+		}))
+		defer secondary.Close()
+
+		destPath := filepath.Join(t.TempDir(), "executable")
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(destPath)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
 	})
 
 	t.Run("all URLs fail and the error lists each one", func(t *testing.T) {
@@ -199,12 +181,30 @@ func TestDownloadFromURLs(t *testing.T) {
 		}))
 		defer secondary.Close()
 
-		_, err := downloadFromURLs([]string{primary.URL, secondary.URL}, log.NewDefaultLogger(false))
+		destPath := filepath.Join(t.TempDir(), "executable")
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to download executable")
 		require.Contains(t, err.Error(), primary.URL)
-		require.Contains(t, err.Error(), "status 404")
+		require.Contains(t, err.Error(), "404")
 		require.Contains(t, err.Error(), secondary.URL)
-		require.Contains(t, err.Error(), "status 403")
+		require.Contains(t, err.Error(), "403")
+	})
+
+	t.Run("hash mismatch on every URL is a final error", func(t *testing.T) {
+		primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("corrupted-1"))
+		}))
+		defer primary.Close()
+		secondary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("corrupted-2"))
+		}))
+		defer secondary.Close()
+
+		destPath := filepath.Join(t.TempDir(), "executable")
+		err := downloadFromURLs(ctx, fetcher, []string{primary.URL, secondary.URL}, hash, destPath, logger)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to download executable")
+		require.Contains(t, err.Error(), "hash mismatch")
 	})
 }

--- a/activator/steplib/testdata/file.txt
+++ b/activator/steplib/testdata/file.txt
@@ -1,1 +1,0 @@
-hash verification test

--- a/internal/httpfetch/httpfetch_test.go
+++ b/internal/httpfetch/httpfetch_test.go
@@ -1,0 +1,153 @@
+package httpfetch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/stretchr/testify/require"
+)
+
+func sha256Hash(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256-" + hex.EncodeToString(sum[:])
+}
+
+func newClient() Client {
+	return NewClient(log.NewDefaultLogger(false))
+}
+
+func TestGet(t *testing.T) {
+	ctx := context.Background()
+	fetcher := newClient()
+
+	t.Run("2xx returns the body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("hello"))
+		}))
+		defer server.Close()
+
+		body, err := fetcher.Get(ctx, server.URL)
+		require.NoError(t, err)
+		defer func() { _ = body.Close() }()
+
+		got, err := io.ReadAll(body)
+		require.NoError(t, err)
+		require.Equal(t, "hello", string(got))
+	})
+
+	t.Run("non-2xx returns a StatusError with the status code and body snippet", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found"))
+		}))
+		defer server.Close()
+
+		_, err := fetcher.Get(ctx, server.URL)
+		require.Error(t, err)
+
+		var statusErr *StatusError
+		require.True(t, errors.As(err, &statusErr), "expected a *StatusError, got %T: %v", err, err)
+		require.Equal(t, http.StatusNotFound, statusErr.Code)
+		require.Equal(t, "not found", statusErr.Body)
+	})
+}
+
+func TestDownload(t *testing.T) {
+	ctx := context.Background()
+	fetcher := newClient()
+	payload := []byte("binary content")
+
+	t.Run("writes the fetched content to destPath", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(payload)
+		}))
+		defer server.Close()
+
+		destPath := filepath.Join(t.TempDir(), "nested", "dir", "out.bin")
+		err := fetcher.Download(ctx, destPath, server.URL)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(destPath)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("a failed fetch leaves no file at destPath", func(t *testing.T) {
+		// 404 (not 500) so retryablehttp's internal retry policy doesn't retry
+		// this and slow the test down: only 5xx/network errors are retried.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		destPath := filepath.Join(t.TempDir(), "out.bin")
+		err := fetcher.Download(ctx, destPath, server.URL)
+		require.Error(t, err)
+
+		_, statErr := os.Stat(destPath)
+		require.True(t, os.IsNotExist(statErr), "destPath should not exist after a failed download")
+
+		// No leftover temp files in the destination directory either.
+		entries, err := os.ReadDir(filepath.Dir(destPath))
+		require.NoError(t, err)
+		require.Empty(t, entries, "temp file should have been cleaned up")
+	})
+}
+
+func TestDownloadWithHash(t *testing.T) {
+	ctx := context.Background()
+	fetcher := newClient()
+	payload := []byte("binary content")
+	hash := sha256Hash(payload)
+
+	t.Run("matching hash succeeds and writes destPath", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(payload)
+		}))
+		defer server.Close()
+
+		destPath := filepath.Join(t.TempDir(), "out.bin")
+		err := fetcher.DownloadWithHash(ctx, destPath, server.URL, hash)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(destPath)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("mismatched hash fails and leaves no file at destPath", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("different content"))
+		}))
+		defer server.Close()
+
+		destPath := filepath.Join(t.TempDir(), "out.bin")
+		err := fetcher.DownloadWithHash(ctx, destPath, server.URL, hash)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "hash mismatch")
+
+		_, statErr := os.Stat(destPath)
+		require.True(t, os.IsNotExist(statErr), "destPath should not exist after a hash mismatch")
+	})
+
+	t.Run("empty expected hash is rejected without making a request", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("server should not have been contacted")
+		}))
+		defer server.Close()
+
+		destPath := filepath.Join(t.TempDir(), "out.bin")
+		err := fetcher.DownloadWithHash(ctx, destPath, server.URL, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "hash is empty")
+	})
+}


### PR DESCRIPTION
## Summary
Routes precompiled step-binary downloads through the shared `internal/httpfetch` client (already used by the V2 steplibrary spec/metadata fetcher), replacing the direct `retryablehttp` calls and hand-rolled `validateHash` with `httpfetch.Client.DownloadWithHash`.

Split out of #405 per review: that PR bundled this with the step-source-zip download swap, which overlaps with in-flight work on `stepman/util.go` (#404). This PR is precompiled-only.

## Changes
- `activator/steplib/activate_executable.go`: `activateStepExecutable`/`downloadExecutable`/`downloadFromURLs` now take a `ctx context.Context` and `httpfetch.Client`; the per-mirror fallback loop calls `fetcher.DownloadWithHash` per URL, keeping the existing `logger.Warnf` on each failed attempt. Deletes the hand-rolled `validateHash`.
- `activator/steplib/activate.go`: `downloadPrecompiled`'s call site constructs `httpfetch.NewClient(log)` and `context.Background()`.
- `activator/steplib/activate_executable_test.go`: rewritten against the new signature using a real `httpfetch.Client` + `httptest` servers; adds coverage for hash-mismatch-falls-back-to-next-mirror (a deliberate behavior improvement — `DownloadWithHash` bundles the hash check into each per-URL attempt, so a bad primary now falls through instead of failing outright).
- **New** `internal/httpfetch/httpfetch_test.go` — this package had zero tests despite now owning hash verification (`Get`, `Download`, `DownloadWithHash`: success, non-2xx, hash mismatch, empty-hash rejection, atomicity).
- Deletes the now-orphaned `activator/steplib/testdata/file.txt` fixture.

## Heads up for reviewers
Two other open PRs touch adjacent code and will need a small rebase against whichever of us lands second:
- #402 (`STEP-2404-sri`) touches `validateHash` (which this PR deletes) and `httpfetch.go`'s internal hash formatting (cosmetic, same wire format).
- #408 (`precompiled-step-executable-cache`) wraps `activateStepExecutable` with an on-disk cache, built against the pre-httpfetch shape of that function.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run --config .golangci.yml ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)