### PR TITLE
Fix Step Source Activation via Steplib API

### DIFF
--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -28,11 +28,6 @@ var precompiledStepsDefaultStorageURLs = []string{
 	"https://storage.googleapis.com/bitrise-steplib-storage",
 }
 
-// newPrecompiledFetcher builds the HTTP client used to download precompiled step
-// executables. It's a package var so tests can inject a fake httpfetch.Client
-// and exercise the executable-activation branch without a real download.
-var newPrecompiledFetcher = httpfetch.NewClient
-
 type ResolvedStep struct {
 	// ExecPath is optional: it holds the activated step executable only for
 	// precompiled executable activation, and is empty for source activation.
@@ -40,7 +35,7 @@ type ResolvedStep struct {
 	StepInfo models.StepInfoModel
 }
 
-func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, isOfflineMode bool, libraryAPI *steplibrary.Client) (ResolvedStep, error) {
+func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, isOfflineMode bool, libraryAPI *steplibrary.Client, precompiledFetcher httpfetch.Client) (ResolvedStep, error) {
 	var stepInfo models.StepInfoModel
 	var resolveErr error
 	if libraryAPI != nil {
@@ -69,7 +64,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 		}
 	}
 
-	execPath, err := downloadPrecompiled(log, stepModel, id, destination)
+	execPath, err := downloadPrecompiled(log, stepModel, id, destination, precompiledFetcher)
 	if execPath != "" {
 		return ResolvedStep{ExecPath: execPath, StepInfo: stepInfo}, err
 	}
@@ -95,14 +90,14 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
 }
 
