### PR TITLE
Report the activation type on failed steplib activations

### DIFF
--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -32,6 +32,9 @@ func ActivateSteplibRefStep(
 	activationResult := ActivatedStep{
 		StepYMLPath:      stepYMLPath,
 		DidStepLibUpdate: false,
+		// Set up front so the partial result kept on error still has a type; the
+		// dispatch below upgrades it on a successful precompiled download.
+		ActivationType: ActivationTypeSteplibSource,
 	}
 
 	var libraryAPI *steplibrary.Client

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -163,6 +163,10 @@ func TestActivateSteplibRefStep(t *testing.T) {
 			got, err := ActivateSteplibRefStep(logger, tt.id, activatedStepDir, workDir, true, false)
 			if tt.wantErr {
 				require.Error(t, err)
+				// The partial result kept on error is reported as telemetry, so it must
+				// still name the path that served it.
+				require.Equal(t, ActivationTypeSteplibSource, got.ActivationType)
+				require.Equal(t, ActivationInventorySourceSteplib, got.ActivationInventorySource)
 				return
 			}
 			require.NoError(t, err)
@@ -225,6 +229,9 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 			got, err := ActivateSteplibRefStep(TestLogger[*testing.T]{t}, tt.id, activatedStepDir, workDir, false, false)
 			if tt.wantErr {
 				require.Error(t, err)
+				// Same as the legacy case: a failed activation stays attributable.
+				require.Equal(t, ActivationTypeSteplibSource, got.ActivationType)
+				require.Equal(t, ActivationInventorySourceSteplibAPI, got.ActivationInventorySource)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
Follow-up to #414, from review of [bitrise#1297].

`ActivationType` was only assigned after the `steplib.ActivateStep` dispatch, but the legacy branch returns before it when `prepareStepLibForActivation` fails — and the caller keeps the partial result on error and reports it as telemetry.

So legacy activation failures reported `activation_type=""` while API failures reported a real type, since the API branch always reaches the dispatch. It is sent unconditionally, so that is an empty string in the warehouse, not an absent key: any dashboard grouping failures by activation type undercounts legacy failures to zero — an asymmetry in exactly the comparison #414 exists to enable.

Fix: set it to the source type up front. The dispatch still upgrades it on a successful precompiled download; a failure before that point never produced an executable, so source is accurate rather than a placeholder.

## Tests

Both tests returned right after `require.Error`, so nothing covered the partial result. They now assert it, and the assertions have teeth:

- revert the fix → all three legacy error cases fail with `expected: "steplib_source"`, `actual: ""`
- same revert → the API error case still passes, reproducing the asymmetry itself

`go build ./...`, `go vet ./...`, `gofmt -l activator/`, and the full `go test ./...` suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[bitrise#1297]: https://github.com/bitrise-io/bitrise/pull/1297
