### PR TITLE
Repurpose precompiled step feature flags

### DIFF
--- a/_tests/activation/harness_test.go
+++ b/_tests/activation/harness_test.go
@@ -86,9 +86,9 @@ func activate(t *testing.T, v variant, id stepid.CanonicalID, offline, didStepLi
 		t.Setenv("BITRISE_STEPLIB_API_ENABLE", "false")
 	}
 	if v.precompiled {
-		t.Setenv("BITRISE_EXPERIMENT_PRECOMPILED_STEPS", "true")
+		t.Setenv("BITRISE_STEPLIB_USE_BINARY", "true")
 	} else {
-		t.Setenv("BITRISE_EXPERIMENT_PRECOMPILED_STEPS", "false")
+		t.Setenv("BITRISE_STEPLIB_USE_BINARY", "false")
 	}
 
 	logger := &capturingLogger{}

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -20,8 +20,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const precompiledStepsEnv = "BITRISE_EXPERIMENT_PRECOMPILED_STEPS"
-const precompiledStepsStorageURLsEnv = "BITRISE_PRECOMPILED_STEPS_STORAGE_URLS"
+const precompiledStepsEnv = "BITRISE_STEPLIB_USE_BINARY"
+const precompiledStepsStorageURLsEnv = "BITRISE_STEPLIB_STORAGE_URLS"
 
 var precompiledStepsDefaultStorageURLs = []string{
 	"https://steplib.bitrise.io",
@@ -91,7 +91,8 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 }
 
 func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.CanonicalID, destination string, fetcher httpfetch.Client) (string, error) {
-	if (os.Getenv(precompiledStepsEnv) == "true" || os.Getenv(precompiledStepsEnv) == "1") && step.Executables != nil {
+	precompiledDisabled := os.Getenv(precompiledStepsEnv) == "false" || os.Getenv(precompiledStepsEnv) == "0"
+	if !precompiledDisabled && step.Executables != nil {
 		platform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 		executableForPlatform, ok := (*step.Executables)[platform]
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {

--- a/activator/steplib/activate_executable_test.go
+++ b/activator/steplib/activate_executable_test.go
@@ -129,7 +129,7 @@ func TestActivateStepExecutable(t *testing.T) {
 		require.Equal(t, hash, fake.calledHash)
 	})
 
-	t.Run("BITRISE_PRECOMPILED_STEPS_STORAGE_URLS override wins", func(t *testing.T) {
+	t.Run("BITRISE_STEPLIB_STORAGE_URLS override wins", func(t *testing.T) {
 		t.Setenv(precompiledStepsStorageURLsEnv, "https://custom.example.com")
 		fake := newFakeExecutableFetcher(t)
 

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -217,7 +217,7 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("HOME", t.TempDir()) // fresh: the git cloned steplib is not set up
 			t.Setenv("BITRISE_STEPLIB_API_ENABLE", "true")
-			t.Setenv("BITRISE_EXPERIMENT_PRECOMPILED_STEPS", "false")
+			t.Setenv("BITRISE_STEPLIB_USE_BINARY", "false")
 
 			activatedStepDir := t.TempDir()
 			workDir := t.TempDir()


### PR DESCRIPTION
## Why

This feature has been rolled out to everyone in CI envs. It also make sense to enable in local envs. Let's flip the default to enabled.

## What

Originally, I wanted to remove the env var completely, but too many tests depend on this to force a specific behavior in tests:

- `activator/steplib/activate_test.go`
  - `TestActivateStep_ResolvesExactVersion` (forces `false` to test source-only activation)
  - `TestActivateStep_ResolvesMajorLock` (forces `false`)
  - `TestActivateStep_NonexistentVersionFails` (forces `false`)
  - `TestActivateStep_NoExecutable_ActivatesSource` (forces `true` to exercise the precompiled branch)
  - `TestActivateStep_ChoosesExecutable` (forces `true`)
  - `TestActivateStep_ExecutableDownloadFails_FallsBackToSource` (forces `true`)
- `activator/steplib_ref_test.go`
  - `TestActivateSteplibRefStep_APIEnabled` (forces `false` against the real production steplib, since there's no other way to guarantee source activation regardless of what's published)
- `_tests/activation/harness_test.go` (integration-tagged)
  - The whole `v1Source`/`v1Precompiled`/`v2Source`/`v2Precompiled` comparison harness toggles the flag to force each path side by side against real production data

So instead I repurposed the two env vars, keeping them as an escape hatch:

- `BITRISE_EXPERIMENT_PRECOMPILED_STEPS` → `BITRISE_STEPLIB_USE_BINARY`, now enabled by default
- `BITRISE_PRECOMPILED_STEPS_STORAGE_URLS` → `BITRISE_STEPLIB_STORAGE_URLS`