-func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.CanonicalID, destination string) (string, error) {
+func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.CanonicalID, destination string, fetcher httpfetch.Client) (string, error) {
 	if (os.Getenv(precompiledStepsEnv) == "true" || os.Getenv(precompiledStepsEnv) == "1") && step.Executables != nil {
 		platform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 		executableForPlatform, ok := (*step.Executables)[platform]
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(context.Background(), newPrecompiledFetcher(log), id.IDorURI, executableForPlatform, destination, log)
+			execPath, err := activateStepExecutable(context.Background(), fetcher, id.IDorURI, executableForPlatform, destination, log)
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -72,7 +72,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	// Fall back to step source activation.
 	if libraryAPI != nil {
 		// activate the source over the API, without git clone
-		if err := activateStepSourceWithAPI(libraryAPI, id.SteplibSource, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
+		if err := activateStepSourceWithAPI(libraryAPI, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -28,6 +28,11 @@ var precompiledStepsDefaultStorageURLs = []string{
 	"https://storage.googleapis.com/bitrise-steplib-storage",
 }
 
+// newPrecompiledFetcher builds the HTTP client used to download precompiled step
+// executables. It's a package var so tests can inject a fake httpfetch.Client
+// and exercise the executable-activation branch without a real download.
+var newPrecompiledFetcher = httpfetch.NewClient
+
 type ResolvedStep struct {
 	// ExecPath is optional: it holds the activated step executable only for
 	// precompiled executable activation, and is empty for source activation.
@@ -97,7 +102,7 @@ func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.Ca
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(context.Background(), httpfetch.NewClient(log), id.IDorURI, executableForPlatform, destination, log)
+			execPath, err := activateStepExecutable(context.Background(), newPrecompiledFetcher(log), id.IDorURI, executableForPlatform, destination, log)
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 

--- a/activator/steplib/activate_api_test.go
+++ b/activator/steplib/activate_api_test.go
@@ -1,0 +1,203 @@
+package steplib
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/stepid"
+	"github.com/bitrise-io/stepman/steplibrary"
+	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise ActivateStep's V2 (API) dispatch logic hermetically: a
+// steplibrary.Client is pointed at a local httptest server that serves a small,
+// wire-faithful inventory (built from the real steplibindex/models structs and
+// addressed via the real Path helpers, so it can't structurally drift from the
+// reader). Source archives are wired back to the same server, so the whole
+// activation — resolve → write step.yml → precompiled gate → source fetch — runs
+// without touching the network or the git-cloned steplib.
+
+const testSteplibURL = "https://github.com/bitrise-io/bitrise-steplib.git"
+
+type apiTestLogger struct{ t *testing.T }
+
+func (l apiTestLogger) Debugf(f string, a ...any) { l.t.Logf("DEBUG "+f, a...) }
+func (l apiTestLogger) Errorf(f string, a ...any) { l.t.Logf("ERROR "+f, a...) }
+func (l apiTestLogger) Warnf(f string, a ...any)  { l.t.Logf("WARN "+f, a...) }
+func (l apiTestLogger) Infof(f string, a ...any)  { l.t.Logf("INFO "+f, a...) }
+
+// helloStepVersions is newest-first, matching the versions.json contract.
+var helloStepVersions = []string{"2.0.0", "1.1.0", "1.0.0"}
+
+// serveHelloStepInventory writes and serves a minimal V2 inventory for
+// "hello-step" and returns the server. The source archive for every version is
+// served from the same server (keyed by step ID + version, the correct layout),
+// so source activation resolves entirely against localhost.
+func serveHelloStepInventory(t *testing.T) *httptest.Server {
+	t.Helper()
+	root := t.TempDir()
+
+	writeInventoryJSON(t, root, steplibindex.StepIDsPath(),
+		steplibindex.StepIDs{StepIDs: []string{"hello-step"}})
+
+	latestPath, err := steplibindex.LatestPointerPath("hello-step")
+	require.NoError(t, err)
+	writeInventoryJSON(t, root, latestPath, steplibindex.LatestPointer{
+		StepID:        "hello-step",
+		Latest:        "2.0.0",
+		LatestByMajor: map[string]string{"1": "1.1.0", "2": "2.0.0"},
+	})
+
+	versionsPath, err := steplibindex.VersionsPath("hello-step")
+	require.NoError(t, err)
+	writeInventoryJSON(t, root, versionsPath,
+		steplibindex.Versions{StepID: "hello-step", Versions: helloStepVersions})
+
+	infoPath, err := steplibindex.StepInfoPath("hello-step")
+	require.NoError(t, err)
+	writeInventoryJSON(t, root, infoPath,
+		steplibindex.StepInfo{Maintainer: "bitrise", AssetURLs: []string{}})
+
+	for _, v := range helloStepVersions {
+		stepJSONPath, err := steplibindex.StepJSONPath("hello-step", v)
+		require.NoError(t, err)
+		title := "Hello Step " + v
+		writeInventoryJSON(t, root, stepJSONPath, models.StepModel{
+			Title: &title,
+			Source: &models.StepSourceModel{
+				Git:    "https://github.com/example/hello-step.git",
+				Commit: "cccc3333cccc3333cccc3333cccc3333cccc3333",
+			},
+		})
+	}
+
+	srv := httptest.NewServer(http.FileServer(http.Dir(root)))
+	t.Cleanup(srv.Close)
+
+	// meta.json declares a single zip download base pointing back at this server.
+	// Written after the server starts so we know its URL; http.FileServer reads
+	// lazily, so it's served on the next request. Only a zip location is listed
+	// (no git) so source activation must resolve against localhost, never a clone.
+	writeInventoryJSON(t, root, steplibindex.MetaPath(), steplibindex.Meta{
+		FormatVersion: steplibindex.FormatVersion,
+		UpdatedAt:     time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC),
+		DownloadLocations: []models.DownloadLocationModel{
+			{Type: "zip", Src: srv.URL + "/archive/"},
+		},
+	})
+
+	// BuildStepSourceDownloadLocations forms "<base><stepID>/<version>/step.zip",
+	// so the archive for each version lives under archive/hello-step/<version>/.
+	for _, v := range helloStepVersions {
+		writeStepSourceZip(t, filepath.Join(root, "archive", "hello-step", v, "step.zip"))
+	}
+
+	return srv
+}
+
+func writeInventoryJSON(t *testing.T, root string, p steplibindex.Path, v any) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(p.FS()))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(full, data, 0o644))
+}
+
+// writeStepSourceZip writes a step source archive whose single entry is a marker
+// file, so a successful activation can be verified by the marker's presence in
+// the destination.
+func writeStepSourceZip(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("activated_marker.txt")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("activated from source"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
+}
+
+func TestActivateStep_APISource_ExactVersion(t *testing.T) {
+	srv := serveHelloStepInventory(t)
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "false")
+
+	destination := t.TempDir()
+	workDir := t.TempDir()
+	stepYML := filepath.Join(workDir, "current_step.yml")
+
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
+
+	resolved, err := ActivateStep(id, destination, stepYML, log, false, steplibrary.New(log, srv.URL))
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello-step", resolved.StepInfo.ID)
+	assert.Equal(t, "2.0.0", resolved.StepInfo.Version, "exact request resolves to itself")
+	assert.Equal(t, "2.0.0", resolved.StepInfo.OriginalVersion)
+	assert.Empty(t, resolved.ExecPath, "source activation must not yield an executable path")
+
+	// writeStepYML placed a step.yml at the requested path.
+	require.FileExists(t, stepYML, "step.yml should be written to the work dir")
+
+	// The source archive was fetched and unpacked into the destination.
+	require.FileExists(t, filepath.Join(destination, "activated_marker.txt"),
+		"step source should be materialized into the destination dir")
+}
+
+func TestActivateStep_APISource_MajorLockResolves(t *testing.T) {
+	srv := serveHelloStepInventory(t)
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "false")
+
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "1"}
+
+	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.1.0", resolved.StepInfo.Version, "major lock 1 resolves to the highest 1.x")
+	assert.Equal(t, "1", resolved.StepInfo.OriginalVersion)
+	assert.Empty(t, resolved.ExecPath)
+}
+
+func TestActivateStep_APISource_NonexistentVersionFails(t *testing.T) {
+	srv := serveHelloStepInventory(t)
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "false")
+
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "99.99.99"}
+
+	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	require.Error(t, err, "a version not in the inventory must fail resolution")
+}
+
+// hello-step ships no prebuilt executables, so with the precompiled experiment
+// enabled ActivateStep must still fall back to source activation.
+func TestActivateStep_APIPrecompiledEnabled_FallsBackToSource(t *testing.T) {
+	srv := serveHelloStepInventory(t)
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "true")
+
+	destination := t.TempDir()
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
+
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	require.NoError(t, err)
+
+	assert.Empty(t, resolved.ExecPath, "a step without executables must fall back to source")
+	require.FileExists(t, filepath.Join(destination, "activated_marker.txt"))
+}

