### PR TITLE
[STEP-2421] Report the StepLib inventory source in ActivatedStep

### DIFF
--- a/_tests/activation/harness_test.go
+++ b/_tests/activation/harness_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/bitrise-io/stepman/activator"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/stepman"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 const bitriseSteplibURL = "https://github.com/bitrise-io/bitrise-steplib.git"
@@ -98,12 +98,14 @@ func activate(t *testing.T, v variant, id stepid.CanonicalID, offline, didStepLi
 
 	// Asserted here so every case below covers it, including the failing ones:
 	// the inventory source is set before any early return, so a failed activation
-	// stays attributable to the path that served it.
-	wantInventorySource := activator.ActivationInventorySourceGitClone
+	// stays attributable to the path that served it. assert, not require: callers
+	// pair two activations and log both afterwards, and FailNow here would cut off
+	// the side-by-side diagnostics this harness exists to print.
+	wantInventorySource := activator.ActivationInventorySourceSteplib
 	if v.useAPI {
 		wantInventorySource = activator.ActivationInventorySourceSteplibAPI
 	}
-	require.Equal(t, wantInventorySource, activated.ActivationInventorySource, "%s inventory source", v.name)
+	assert.Equal(t, wantInventorySource, activated.ActivationInventorySource, "%s inventory source", v.name)
 
 	return activationResult{activated: activated, err: err, logs: logger.entries, elapsed: elapsed}
 }

--- a/_tests/activation/harness_test.go
+++ b/_tests/activation/harness_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bitrise-io/stepman/activator"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/stepman"
+	"github.com/stretchr/testify/require"
 )
 
 const bitriseSteplibURL = "https://github.com/bitrise-io/bitrise-steplib.git"
@@ -93,7 +94,18 @@ func activate(t *testing.T, v variant, id stepid.CanonicalID, offline, didStepLi
 	logger := &capturingLogger{}
 	start := time.Now()
 	activated, err := activator.ActivateSteplibRefStep(logger, id, t.TempDir(), t.TempDir(), didStepLibUpdate, offline)
-	return activationResult{activated: activated, err: err, logs: logger.entries, elapsed: time.Since(start)}
+	elapsed := time.Since(start)
+
+	// Asserted here so every case below covers it, including the failing ones:
+	// the inventory source is set before any early return, so a failed activation
+	// stays attributable to the path that served it.
+	wantInventorySource := activator.ActivationInventorySourceGitClone
+	if v.useAPI {
+		wantInventorySource = activator.ActivationInventorySourceSteplibAPI
+	}
+	require.Equal(t, wantInventorySource, activated.ActivationInventorySource, "%s inventory source", v.name)
+
+	return activationResult{activated: activated, err: err, logs: logger.entries, elapsed: elapsed}
 }
 
 // logResult prints a case's verdict, key result fields, and raw captured logs.
@@ -105,8 +117,9 @@ func logResult(t *testing.T, header string, r activationResult) {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "\n──────── %s ────────\n", header)
-	fmt.Fprintf(&b, "verdict=%s  elapsed=%s  activationType=%q  executable=%t  didStepLibUpdate=%t\n",
-		verdict, r.elapsed.Round(time.Millisecond), r.activated.ActivationType, r.activated.ExecutablePath != "", r.activated.DidStepLibUpdate)
+	fmt.Fprintf(&b, "verdict=%s  elapsed=%s  activationType=%q  inventorySource=%q  executable=%t  didStepLibUpdate=%t\n",
+		verdict, r.elapsed.Round(time.Millisecond), r.activated.ActivationType, r.activated.ActivationInventorySource,
+		r.activated.ExecutablePath != "", r.activated.DidStepLibUpdate)
 	if r.err != nil {
 		fmt.Fprintf(&b, "error: %s\n", r.err)
 	}

--- a/activator/activate_ref_test.go
+++ b/activator/activate_ref_test.go
@@ -44,6 +44,7 @@ func TestActivatePathRefStep(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, ActivationTypePathRef, got.ActivationType)
+	require.Equal(t, ActivationInventorySourceNone, got.ActivationInventorySource)
 	require.Equal(t, filepath.Join(workDir, "current_step.yml"), got.StepYMLPath)
 	require.Equal(t, "path", got.StepInfo.Library)
 	require.Equal(t, absStepSrcDir, got.StepInfo.ID)
@@ -65,6 +66,7 @@ func TestActivateGitRefStep(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, ActivationTypeGitRef, got.ActivationType)
+	require.Equal(t, ActivationInventorySourceNone, got.ActivationInventorySource)
 	require.Equal(t, filepath.Join(workDir, "current_step.yml"), got.StepYMLPath)
 	require.Equal(t, "git", got.StepInfo.Library)
 	require.Equal(t, srcRepoDir, got.StepInfo.ID)

