### PR TITLE
chore(steplib-api): Change prod deployment base url

### DIFF
--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	bitriseSteplibURL    = "https://github.com/bitrise-io/bitrise-steplib.git"
-	bitriseSteplibAPIURL = "https://steplib.bitrise.io" // Base URL of steplib API
+	bitriseSteplibAPIURL = "https://steplib.bitrise.io/api"
 	enableSteplibAPIEnv  = "BITRISE_STEPLIB_API_ENABLE"
 )
 


### PR DESCRIPTION
This is just a hosting change for legibility improvements of the end product and to follow deployment changes. 
No API or behavioral changes whatsoever.