--- a/activator/steplib/activate_executable_test.go
+++ b/activator/steplib/activate_executable_test.go
@@ -105,6 +105,42 @@ func TestBuildDownloadURLs(t *testing.T) {
 	}
 }
 
+// TestActivateStepExecutable covers the URL assembly and hash threading between
+// activateStepExecutable → downloadExecutable and the fetcher, using a fake
+// fetcher so no bytes are transferred. The download loop itself (mirror fallback,
+// hash verification) is covered by TestDownloadFromURLs.
+func TestActivateStepExecutable(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewDefaultLogger(false)
+	storageURI := "steps/hello-step/2.0.0/bin/hello-step"
+	const hash = "sha256-1111111111111111111111111111111111111111111111111111111111111111"
+
+	t.Run("default bases: first mirror + StorageURI, hash threaded through", func(t *testing.T) {
+		fake := &fakeExecutableFetcher{}
+		destDir := t.TempDir()
+
+		path, err := activateStepExecutable(ctx, fake, "hello-step",
+			models.Executable{StorageURI: storageURI, Hash: hash}, destDir, logger)
+		require.NoError(t, err)
+
+		require.Equal(t, filepath.Join(destDir, "hello-step"), path)
+		require.FileExists(t, path)
+		require.Equal(t, precompiledStepsDefaultStorageURLs[0]+"/"+storageURI, fake.calledURL)
+		require.Equal(t, hash, fake.calledHash)
+	})
+
+	t.Run("BITRISE_PRECOMPILED_STEPS_STORAGE_URLS override wins", func(t *testing.T) {
+		t.Setenv(precompiledStepsStorageURLsEnv, "https://custom.example.com")
+		fake := &fakeExecutableFetcher{}
+
+		_, err := activateStepExecutable(ctx, fake, "hello-step",
+			models.Executable{StorageURI: storageURI, Hash: hash}, t.TempDir(), logger)
+		require.NoError(t, err)
+
+		require.Equal(t, "https://custom.example.com/"+storageURI, fake.calledURL)
+	})
+}
+
 func TestDownloadFromURLs(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewDefaultLogger(false)

--- a/activator/steplib/activate_test.go
+++ b/activator/steplib/activate_test.go
@@ -1,0 +1,149 @@
+package steplib
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/bitrise-io/stepman/internal/httpfetch"
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/stepid"
+	"github.com/bitrise-io/stepman/steplibrary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for ActivateStep's dispatch: version resolution, step.yml placement, and
+// the executable-vs-source-vs-fallback decision. Leaf mechanics — download URL
+// building, mirror fallback, hash checks (activate_executable_test.go) and the
+// source guard clauses (source_test.go) — are owned elsewhere; these tests assert
+// only which branch ran and the shape of the result.
+
+func TestActivateStep_ResolvesExactVersion(t *testing.T) {
+	srv := serveHelloStepInventory(t)
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "false")
+
+	destination := t.TempDir()
+	workDir := t.TempDir()
+	stepYML := filepath.Join(workDir, "current_step.yml")
+
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
+
+	resolved, err := ActivateStep(id, destination, stepYML, log, false, steplibrary.New(log, srv.URL))
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello-step", resolved.StepInfo.ID)
+	assert.Equal(t, "2.0.0", resolved.StepInfo.Version, "exact request resolves to itself")
+	assert.Equal(t, "2.0.0", resolved.StepInfo.OriginalVersion)
+	assert.Empty(t, resolved.ExecPath, "source activation must not yield an executable path")
+
+	require.FileExists(t, stepYML, "step.yml should be written to the work dir")
+	require.FileExists(t, filepath.Join(destination, "activated_marker.txt"),
+		"step source should be materialized into the destination dir")
+}
+
+func TestActivateStep_ResolvesMajorLock(t *testing.T) {
+	srv := serveHelloStepInventory(t)
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "false")
+
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "1"}
+
+	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.1.0", resolved.StepInfo.Version, "major lock 1 resolves to the highest 1.x")
+	assert.Equal(t, "1", resolved.StepInfo.OriginalVersion)
+	assert.Empty(t, resolved.ExecPath)
+}
+
+func TestActivateStep_NonexistentVersionFails(t *testing.T) {
+	srv := serveHelloStepInventory(t)
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "false")
+
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "99.99.99"}
+
+	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	require.Error(t, err, "a version not in the inventory must fail resolution")
+}
+
+// With the precompiled step flag on but no executable published for a step,
+// ActivateStep falls back to source activation.
+func TestActivateStep_NoExecutable_ActivatesSource(t *testing.T) {
+	srv := serveHelloStepInventory(t)
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "true")
+
+	destination := t.TempDir()
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
+
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	require.NoError(t, err)
+
+	assert.Empty(t, resolved.ExecPath, "a step without executables must fall back to source")
+	require.FileExists(t, filepath.Join(destination, "activated_marker.txt"))
+}
+
+// With the precompiled step flag on and an executable published for the current
+// platform, ActivateStep takes the executable branch and does not fall back to
+// source. The binary transfer is faked; asserting the download URL/hash is the
+// job of activate_executable_test.go.
+func TestActivateStep_ChoosesExecutable(t *testing.T) {
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	srv := serveHelloStepInventoryWithExecutables(t, &models.Executables{
+		platform: models.Executable{
+			StorageURI: "steps/hello-step/2.0.0/bin/hello-step-" + platform,
+			Hash:       "sha256-1111111111111111111111111111111111111111111111111111111111111111",
+		},
+	})
+
+	orig := newPrecompiledFetcher
+	t.Cleanup(func() { newPrecompiledFetcher = orig })
+	newPrecompiledFetcher = func(httpfetch.Logger) httpfetch.Client { return &fakeExecutableFetcher{} }
+
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "true")
+
+	destination := t.TempDir()
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
+
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(destination, "hello-step"), resolved.ExecPath)
+	require.FileExists(t, resolved.ExecPath)
+	require.NoFileExists(t, filepath.Join(destination, "activated_marker.txt"),
+		"executable activation must not fall back to source")
+}
+
+// If the executable download fails, ActivateStep falls back to source activation
+// rather than erroring.
+func TestActivateStep_ExecutableDownloadFails_FallsBackToSource(t *testing.T) {
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	srv := serveHelloStepInventoryWithExecutables(t, &models.Executables{
+		platform: models.Executable{
+			StorageURI: "steps/hello-step/2.0.0/bin/hello-step-" + platform,
+			Hash:       "sha256-1111111111111111111111111111111111111111111111111111111111111111",
+		},
+	})
+
+	orig := newPrecompiledFetcher
+	t.Cleanup(func() { newPrecompiledFetcher = orig })
+	newPrecompiledFetcher = func(httpfetch.Logger) httpfetch.Client {
+		return &fakeExecutableFetcher{downloadErr: errFakeDownload}
+	}
+
+	log := apiTestLogger{t}
+	t.Setenv(precompiledStepsEnv, "true")
+
+	destination := t.TempDir()
+	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
+
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	require.NoError(t, err, "a failed executable download must fall back to source, not error")
+
+	assert.Empty(t, resolved.ExecPath)
+	require.FileExists(t, filepath.Join(destination, "activated_marker.txt"))
+}

--- a/activator/steplib/activate_test.go
+++ b/activator/steplib/activate_test.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/steplibrary"
@@ -30,7 +29,7 @@ func TestActivateStep_ResolvesExactVersion(t *testing.T) {
 
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, stepYML, log, false, steplibrary.New(log, srv.URL))
+	resolved, err := ActivateStep(id, destination, stepYML, log, false, steplibrary.New(log, srv.URL), &fakeExecutableFetcher{})
 	require.NoError(t, err)
 
 	assert.Equal(t, "hello-step", resolved.StepInfo.ID)
@@ -50,7 +49,7 @@ func TestActivateStep_ResolvesMajorLock(t *testing.T) {
 
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "1"}
 
-	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), &fakeExecutableFetcher{})
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.1.0", resolved.StepInfo.Version, "major lock 1 resolves to the highest 1.x")
@@ -65,7 +64,7 @@ func TestActivateStep_NonexistentVersionFails(t *testing.T) {
 
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "99.99.99"}
 
-	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), &fakeExecutableFetcher{})
 	require.Error(t, err, "a version not in the inventory must fail resolution")
 }
 
@@ -79,7 +78,7 @@ func TestActivateStep_NoExecutable_ActivatesSource(t *testing.T) {
 	destination := t.TempDir()
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), &fakeExecutableFetcher{})
 	require.NoError(t, err)
 
 	assert.Empty(t, resolved.ExecPath, "a step without executables must fall back to source")