--- a/activator/git_ref.go
+++ b/activator/git_ref.go
@@ -21,7 +21,7 @@ func ActivateGitRefStep(
 ) (ActivatedStep, error) {
 	repo, err := git.New(activatedStepDir)
 	if err != nil {
-		return ActivatedStep{},err
+		return ActivatedStep{}, err
 	}
 
 	var cloneCmd *command.Model
@@ -39,26 +39,27 @@ even if the repository is open source!`)
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return ActivatedStep{},fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), cloneCmd.PrintableCommandArgs(), errors.New(out))
+			return ActivatedStep{}, fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), cloneCmd.PrintableCommandArgs(), errors.New(out))
 		}
-		return ActivatedStep{},err
+		return ActivatedStep{}, err
 	}
 
 	stepYMLPath := filepath.Join(workDir, "current_step.yml")
 	if err := command.CopyFile(filepath.Join(activatedStepDir, "step.yml"), stepYMLPath); err != nil {
-		return ActivatedStep{},err
+		return ActivatedStep{}, err
 	}
 
 	stepInfo, err := stepman.QueryStepInfoFromGitStepDir(activatedStepDir, id.IDorURI, id.Version)
 	if err != nil {
-		return ActivatedStep{},err
+		return ActivatedStep{}, err
 	}
 
 	return ActivatedStep{
-		StepInfo:         stepInfo,
-		StepYMLPath:      stepYMLPath,
-		DidStepLibUpdate: false,
-		ActivationType:   ActivationTypeGitRef,
-		ExecutablePath:   "",
+		StepInfo:                  stepInfo,
+		StepYMLPath:               stepYMLPath,
+		DidStepLibUpdate:          false,
+		ActivationType:            ActivationTypeGitRef,
+		ActivationInventorySource: ActivationInventorySourceNone,
+		ExecutablePath:            "",
 	}, nil
 }

--- a/activator/path_ref.go
+++ b/activator/path_ref.go
@@ -55,10 +55,11 @@ func ActivatePathRefStep(
 	}
 
 	return ActivatedStep{
-		StepInfo:         stepInfo,
-		StepYMLPath:      activatedStepYMLPath,
-		DidStepLibUpdate: false,
-		ActivationType:   ActivationTypePathRef,
-		ExecutablePath:   "",
+		StepInfo:                  stepInfo,
+		StepYMLPath:               activatedStepYMLPath,
+		DidStepLibUpdate:          false,
+		ActivationType:            ActivationTypePathRef,
+		ActivationInventorySource: ActivationInventorySourceNone,
+		ExecutablePath:            "",
 	}, nil
 }

--- a/activator/result.go
+++ b/activator/result.go
@@ -42,8 +42,9 @@ type ActivationInventorySource string
 const (
 	// ActivationInventorySourceNone means the step was not activated from a StepLib (git or path ref).
 	ActivationInventorySourceNone ActivationInventorySource = ""
-	// ActivationInventorySourceSteplibAPI means the metadata came from the StepLib API, with no git clone.
+	// ActivationInventorySourceSteplibAPI means the metadata came from the StepLib API.
 	ActivationInventorySourceSteplibAPI ActivationInventorySource = "steplib_api"
-	// ActivationInventorySourceGitClone means the metadata came from the locally cloned StepLib and its spec.json.
-	ActivationInventorySourceGitClone ActivationInventorySource = "git_clone"
+	// ActivationInventorySourceSteplib means the metadata came from the locally set up StepLib
+	// and its generated spec.json.
+	ActivationInventorySourceSteplib ActivationInventorySource = "steplib"
 )

--- a/activator/result.go
+++ b/activator/result.go
@@ -9,6 +9,10 @@ type ActivatedStep struct {
 
 	ActivationType ActivationType
 
+	// ActivationInventorySource is the StepLib inventory that served the step metadata.
+	// It is ActivationInventorySourceNone for git and path references.
+	ActivationInventorySource ActivationInventorySource
+
 	// ExecutablePath is a local path to the main entrypoint of the step, ready for execution.
 	// This can be an empty string if:
 	// - step was activated from a git reference (we checked out the source dir directly)
@@ -30,4 +34,16 @@ const (
 	ActivationTypeSteplibSource     ActivationType = "steplib_source"
 	ActivationTypePathRef           ActivationType = "path"
 	ActivationTypeGitRef            ActivationType = "git"
+)
+
+// ActivationInventorySource identifies which StepLib inventory served the step metadata.
+type ActivationInventorySource string
+
+const (
+	// ActivationInventorySourceNone means the step was not activated from a StepLib (git or path ref).
+	ActivationInventorySourceNone ActivationInventorySource = ""
+	// ActivationInventorySourceSteplibAPI means the metadata came from the StepLib API, with no git clone.
+	ActivationInventorySourceSteplibAPI ActivationInventorySource = "steplib_api"
+	// ActivationInventorySourceGitClone means the metadata came from the locally cloned StepLib and its spec.json.
+	ActivationInventorySourceGitClone ActivationInventorySource = "git_clone"
 )

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -34,8 +34,6 @@ func ActivateSteplibRefStep(
 		DidStepLibUpdate: false,
 	}
 
-	// Set before any return: the caller keeps the partial result on error, so a
-	// failed activation stays attributable to the inventory that served it.
 	var libraryAPI *steplibrary.Client
 	if shouldUseSteplibAPI(id.SteplibSource) {
 		libraryAPI = steplibrary.New(log, bitriseSteplibAPIURL)

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -34,9 +34,14 @@ func ActivateSteplibRefStep(
 		DidStepLibUpdate: false,
 	}
 
+	// Set before any return: the caller keeps the partial result on error, so a
+	// failed activation stays attributable to the inventory that served it.
 	var libraryAPI *steplibrary.Client
 	if shouldUseSteplibAPI(id.SteplibSource) {
 		libraryAPI = steplibrary.New(log, bitriseSteplibAPIURL)
+		activationResult.ActivationInventorySource = ActivationInventorySourceSteplibAPI
+	} else {
+		activationResult.ActivationInventorySource = ActivationInventorySourceGitClone
 	}
 
 	if libraryAPI == nil {

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -37,12 +37,14 @@ func ActivateSteplibRefStep(
 	var libraryAPI *steplibrary.Client
 	if shouldUseSteplibAPI(id.SteplibSource) {
 		libraryAPI = steplibrary.New(log, bitriseSteplibAPIURL)
-		activationResult.ActivationInventorySource = ActivationInventorySourceSteplibAPI
-	} else {
-		activationResult.ActivationInventorySource = ActivationInventorySourceGitClone
 	}
 
+	// The inventory source is set here, on the same branch that dispatches, and before
+	// any return: the caller keeps the partial result on error, so a failed activation
+	// is still attributable to the inventory that served it.
 	if libraryAPI == nil {
+		activationResult.ActivationInventorySource = ActivationInventorySourceSteplib
+
 		// Old stepman preparation codepath
 		stepInfo, didUpdate, err := prepareStepLibForActivation(log, id, didStepLibUpdateInWorkflow, isOfflineMode)
 		activationResult.StepInfo = stepInfo
@@ -50,6 +52,8 @@ func ActivateSteplibRefStep(
 		if err != nil {
 			return activationResult, err
 		}
+	} else {
+		activationResult.ActivationInventorySource = ActivationInventorySourceSteplibAPI
 	}
 
 	// ActivateStep dispatches to the v2 or legacy codepath.

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -153,6 +153,8 @@ func TestActivateSteplibRefStep(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BITRISE_STEPLIB_API_ENABLE", "false")
+
 			activatedStepDir := t.TempDir()
 			workDir := t.TempDir()
 
@@ -168,6 +170,7 @@ func TestActivateSteplibRefStep(t *testing.T) {
 			require.Equal(t, tt.id.IDorURI, got.StepInfo.ID)
 			require.Equal(t, tt.wantVersion, got.StepInfo.Version)
 			require.Equal(t, ActivationTypeSteplibSource, got.ActivationType)
+			require.Equal(t, ActivationInventorySourceGitClone, got.ActivationInventorySource)
 			require.Empty(t, got.ExecutablePath)
 			require.False(t, got.DidStepLibUpdate)
 
@@ -236,6 +239,7 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 					"resolved version %q should start with %q", got.StepInfo.Version, tt.wantPrefix)
 			}
 			require.Equal(t, ActivationTypeSteplibSource, got.ActivationType)
+			require.Equal(t, ActivationInventorySourceSteplibAPI, got.ActivationInventorySource)
 			require.Empty(t, got.ExecutablePath)
 			require.False(t, got.DidStepLibUpdate)
 

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -170,7 +170,7 @@ func TestActivateSteplibRefStep(t *testing.T) {
 			require.Equal(t, tt.id.IDorURI, got.StepInfo.ID)
 			require.Equal(t, tt.wantVersion, got.StepInfo.Version)
 			require.Equal(t, ActivationTypeSteplibSource, got.ActivationType)
-			require.Equal(t, ActivationInventorySourceGitClone, got.ActivationInventorySource)
+			require.Equal(t, ActivationInventorySourceSteplib, got.ActivationInventorySource)
 			require.Empty(t, got.ExecutablePath)
 			require.False(t, got.DidStepLibUpdate)
 


### PR DESCRIPTION
## Why

`ActivateSteplibRefStep` decides between the StepLib API and the legacy git-clone path (`shouldUseSteplibAPI`) and then throws that fact away: both branches return an identical `ActivatedStep`. The Bitrise CLI has no reference to `BITRISE_STEPLIB_API_ENABLE`, so it cannot infer the path itself — which makes every metric on its `cli_step_activation` event (duration, success rate) unattributable to a path. That attribution is what the gradual API rollout needs ([STEP-2421](https://bitrise.atlassian.net/browse/STEP-2421)).

## Next

Follow-ups from the STEP-2421 plan, each as its own PR: step source origin (`steplib_cache` / `zip` / `git`) with retry and fallback counts, and the precompiled outcome enum that distinguishes the four currently-silent fallbacks to source. The CLI-side telemetry property lands after a stepman release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STEP-2421]: https://bitrise.atlassian.net/browse/STEP-2421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