### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every file in the repo is owned by Mobile Pillar, so all PRs request their review.
+* @bitrise-io/mobile-pillar-members


### PR DESCRIPTION
### Changes
Add `.github/CODEOWNERS` assigning every file to `@bitrise-io/mobile-pillar-members`, so all PRs automatically request their review.

### Context
Part of rolling out codeowner-based review assignment across Mobile Pillar repositories.