@@ -99,17 +98,13 @@ func TestActivateStep_ChoosesExecutable(t *testing.T) {
 		},
 	})
 
-	orig := newPrecompiledFetcher
-	t.Cleanup(func() { newPrecompiledFetcher = orig })
-	newPrecompiledFetcher = func(httpfetch.Logger) httpfetch.Client { return &fakeExecutableFetcher{} }
-
 	log := apiTestLogger{t}
 	t.Setenv(precompiledStepsEnv, "true")
 
 	destination := t.TempDir()
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), &fakeExecutableFetcher{})
 	require.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(destination, "hello-step"), resolved.ExecPath)
@@ -129,19 +124,14 @@ func TestActivateStep_ExecutableDownloadFails_FallsBackToSource(t *testing.T) {
 		},
 	})
 
-	orig := newPrecompiledFetcher
-	t.Cleanup(func() { newPrecompiledFetcher = orig })
-	newPrecompiledFetcher = func(httpfetch.Logger) httpfetch.Client {
-		return &fakeExecutableFetcher{downloadErr: errFakeDownload}
-	}
-
 	log := apiTestLogger{t}
 	t.Setenv(precompiledStepsEnv, "true")
 
 	destination := t.TempDir()
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
+	fetcher := &fakeExecutableFetcher{downloadErr: errFakeDownload}
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), fetcher)
 	require.NoError(t, err, "a failed executable download must fall back to source, not error")
 
 	assert.Empty(t, resolved.ExecPath)

