### PR TITLE
STEP-2522: enable the StepLib API by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,24 @@ Stepman is the tool behind Bitrise steps: it allows submitting new steps to the 
 
 Key entry point is `main.go` → `cli.Run()` which sets up the CLI application with commands defined in `cli/commands.go`.
 
+### Step activation paths
+
+`activator/` has two ways to resolve and download a step:
+
+- **Legacy git-clone path**: clones the steplib repo locally and reads spec.json. This is the codepath used for custom/self-hosted steplibs.
+- **StepLib V2 API path** (default): fetches static JSON over HTTPS (no git clone), implemented in `activator/steplib/` (`activate.go`, `source.go`) and `steplibrary/`. Used for the canonical Bitrise steplib source unless `BITRISE_STEPLIB_USE_API` is set to `false`/`0` — see `shouldUseSteplibAPI` and the `bitriseSteplibAPIURL` / `useSteplibAPIEnv` constants in `activator/steplib_ref.go`. The API base URL is passed to `steplibrary.New`. Offline mode is not supported on this path and fails explicitly: an offline run against the canonical steplib has to opt out via the env var to fall back to the git-clone path.
+
+Precompiled step executables (skip building from source) are on by default and disabled by setting `BITRISE_STEPLIB_USE_BINARY` to `false`/`0`, with storage URLs overridable via `BITRISE_STEPLIB_STORAGE_URLS` (see `activator/steplib/activate.go`).
+
 ## Development Commands
 
 This is a standard Go project, use standard Go tooling for development tasks.
 
 `bitrise.yml` contains the tasks and workflows that run in CI
+
+## Releasing
+
+Pushing a `vX.Y.Z` git tag on `master` triggers the release: the Tooling Control Center Bitrise project runs the `binary-tool-release` workflow (Goreleaser), builds binaries, and creates a GitHub release. Consumers (e.g. the Bitrise CLI) then bump the module version. Note: `v0.22.0` is a poisoned tag serving a stale API — never depend on it; use `v0.23.0+`.
 
 ## Coding preferences
 