--- a/activator/steplib/helpers_test.go
+++ b/activator/steplib/helpers_test.go
@@ -3,7 +3,10 @@ package steplib
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,21 +14,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
-	"github.com/bitrise-io/stepman/stepid"
-	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// These tests exercise ActivateStep's V2 (API) dispatch logic hermetically: a
-// steplibrary.Client is pointed at a local httptest server that serves a small,
-// wire-faithful inventory (built from the real steplibindex/models structs and
-// addressed via the real Path helpers, so it can't structurally drift from the
-// reader). Source archives are wired back to the same server, so the whole
-// activation — resolve → write step.yml → precompiled gate → source fetch — runs
-// without touching the network or the git-cloned steplib.
+// Shared hermetic fixtures for the steplib package tests. A steplibrary.Client
+// pointed at serveHelloStepInventory's server exercises the real read and source
+// paths with no network and no git-cloned steplib; the inventory is built from
+// the real steplibindex/models structs via the real Path helpers, so it cannot
+// structurally drift from the reader.
 
 const testSteplibURL = "https://github.com/bitrise-io/bitrise-steplib.git"
 
@@ -44,6 +43,13 @@ var helloStepVersions = []string{"2.0.0", "1.1.0", "1.0.0"}
 // served from the same server (keyed by step ID + version, the correct layout),
 // so source activation resolves entirely against localhost.
 func serveHelloStepInventory(t *testing.T) *httptest.Server {
+	return serveHelloStepInventoryWithExecutables(t, nil)
+}
+
+// serveHelloStepInventoryWithExecutables is serveHelloStepInventory with an
+// optional executables block applied to every version's step.json, so the
+// precompiled-activation branch can be exercised.
+func serveHelloStepInventoryWithExecutables(t *testing.T, executables *models.Executables) *httptest.Server {
 	t.Helper()
 	root := t.TempDir()
 
@@ -78,6 +84,7 @@ func serveHelloStepInventory(t *testing.T) *httptest.Server {
 				Git:    "https://github.com/example/hello-step.git",
 				Commit: "cccc3333cccc3333cccc3333cccc3333cccc3333",
 			},
+			Executables: executables,
 		})
 	}
 
@@ -132,72 +139,30 @@ func writeStepSourceZip(t *testing.T, path string) {
 	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
 }
 
-func TestActivateStep_APISource_ExactVersion(t *testing.T) {
-	srv := serveHelloStepInventory(t)
-	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "false")
+// errFakeDownload is returned by fakeExecutableFetcher when it is set to fail,
+// so the executable-download-failure fallback can be driven deterministically.
+var errFakeDownload = errors.New("simulated executable download failure")
 
-	destination := t.TempDir()
-	workDir := t.TempDir()
-	stepYML := filepath.Join(workDir, "current_step.yml")
-
-	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
-
-	resolved, err := ActivateStep(id, destination, stepYML, log, false, steplibrary.New(log, srv.URL))
-	require.NoError(t, err)
-
-	assert.Equal(t, "hello-step", resolved.StepInfo.ID)
-	assert.Equal(t, "2.0.0", resolved.StepInfo.Version, "exact request resolves to itself")
-	assert.Equal(t, "2.0.0", resolved.StepInfo.OriginalVersion)
-	assert.Empty(t, resolved.ExecPath, "source activation must not yield an executable path")
-
-	// writeStepYML placed a step.yml at the requested path.
-	require.FileExists(t, stepYML, "step.yml should be written to the work dir")
-
-	// The source archive was fetched and unpacked into the destination.
-	require.FileExists(t, filepath.Join(destination, "activated_marker.txt"),
-		"step source should be materialized into the destination dir")
+// fakeExecutableFetcher is an httpfetch.Client that records the requested
+// download and writes a stub file at destPath instead of fetching bytes, so the
+// executable-activation path can be exercised without a real download or a
+// hash-matching served artifact. When downloadErr is set, DownloadWithHash
+// returns it instead. Only DownloadWithHash is used by that path.
+type fakeExecutableFetcher struct {
+	calledURL   string
+	calledHash  string
+	downloadErr error
 }
 
-func TestActivateStep_APISource_MajorLockResolves(t *testing.T) {
-	srv := serveHelloStepInventory(t)
-	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "false")
+var _ httpfetch.Client = (*fakeExecutableFetcher)(nil)
 
-	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "1"}
-
-	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
-	require.NoError(t, err)
-
-	assert.Equal(t, "1.1.0", resolved.StepInfo.Version, "major lock 1 resolves to the highest 1.x")
-	assert.Equal(t, "1", resolved.StepInfo.OriginalVersion)
-	assert.Empty(t, resolved.ExecPath)
-}
-
-func TestActivateStep_APISource_NonexistentVersionFails(t *testing.T) {
-	srv := serveHelloStepInventory(t)
-	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "false")
-
-	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "99.99.99"}
-
-	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
-	require.Error(t, err, "a version not in the inventory must fail resolution")
-}
-
-// hello-step ships no prebuilt executables, so with the precompiled experiment
-// enabled ActivateStep must still fall back to source activation.
-func TestActivateStep_APIPrecompiledEnabled_FallsBackToSource(t *testing.T) {
-	srv := serveHelloStepInventory(t)
-	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "true")
-
-	destination := t.TempDir()
-	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
-
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL))
-	require.NoError(t, err)
-
-	assert.Empty(t, resolved.ExecPath, "a step without executables must fall back to source")
-	require.FileExists(t, filepath.Join(destination, "activated_marker.txt"))
+func (fakeExecutableFetcher) Get(context.Context, string) (io.ReadCloser, error) { return nil, nil }
+func (fakeExecutableFetcher) Download(context.Context, string, string) error     { return nil }
+func (f *fakeExecutableFetcher) DownloadWithHash(_ context.Context, destPath, url, expectedHash string) error {
+	f.calledURL = url
+	f.calledHash = expectedHash
+	if f.downloadErr != nil {
+		return f.downloadErr
+	}
+	return os.WriteFile(destPath, []byte("stub binary"), 0o644)
 }