--- a/_tests/activation/harness_test.go
+++ b/_tests/activation/harness_test.go
@@ -81,9 +81,9 @@ func activate(t *testing.T, v variant, id stepid.CanonicalID, offline, didStepLi
 	// The V2 API path targets the production inventory; there is no longer an
 	// override to redirect it at a dev/test inventory.
 	if v.useAPI {
-		t.Setenv("BITRISE_STEPLIB_API_ENABLE", "true")
+		t.Setenv("BITRISE_STEPLIB_USE_API", "true")
 	} else {
-		t.Setenv("BITRISE_STEPLIB_API_ENABLE", "false")
+		t.Setenv("BITRISE_STEPLIB_USE_API", "false")
 	}
 	if v.precompiled {
 		t.Setenv("BITRISE_STEPLIB_USE_BINARY", "true")

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -15,7 +15,7 @@ import (
 // without cloning a git steplib.
 func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool, fetcher httpfetch.Client) error {
 	if isOfflineMode {
-		return errors.New("offline mode is not supported with Steplib API")
+		return errors.New("offline mode is not supported with the Steplib API, set BITRISE_STEPLIB_USE_API=false to activate steps from the local StepLib cache")
 	}
 
 	if source == nil || source.Git == "" {

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -16,7 +16,7 @@ import (
 const (
 	bitriseSteplibURL    = "https://github.com/bitrise-io/bitrise-steplib.git"
 	bitriseSteplibAPIURL = "https://steplib.bitrise.io/api"
-	enableSteplibAPIEnv  = "BITRISE_STEPLIB_API_ENABLE"
+	useSteplibAPIEnv     = "BITRISE_STEPLIB_USE_API"
 )
 
 func ActivateSteplibRefStep(
@@ -73,8 +73,12 @@ func ActivateSteplibRefStep(
 }
 
 func shouldUseSteplibAPI(steplibURI string) bool {
-	enableAPI := os.Getenv(enableSteplibAPIEnv) == "true" || os.Getenv(enableSteplibAPIEnv) == "1"
-	return enableAPI && steplibURI == bitriseSteplibURL
+	if steplibURI != bitriseSteplibURL {
+		return false
+	}
+
+	apiDisabled := os.Getenv(useSteplibAPIEnv) == "false" || os.Getenv(useSteplibAPIEnv) == "0"
+	return !apiDisabled
 }
 
 func prepareStepLibForActivation(

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -153,7 +153,7 @@ func TestActivateSteplibRefStep(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("BITRISE_STEPLIB_API_ENABLE", "false")
+			t.Setenv("BITRISE_STEPLIB_USE_API", "false")
 
 			activatedStepDir := t.TempDir()
 			workDir := t.TempDir()
@@ -216,7 +216,7 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("HOME", t.TempDir()) // fresh: the git cloned steplib is not set up
-			t.Setenv("BITRISE_STEPLIB_API_ENABLE", "true")
+			t.Setenv("BITRISE_STEPLIB_USE_API", "true")
 			t.Setenv("BITRISE_STEPLIB_USE_BINARY", "false")
 
 			activatedStepDir := t.TempDir()
@@ -251,6 +251,39 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 			// API route must not have set up the git cloned steplib.
 			_, found := stepman.ReadRoute(steplib)
 			require.False(t, found, "v2 activation must not set up the v1 steplib")
+		})
+	}
+}
+
+func TestShouldUseSteplibAPI(t *testing.T) {
+	const customSteplib = "https://github.com/acme/custom-steplib.git"
+
+	tests := []struct {
+		name     string
+		envValue string // empty means the env var is unset
+		steplib  string
+		want     bool
+	}{
+		{name: "Unset env enables the API for the Bitrise steplib", steplib: bitriseSteplibURL, want: true},
+		{name: "Explicit true keeps the API enabled", envValue: "true", steplib: bitriseSteplibURL, want: true},
+		{name: "Explicit 1 keeps the API enabled", envValue: "1", steplib: bitriseSteplibURL, want: true},
+		{name: "Unrecognized value keeps the API enabled", envValue: "maybe", steplib: bitriseSteplibURL, want: true},
+		{name: "false opts out", envValue: "false", steplib: bitriseSteplibURL, want: false},
+		{name: "0 opts out", envValue: "0", steplib: bitriseSteplibURL, want: false},
+		{name: "Custom steplib never uses the API", steplib: customSteplib, want: false},
+		{name: "Custom steplib is not enabled by an explicit true", envValue: "true", steplib: customSteplib, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv registers the restore even when the value is then removed,
+			// so an unset case cannot leak into the rest of the suite.
+			t.Setenv(useSteplibAPIEnv, tt.envValue)
+			if tt.envValue == "" {
+				require.NoError(t, os.Unsetenv(useSteplibAPIEnv))
+			}
+
+			require.Equal(t, tt.want, shouldUseSteplibAPI(tt.steplib))
 		})
 	}
 }


### PR DESCRIPTION
[STEP-2522](https://bitrise.atlassian.net/browse/STEP-2522)

Turn `BITRISE_STEPLIB_API_ENABLE` from an opt-in gate into an opt-out one, renamed to `BITRISE_STEPLIB_USE_API`. This matches the naming and the "default on, `false`/`0` disables" convention #417 introduced for `BITRISE_STEPLIB_USE_BINARY`.

Activation of the canonical Bitrise steplib now goes through the V2 API unless the env var is explicitly disabled, so the API path works on local dev machines without a Datadog flag setting the env var, and that flag can be retired.

### Offline mode

Deliberately not carved out. The API path has no local inventory, so an offline run against the canonical steplib now fails with an explicit error naming the opt-out, rather than silently falling back to the git-clone path:

```
offline mode is not supported with the Steplib API, set BITRISE_STEPLIB_USE_API=false
to activate steps from the local StepLib cache
```

### Note for reviewers

The rename means that if anything in the build environment currently sets the **old** name to `false` as a kill switch, that switch goes inert on this version. Setting the old name to `true` is harmless — that is the default now.

### Testing

- `go build ./...`, `go vet ./...`, `golangci-lint run --config .golangci.yml` — clean
- `go test ./activator/...` — pass, including a new `TestShouldUseSteplibAPI` table test covering default-on, both opt-out values, and custom steplibs
- `_tests/activation` harness compiles under `-tags integration` (not run here — network suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STEP-2522]: https://bitrise.atlassian.net/browse/STEP-2522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