--- a/activator/steplib/source_test.go
+++ b/activator/steplib/source_test.go
@@ -1,0 +1,67 @@
+package steplib
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/steplibrary"
+	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for activateStepSourceWithAPI (V2 source activation) — its guard clauses.
+// The happy-path id → step.zip URL flow is covered end-to-end by
+// TestActivateStep_ResolvesExactVersion in activate_test.go, which serves the
+// archive at the id-keyed path (so a wrong id would 404 there).
+
+func TestActivateStepSourceWithAPI_OfflineFails(t *testing.T) {
+	log := apiTestLogger{t}
+	client := steplibrary.New(log, "http://unused.invalid")
+
+	err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
+		&models.StepSourceModel{Git: "https://github.com/example/hello-step.git"}, t.TempDir(), log, true)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "offline")
+}
+
+func TestActivateStepSourceWithAPI_MissingSourceGitFails(t *testing.T) {
+	log := apiTestLogger{t}
+	client := steplibrary.New(log, "http://unused.invalid")
+
+	t.Run("nil source", func(t *testing.T) {
+		err := activateStepSourceWithAPI(client, "hello-step", "2.0.0", nil, t.TempDir(), log, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "source git")
+	})
+
+	t.Run("empty git URL", func(t *testing.T) {
+		err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
+			&models.StepSourceModel{Git: ""}, t.TempDir(), log, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "source git")
+	})
+}
+
+// When the inventory publishes no download locations, source activation fails
+// with a clear error rather than silently doing nothing.
+func TestActivateStepSourceWithAPI_NoDownloadLocationFails(t *testing.T) {
+	root := t.TempDir()
+	// meta.json with no download_locations; that's all StepSourceDownloadLocations reads.
+	writeInventoryJSON(t, root, steplibindex.MetaPath(), steplibindex.Meta{
+		FormatVersion: steplibindex.FormatVersion,
+	})
+	srv := httptest.NewServer(http.FileServer(http.Dir(root)))
+	t.Cleanup(srv.Close)
+
+	log := apiTestLogger{t}
+	client := steplibrary.New(log, srv.URL)
+
+	err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
+		&models.StepSourceModel{Git: "https://github.com/example/hello-step.git"}, t.TempDir(), log, false)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no download location")
+}

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/bitrise-io/stepman/activator/steplib"
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/steplibrary"
@@ -49,7 +50,7 @@ func ActivateSteplibRefStep(
 	}
 
 	// ActivateStep dispatches to the v2 or legacy codepath.
-	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, isOfflineMode, libraryAPI)
+	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, isOfflineMode, libraryAPI, httpfetch.NewClient(log))
 	activationResult.StepInfo = resolvedStep.StepInfo
 	activationResult.ExecutablePath = resolvedStep.ExecPath
 	if resolvedStep.ExecPath != "" {

--- a/toolkits/golang_test.go
+++ b/toolkits/golang_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/stepman/activator/steplib"
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/stretchr/testify/require"
@@ -226,7 +227,7 @@ func Benchmark_goBuildStep(b *testing.B) {
 		IDorURI:       "xcode-test",
 		Version:       "5.1.1",
 	}
-	_, err = steplib.ActivateStep(id, stepDir, "", logger, false, nil)
+	_, err = steplib.ActivateStep(id, stepDir, "", logger, false, nil, httpfetch.NewClient(logger))
 	require.NoError(b, err)
 
 	packageName := "github.com/bitrise-steplib/steps-xcode-test"


### PR DESCRIPTION
Steplib branching: `activateStepSourceWithAPI` had a bug which caused it to never be able to activate a step on this branch.

This had no explicit tests (certainly not unit test), so while there fixing the bug, I expanded tests.

- File `activate_test.go` checks v2 side to not have to refactor v1, and its aim is to only test the selection logic branching.
- Expanded on `activate_executable_test.go` test, with the aim of testing the executable activation specifically
- File `source.go` got its own tests in `source_test.go` which only targets v2 (API) source activations.