### PR TITLE
STEP-2520: build step activation through a constructor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,14 @@ Key entry point is `main.go` → `cli.Run()` which sets up the CLI application w
 
 ### Step activation paths
 
-`activator/` has two ways to resolve and download a step:
+Activation goes through `activator.Activator`, built once per run with `activator.New` (see `activator/activator.go`), so every step of a run shares one HTTP client. `Options` carries the config that used to be read from env vars deep in the call stack: stepman reads no environment of its own, and the caller — the Bitrise CLI — resolves those settings and passes them in. `activator/` has two ways to resolve and download a step:
 
 - **Legacy git-clone path**: clones the steplib repo locally and reads spec.json. This is the codepath used for custom/self-hosted steplibs.
-- **StepLib V2 API path** (default): fetches static JSON over HTTPS (no git clone), implemented in `activator/steplib/` (`activate.go`, `source.go`) and `steplibrary/`. Used for the canonical Bitrise steplib source unless `BITRISE_STEPLIB_USE_API` is set to `false`/`0` — see `shouldUseSteplibAPI` and the `bitriseSteplibAPIURL` / `useSteplibAPIEnv` constants in `activator/steplib_ref.go`. The API base URL is passed to `steplibrary.New`. Offline mode is not supported on this path and fails explicitly: an offline run against the canonical steplib has to opt out via the env var to fall back to the git-clone path.
+- **StepLib V2 API path** (default): fetches static JSON over HTTPS (no git clone), implemented in `activator/steplib/` (`activate.go`, `source.go`) and `steplibrary/`. Used for the canonical Bitrise steplib source when `Options.UseSteplibAPI` is set — see `Activator.useSteplibAPIFor` in `activator/activator.go`. The API base URL and the shared HTTP client are passed to `steplibrary.New`. Offline mode is not supported on this path and fails explicitly: an offline run against the canonical steplib has to opt out via `Options.UseSteplibAPI` to fall back to the git-clone path.
 
-Precompiled step executables (skip building from source) are on by default and disabled by setting `BITRISE_STEPLIB_USE_BINARY` to `false`/`0`, with storage URLs overridable via `BITRISE_STEPLIB_STORAGE_URLS` (see `activator/steplib/activate.go`).
+Precompiled step executables (skip building from source) are controlled by `Options.UsePrecompiled`, with the storage URLs to try in `Options.PrecompiledStorageURLs` (defaults in `activator/steplib/activate.go`).
+
+The Bitrise CLI maps `BITRISE_STEPLIB_USE_API`, `BITRISE_STEPLIB_USE_BINARY` and `BITRISE_STEPLIB_STORAGE_URLS` onto those options in `cli/step_activator.go`; both feature flags default to on there and are disabled with `false`/`0`.
 
 ## Development Commands
 

--- a/_tests/activation/harness_test.go
+++ b/_tests/activation/harness_test.go
@@ -80,20 +80,18 @@ func activate(t *testing.T, v variant, id stepid.CanonicalID, offline, didStepLi
 
 	// The V2 API path targets the production inventory; there is no longer an
 	// override to redirect it at a dev/test inventory.
-	if v.useAPI {
-		t.Setenv("BITRISE_STEPLIB_USE_API", "true")
-	} else {
-		t.Setenv("BITRISE_STEPLIB_USE_API", "false")
-	}
-	if v.precompiled {
-		t.Setenv("BITRISE_STEPLIB_USE_BINARY", "true")
-	} else {
-		t.Setenv("BITRISE_STEPLIB_USE_BINARY", "false")
+	//nolint:exhaustruct // the API URL and storage URLs fall back to their defaults
+	opts := activator.Options{
+		UseSteplibAPI:  v.useAPI,
+		UsePrecompiled: v.precompiled,
+		IsOfflineMode:  offline,
 	}
 
 	logger := &capturingLogger{}
 	start := time.Now()
-	activated, err := activator.ActivateSteplibRefStep(logger, id, t.TempDir(), t.TempDir(), didStepLibUpdate, offline)
+	// Built per activation here on purpose: each case is an independent
+	// measurement, so they must not share a warmed connection pool.
+	activated, err := activator.New(logger, opts).ActivateSteplibRefStep(id, t.TempDir(), t.TempDir(), didStepLibUpdate)
 	elapsed := time.Since(start)
 
 	// Asserted here so every case below covers it, including the failing ones:

--- a/_tests/activation/harness_test.go
+++ b/_tests/activation/harness_test.go
@@ -82,9 +82,9 @@ func activate(t *testing.T, v variant, id stepid.CanonicalID, offline, didStepLi
 	// override to redirect it at a dev/test inventory.
 	//nolint:exhaustruct // the API URL and storage URLs fall back to their defaults
 	opts := activator.Options{
-		UseSteplibAPI:  v.useAPI,
-		UsePrecompiled: v.precompiled,
-		IsOfflineMode:  offline,
+		DisableSteplibAPI:  !v.useAPI,
+		DisablePrecompiled: !v.precompiled,
+		IsOfflineMode:      offline,
 	}
 
 	logger := &capturingLogger{}

--- a/activator/activator.go
+++ b/activator/activator.go
@@ -1,9 +1,6 @@
 package activator
 
 import (
-	"os"
-	"strings"
-
 	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/steplibrary"
@@ -13,14 +10,16 @@ import (
 const (
 	bitriseSteplibURL    = "https://github.com/bitrise-io/bitrise-steplib.git"
 	bitriseSteplibAPIURL = "https://steplib.bitrise.io/api"
-
-	useSteplibAPIEnv               = "BITRISE_STEPLIB_USE_API"
-	precompiledStepsEnv            = "BITRISE_STEPLIB_USE_BINARY"
-	precompiledStepsStorageURLsEnv = "BITRISE_STEPLIB_STORAGE_URLS"
 )
 
 // Options is the configuration of an Activator. It is resolved once, when the
 // Activator is built, rather than re-read on every step activation.
+//
+// Every field is supplied by the caller: stepman reads no configuration of its
+// own, so whichever process owns these settings also owns how they are
+// discovered. The Bitrise CLI, for one, maps environment variables onto them.
+// The zero value activates every step from source, through a git-cloned
+// StepLib.
 type Options struct {
 	// UseSteplibAPI activates steps of the canonical Bitrise StepLib over the
 	// StepLib V2 API instead of a local git clone. It has no effect on
@@ -43,34 +42,6 @@ type Options struct {
 	// already in the local StepLib cache. It is not supported together with
 	// UseSteplibAPI, which has no local inventory to read from.
 	IsOfflineMode bool
-}
-
-// OptionsFromEnv resolves the Options that stepman reads from the environment.
-// Both feature flags default to on and are disabled by setting them to "false"
-// or "0". Callers that configure the activator themselves do not need this.
-func OptionsFromEnv() Options {
-	return Options{
-		UseSteplibAPI:          !isEnvDisabled(useSteplibAPIEnv),
-		SteplibAPIURL:          "",
-		UsePrecompiled:         !isEnvDisabled(precompiledStepsEnv),
-		PrecompiledStorageURLs: splitStorageURLs(os.Getenv(precompiledStepsStorageURLsEnv)),
-		IsOfflineMode:          false,
-	}
-}
-
-// isEnvDisabled reports whether an opt-out flag is switched off. Any other
-// value, including an unset variable, leaves the feature enabled.
-func isEnvDisabled(key string) bool {
-	return os.Getenv(key) == "false" || os.Getenv(key) == "0"
-}
-
-// splitStorageURLs parses the comma-separated storage URL override. An empty
-// override yields nil, which withDefaults resolves to the built-in list.
-func splitStorageURLs(override string) []string {
-	if override == "" {
-		return nil
-	}
-	return strings.Split(override, ",")
 }
 
 // withDefaults fills in the values that Options leaves optional, so the rest of

--- a/activator/activator.go
+++ b/activator/activator.go
@@ -1,0 +1,122 @@
+package activator
+
+import (
+	"os"
+	"strings"
+
+	"github.com/bitrise-io/stepman/activator/steplib"
+	"github.com/bitrise-io/stepman/internal/httpfetch"
+	"github.com/bitrise-io/stepman/steplibrary"
+	"github.com/bitrise-io/stepman/stepman"
+)
+
+const (
+	bitriseSteplibURL    = "https://github.com/bitrise-io/bitrise-steplib.git"
+	bitriseSteplibAPIURL = "https://steplib.bitrise.io/api"
+
+	useSteplibAPIEnv               = "BITRISE_STEPLIB_USE_API"
+	precompiledStepsEnv            = "BITRISE_STEPLIB_USE_BINARY"
+	precompiledStepsStorageURLsEnv = "BITRISE_STEPLIB_STORAGE_URLS"
+)
+
+// Options is the configuration of an Activator. It is resolved once, when the
+// Activator is built, rather than re-read on every step activation.
+type Options struct {
+	// UseSteplibAPI activates steps of the canonical Bitrise StepLib over the
+	// StepLib V2 API instead of a local git clone. It has no effect on
+	// custom/self-hosted StepLibs, which always use the git-clone path.
+	UseSteplibAPI bool
+
+	// SteplibAPIURL is the base URL of the StepLib V2 API. Empty means the
+	// canonical Bitrise inventory.
+	SteplibAPIURL string
+
+	// UsePrecompiled allows activating a step from a prebuilt executable
+	// instead of downloading and building its source.
+	UsePrecompiled bool
+
+	// PrecompiledStorageURLs are the base URLs tried in order for precompiled
+	// executables. Empty means steplib.DefaultPrecompiledStorageURLs.
+	PrecompiledStorageURLs []string
+
+	// IsOfflineMode forbids network access, restricting activation to what is
+	// already in the local StepLib cache. It is not supported together with
+	// UseSteplibAPI, which has no local inventory to read from.
+	IsOfflineMode bool
+}
+
+// OptionsFromEnv resolves the Options that stepman reads from the environment.
+// Both feature flags default to on and are disabled by setting them to "false"
+// or "0". Callers that configure the activator themselves do not need this.
+func OptionsFromEnv() Options {
+	return Options{
+		UseSteplibAPI:          !isEnvDisabled(useSteplibAPIEnv),
+		SteplibAPIURL:          "",
+		UsePrecompiled:         !isEnvDisabled(precompiledStepsEnv),
+		PrecompiledStorageURLs: splitStorageURLs(os.Getenv(precompiledStepsStorageURLsEnv)),
+		IsOfflineMode:          false,
+	}
+}
+
+// isEnvDisabled reports whether an opt-out flag is switched off. Any other
+// value, including an unset variable, leaves the feature enabled.
+func isEnvDisabled(key string) bool {
+	return os.Getenv(key) == "false" || os.Getenv(key) == "0"
+}
+
+// splitStorageURLs parses the comma-separated storage URL override. An empty
+// override yields nil, which withDefaults resolves to the built-in list.
+func splitStorageURLs(override string) []string {
+	if override == "" {
+		return nil
+	}
+	return strings.Split(override, ",")
+}
+
+// withDefaults fills in the values that Options leaves optional, so the rest of
+// the package can rely on them being set.
+func withDefaults(opts Options) Options {
+	if opts.SteplibAPIURL == "" {
+		opts.SteplibAPIURL = bitriseSteplibAPIURL
+	}
+	if len(opts.PrecompiledStorageURLs) == 0 {
+		opts.PrecompiledStorageURLs = steplib.DefaultPrecompiledStorageURLs
+	}
+	return opts
+}
+
+// Activator activates steps. It owns the collaborators that are worth keeping
+// alive across activations — most importantly a single HTTP client, so that
+// every step in a run shares one connection pool — and is therefore meant to be
+// built once per workflow run and reused, not per step.
+type Activator struct {
+	log     stepman.Logger
+	opts    Options
+	fetcher httpfetch.Client
+
+	// library serves the StepLib V2 inventory. It is built even when
+	// UseSteplibAPI is off, because whether a given step may use it also
+	// depends on that step's StepLib source; see useSteplibAPIFor.
+	library *steplibrary.Client
+}
+
+// New builds an Activator. Reuse the returned value for every step of a run:
+// building one per step is what this constructor exists to avoid.
+func New(log stepman.Logger, opts Options) *Activator {
+	opts = withDefaults(opts)
+	fetcher := httpfetch.NewClient(log)
+
+	return &Activator{
+		log:     log,
+		opts:    opts,
+		fetcher: fetcher,
+		library: steplibrary.New(log, opts.SteplibAPIURL, fetcher),
+	}
+}
+
+// useSteplibAPIFor reports whether steplibURI's steps are served by the StepLib
+// V2 API. The API only hosts the canonical Bitrise StepLib, so custom StepLibs
+// stay on the git-clone path regardless of configuration.
+func (a *Activator) useSteplibAPIFor(steplibURI string) bool {
+	return a.opts.UseSteplibAPI && steplibURI == bitriseSteplibURL
+}

--- a/activator/activator.go
+++ b/activator/activator.go
@@ -1,7 +1,6 @@
 package activator
 
 import (
-	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
@@ -14,16 +13,22 @@ const (
 
 // Options is the configuration of an Activator. It is resolved once, when the
 // Activator is built, rather than re-read on every step activation.
+//
+// The flags are opt-outs, so the zero value is what production wants: the
+// StepLib V2 API and prebuilt executables both on.
 type Options struct {
-	UseSteplibAPI bool
+	// DisableSteplibAPI routes canonical Bitrise StepLib steps through a local
+	// git clone instead of the StepLib V2 API. Custom/self-hosted StepLibs use
+	// the git-clone path either way.
+	DisableSteplibAPI bool
 
 	// SteplibAPIURL is the base URL of the StepLib V2 API. Empty means the
 	// canonical Bitrise inventory.
 	SteplibAPIURL string
 
-	// UsePrecompiled allows activating a step from a prebuilt executable
-	// instead of downloading and building its source.
-	UsePrecompiled bool
+	// DisablePrecompiled builds every step from source, even where the library
+	// offers a prebuilt executable.
+	DisablePrecompiled bool
 
 	// PrecompiledStorageURLs are the base URLs tried in order for precompiled
 	// executables. Empty means steplib.DefaultPrecompiledStorageURLs.
@@ -31,18 +36,16 @@ type Options struct {
 
 	// IsOfflineMode forbids network access, restricting activation to what is
 	// already in the local StepLib cache. It is not supported together with
-	// UseSteplibAPI, which has no local inventory to read from.
+	// the StepLib V2 API, which has no local inventory to read from.
 	IsOfflineMode bool
 }
 
 // withDefaults fills in the values that Options leaves optional, so the rest of
-// the package can rely on them being set.
+// the package can rely on them being set. PrecompiledStorageURLs is not among
+// them: steplib owns that list and defaults it itself.
 func withDefaults(opts Options) Options {
 	if opts.SteplibAPIURL == "" {
 		opts.SteplibAPIURL = bitriseSteplibAPIURL
-	}
-	if len(opts.PrecompiledStorageURLs) == 0 {
-		opts.PrecompiledStorageURLs = steplib.DefaultPrecompiledStorageURLs
 	}
 	return opts
 }
@@ -78,5 +81,5 @@ func New(log stepman.Logger, opts Options) *Activator {
 // V2 API. The API only hosts the canonical Bitrise StepLib, so custom StepLibs
 // stay on the git-clone path regardless of configuration.
 func (a *Activator) useSteplibAPIFor(steplibURI string) bool {
-	return a.opts.UseSteplibAPI && steplibURI == bitriseSteplibURL
+	return !a.opts.DisableSteplibAPI && steplibURI == bitriseSteplibURL
 }

--- a/activator/activator.go
+++ b/activator/activator.go
@@ -14,16 +14,7 @@ const (
 
 // Options is the configuration of an Activator. It is resolved once, when the
 // Activator is built, rather than re-read on every step activation.
-//
-// Every field is supplied by the caller: stepman reads no configuration of its
-// own, so whichever process owns these settings also owns how they are
-// discovered. The Bitrise CLI, for one, maps environment variables onto them.
-// The zero value activates every step from source, through a git-cloned
-// StepLib.
 type Options struct {
-	// UseSteplibAPI activates steps of the canonical Bitrise StepLib over the
-	// StepLib V2 API instead of a local git clone. It has no effect on
-	// custom/self-hosted StepLibs, which always use the git-clone path.
 	UseSteplibAPI bool
 
 	// SteplibAPIURL is the base URL of the StepLib V2 API. Empty means the
@@ -56,19 +47,17 @@ func withDefaults(opts Options) Options {
 	return opts
 }
 
-// Activator activates steps. It owns the collaborators that are worth keeping
-// alive across activations — most importantly a single HTTP client, so that
-// every step in a run shares one connection pool — and is therefore meant to be
-// built once per workflow run and reused, not per step.
+// Activator activates steps.
 type Activator struct {
 	log     stepman.Logger
 	opts    Options
 	fetcher httpfetch.Client
 
-	// library serves the StepLib V2 inventory. It is built even when
-	// UseSteplibAPI is off, because whether a given step may use it also
-	// depends on that step's StepLib source; see useSteplibAPIFor.
-	library *steplibrary.Client
+	// library serves the StepLib V2 inventory. Always present, including when
+	// UseSteplibAPI is off: whether a given step may use it depends on that
+	// step's StepLib source too, so the choice is made per activation rather
+	// than here. See useSteplibAPIFor.
+	library steplibrary.Client
 }
 
 // New builds an Activator. Reuse the returned value for every step of a run:

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -51,11 +51,14 @@ type ResolvedStep struct {
 	StepInfo models.StepInfoModel
 }
 
-func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, opts Options, libraryAPI *steplibrary.Client, fetcher httpfetch.Client) (ResolvedStep, error) {
+// useSteplibAPI selects the inventory backend: the StepLib V2 API when set, a
+// git-cloned steplib otherwise. library serves the former and is unread when
+// useSteplibAPI is false.
+func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, opts Options, useSteplibAPI bool, library *steplibrary.Client, fetcher httpfetch.Client) (ResolvedStep, error) {
 	var stepInfo models.StepInfoModel
 	var resolveErr error
-	if libraryAPI != nil {
-		stepInfo, resolveErr = libraryAPI.FetchStepMetadata(context.Background(), id)
+	if useSteplibAPI {
+		stepInfo, resolveErr = library.FetchStepMetadata(context.Background(), id)
 	} else {
 		// Legacy path: resolve the step from the local steplib spec (resolving the
 		// version constraint to a concrete version). This repeats the resolution
@@ -70,7 +73,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	version := stepInfo.Version
 
 	// Place the step.yml at destinationStepYML once, up front.
-	if libraryAPI == nil {
+	if !useSteplibAPI {
 		if err := copyStepYML(id.SteplibSource, id.IDorURI, version, destinationStepYML); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("copy step.yml: %s", err)
 		}
@@ -86,9 +89,9 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	}
 
 	// Fall back to step source activation.
-	if libraryAPI != nil {
+	if useSteplibAPI {
 		// activate the source over the API, without git clone
-		if err := activateStepSourceWithAPI(libraryAPI, id.IDorURI, version, stepModel.Source, destination, log, opts.IsOfflineMode, fetcher); err != nil {
+		if err := activateStepSourceWithAPI(library, id.IDorURI, version, stepModel.Source, destination, log, opts.IsOfflineMode, fetcher); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -29,19 +29,29 @@ var DefaultPrecompiledStorageURLs = []string{
 
 // Options is the per-run configuration of step activation. It is passed in
 // rather than read from the environment here, so that a caller building an
-// activator once per run resolves the configuration once.
+// activator once per run resolves the configuration once. The zero value is
+// what production wants: prebuilt executables on, from the default storage.
 type Options struct {
-	// UsePrecompiled allows activating a step from a prebuilt executable
-	// instead of downloading and building its source.
-	UsePrecompiled bool
+	// DisablePrecompiled builds every step from source, even where the library
+	// offers a prebuilt executable.
+	DisablePrecompiled bool
 
 	// StorageURLs are the base URLs tried in order for precompiled
-	// executables. Required when UsePrecompiled is set.
+	// executables. Empty means DefaultPrecompiledStorageURLs.
 	StorageURLs []string
 
 	// IsOfflineMode forbids network access, restricting activation to what is
 	// already in the local StepLib cache.
 	IsOfflineMode bool
+}
+
+// storageURLs is the configured list, or the built-in one when unset, so a
+// caller using Options directly does not silently lose the precompiled path.
+func (o Options) storageURLs() []string {
+	if len(o.StorageURLs) == 0 {
+		return DefaultPrecompiledStorageURLs
+	}
+	return o.StorageURLs
 }
 
 type ResolvedStep struct {
@@ -51,10 +61,11 @@ type ResolvedStep struct {
 	StepInfo models.StepInfoModel
 }
 
-// useSteplibAPI selects the inventory backend: the StepLib V2 API when set, a
-// git-cloned steplib otherwise. library serves the former and is unread when
+// ActivateStep materializes a step into destination and writes its step.yml to
+// destinationStepYML. useSteplibAPI picks the inventory backend: the StepLib V2
+// API, served by library, or a git-cloned steplib. library is unread when
 // useSteplibAPI is false.
-func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, opts Options, useSteplibAPI bool, library *steplibrary.Client, fetcher httpfetch.Client) (ResolvedStep, error) {
+func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, opts Options, useSteplibAPI bool, library steplibrary.Client, fetcher httpfetch.Client) (ResolvedStep, error) {
 	var stepInfo models.StepInfoModel
 	var resolveErr error
 	if useSteplibAPI {
@@ -110,13 +121,13 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 }
 
 func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.CanonicalID, destination string, fetcher httpfetch.Client, opts Options) (string, error) {
-	if opts.UsePrecompiled && step.Executables != nil {
+	if !opts.DisablePrecompiled && step.Executables != nil {
 		platform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 		executableForPlatform, ok := (*step.Executables)[platform]
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(context.Background(), fetcher, id.IDorURI, executableForPlatform, destination, log, opts.StorageURLs)
+			execPath, err := activateStepExecutable(context.Background(), fetcher, id.IDorURI, executableForPlatform, destination, log, opts.storageURLs())
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 

--- a/activator/steplib/activate.go
+++ b/activator/steplib/activate.go
@@ -20,12 +20,28 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const precompiledStepsEnv = "BITRISE_STEPLIB_USE_BINARY"
-const precompiledStepsStorageURLsEnv = "BITRISE_STEPLIB_STORAGE_URLS"
-
-var precompiledStepsDefaultStorageURLs = []string{
+// DefaultPrecompiledStorageURLs are the base URLs tried in order when
+// downloading a precompiled step executable.
+var DefaultPrecompiledStorageURLs = []string{
 	"https://steplib.bitrise.io",
 	"https://storage.googleapis.com/bitrise-steplib-storage",
+}
+
+// Options is the per-run configuration of step activation. It is passed in
+// rather than read from the environment here, so that a caller building an
+// activator once per run resolves the configuration once.
+type Options struct {
+	// UsePrecompiled allows activating a step from a prebuilt executable
+	// instead of downloading and building its source.
+	UsePrecompiled bool
+
+	// StorageURLs are the base URLs tried in order for precompiled
+	// executables. Required when UsePrecompiled is set.
+	StorageURLs []string
+
+	// IsOfflineMode forbids network access, restricting activation to what is
+	// already in the local StepLib cache.
+	IsOfflineMode bool
 }
 
 type ResolvedStep struct {
@@ -35,7 +51,7 @@ type ResolvedStep struct {
 	StepInfo models.StepInfoModel
 }
 
-func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, isOfflineMode bool, libraryAPI *steplibrary.Client, fetcher httpfetch.Client) (ResolvedStep, error) {
+func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, opts Options, libraryAPI *steplibrary.Client, fetcher httpfetch.Client) (ResolvedStep, error) {
 	var stepInfo models.StepInfoModel
 	var resolveErr error
 	if libraryAPI != nil {
@@ -64,7 +80,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 		}
 	}
 
-	execPath, err := downloadPrecompiled(log, stepModel, id, destination, fetcher)
+	execPath, err := downloadPrecompiled(log, stepModel, id, destination, fetcher, opts)
 	if execPath != "" {
 		return ResolvedStep{ExecPath: execPath, StepInfo: stepInfo}, err
 	}
@@ -72,7 +88,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	// Fall back to step source activation.
 	if libraryAPI != nil {
 		// activate the source over the API, without git clone
-		if err := activateStepSourceWithAPI(libraryAPI, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode, fetcher); err != nil {
+		if err := activateStepSourceWithAPI(libraryAPI, id.IDorURI, version, stepModel.Source, destination, log, opts.IsOfflineMode, fetcher); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
@@ -83,22 +99,21 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	if err != nil {
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("failed to read %s steplib: %s", id.SteplibSource, err)
 	}
-	if err := activateStepSource(stepCollection, id.SteplibSource, id.IDorURI, version, stepModel, destination, log, isOfflineMode, fetcher); err != nil {
+	if err := activateStepSource(stepCollection, id.SteplibSource, id.IDorURI, version, stepModel, destination, log, opts.IsOfflineMode, fetcher); err != nil {
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 	}
 
 	return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
 }
 
-func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.CanonicalID, destination string, fetcher httpfetch.Client) (string, error) {
-	precompiledDisabled := os.Getenv(precompiledStepsEnv) == "false" || os.Getenv(precompiledStepsEnv) == "0"
-	if !precompiledDisabled && step.Executables != nil {
+func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.CanonicalID, destination string, fetcher httpfetch.Client, opts Options) (string, error) {
+	if opts.UsePrecompiled && step.Executables != nil {
 		platform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 		executableForPlatform, ok := (*step.Executables)[platform]
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(context.Background(), fetcher, id.IDorURI, executableForPlatform, destination, log)
+			execPath, err := activateStepExecutable(context.Background(), fetcher, id.IDorURI, executableForPlatform, destination, log, opts.StorageURLs)
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 

--- a/activator/steplib/activate_executable.go
+++ b/activator/steplib/activate_executable.go
@@ -20,10 +20,11 @@ func activateStepExecutable(
 	executable models.Executable,
 	destinationDir string,
 	logger stepman.Logger,
+	storageURLs []string,
 ) (string, error) {
 	path := filepath.Join(destinationDir, stepID)
 
-	if err := downloadExecutable(ctx, fetcher, executable, path, logger); err != nil {
+	if err := downloadExecutable(ctx, fetcher, executable, path, logger, storageURLs); err != nil {
 		return "", err
 	}
 
@@ -55,13 +56,8 @@ func buildDownloadURLs(bases []string, executable models.Executable) ([]string, 
 	return urls, nil
 }
 
-func downloadExecutable(ctx context.Context, fetcher httpfetch.Client, executable models.Executable, destPath string, logger stepman.Logger) error {
-	bases := precompiledStepsDefaultStorageURLs
-	if override := os.Getenv(precompiledStepsStorageURLsEnv); override != "" {
-		bases = strings.Split(override, ",")
-	}
-
-	urls, err := buildDownloadURLs(bases, executable)
+func downloadExecutable(ctx context.Context, fetcher httpfetch.Client, executable models.Executable, destPath string, logger stepman.Logger, storageURLs []string) error {
+	urls, err := buildDownloadURLs(storageURLs, executable)
 	if err != nil {
 		return err
 	}

--- a/activator/steplib/activate_executable_test.go
+++ b/activator/steplib/activate_executable_test.go
@@ -32,7 +32,7 @@ func TestBuildDownloadURLs(t *testing.T) {
 	}{
 		{
 			name:  "Default list: steplib.bitrise.io first, GCS second",
-			bases: precompiledStepsDefaultStorageURLs,
+			bases: DefaultPrecompiledStorageURLs,
 			executable: models.Executable{
 				StorageURI: "steps/step1.tar.gz",
 			},
@@ -120,21 +120,21 @@ func TestActivateStepExecutable(t *testing.T) {
 		destDir := t.TempDir()
 
 		path, err := activateStepExecutable(ctx, fake, "hello-step",
-			models.Executable{StorageURI: storageURI, Hash: hash}, destDir, logger)
+			models.Executable{StorageURI: storageURI, Hash: hash}, destDir, logger, DefaultPrecompiledStorageURLs)
 		require.NoError(t, err)
 
 		require.Equal(t, filepath.Join(destDir, "hello-step"), path)
 		require.FileExists(t, path)
-		require.Equal(t, precompiledStepsDefaultStorageURLs[0]+"/"+storageURI, fake.calledURL)
+		require.Equal(t, DefaultPrecompiledStorageURLs[0]+"/"+storageURI, fake.calledURL)
 		require.Equal(t, hash, fake.calledHash)
 	})
 
-	t.Run("BITRISE_STEPLIB_STORAGE_URLS override wins", func(t *testing.T) {
-		t.Setenv(precompiledStepsStorageURLsEnv, "https://custom.example.com")
+	t.Run("configured storage URLs win over the defaults", func(t *testing.T) {
 		fake := newFakeExecutableFetcher(t)
 
 		_, err := activateStepExecutable(ctx, fake, "hello-step",
-			models.Executable{StorageURI: storageURI, Hash: hash}, t.TempDir(), logger)
+			models.Executable{StorageURI: storageURI, Hash: hash}, t.TempDir(), logger,
+			[]string{"https://custom.example.com"})
 		require.NoError(t, err)
 
 		require.Equal(t, "https://custom.example.com/"+storageURI, fake.calledURL)

--- a/activator/steplib/activate_test.go
+++ b/activator/steplib/activate_test.go
@@ -30,7 +30,7 @@ func TestActivateStep_ResolvesExactVersion(t *testing.T) {
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
 	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
-	resolved, err := ActivateStep(id, destination, stepYML, log, sourceOnlyOpts(), true, &library, newFakeExecutableFetcher(t))
+	resolved, err := ActivateStep(id, destination, stepYML, log, sourceOnlyOpts(), true, library, newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Equal(t, "hello-step", resolved.StepInfo.ID)
@@ -50,7 +50,7 @@ func TestActivateStep_ResolvesMajorLock(t *testing.T) {
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "1"}
 
 	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
-	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), true, &library, newFakeExecutableFetcher(t))
+	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), true, library, newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.1.0", resolved.StepInfo.Version, "major lock 1 resolves to the highest 1.x")
@@ -65,7 +65,7 @@ func TestActivateStep_NonexistentVersionFails(t *testing.T) {
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "99.99.99"}
 
 	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
-	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), true, &library, newFakeExecutableFetcher(t))
+	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), true, library, newFakeExecutableFetcher(t))
 	require.Error(t, err, "a version not in the inventory must fail resolution")
 }
 
@@ -80,7 +80,7 @@ func TestActivateStep_NoExecutable_ActivatesSource(t *testing.T) {
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
 	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, &library, newFakeExecutableFetcher(t))
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, library, newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Empty(t, resolved.ExecPath, "a step without executables must fall back to source")
@@ -107,7 +107,7 @@ func TestActivateStep_ChoosesExecutable(t *testing.T) {
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
 	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, &library, newFakeExecutableFetcher(t))
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, library, newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(destination, "hello-step"), resolved.ExecPath)
@@ -136,9 +136,20 @@ func TestActivateStep_ExecutableDownloadFails_FallsBackToSource(t *testing.T) {
 	fetcher := newFakeExecutableFetcher(t)
 	fetcher.downloadErr = errFakeDownload
 	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, &library, fetcher)
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, library, fetcher)
 	require.NoError(t, err, "a failed executable download must fall back to source, not error")
 
 	assert.Empty(t, resolved.ExecPath)
 	require.FileExists(t, filepath.Join(destination, "activated_marker.txt"))
+}
+
+// Options.storageURLs falls back to the built-in list, so a caller using
+// steplib.Options directly does not silently lose the precompiled path.
+func TestOptionsStorageURLsDefault(t *testing.T) {
+	//nolint:exhaustruct // exercising exactly the unset field
+	require.Equal(t, DefaultPrecompiledStorageURLs, Options{}.storageURLs())
+
+	custom := []string{"https://custom.example.com"}
+	//nolint:exhaustruct // exercising exactly the set field
+	require.Equal(t, custom, Options{StorageURLs: custom}.storageURLs())
 }

--- a/activator/steplib/activate_test.go
+++ b/activator/steplib/activate_test.go
@@ -29,7 +29,8 @@ func TestActivateStep_ResolvesExactVersion(t *testing.T) {
 
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, stepYML, log, sourceOnlyOpts(), steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
+	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
+	resolved, err := ActivateStep(id, destination, stepYML, log, sourceOnlyOpts(), true, &library, newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Equal(t, "hello-step", resolved.StepInfo.ID)
@@ -48,7 +49,8 @@ func TestActivateStep_ResolvesMajorLock(t *testing.T) {
 
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "1"}
 
-	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
+	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
+	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), true, &library, newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.1.0", resolved.StepInfo.Version, "major lock 1 resolves to the highest 1.x")
@@ -62,7 +64,8 @@ func TestActivateStep_NonexistentVersionFails(t *testing.T) {
 
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "99.99.99"}
 
-	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
+	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
+	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), true, &library, newFakeExecutableFetcher(t))
 	require.Error(t, err, "a version not in the inventory must fail resolution")
 }
 
@@ -76,7 +79,8 @@ func TestActivateStep_NoExecutable_ActivatesSource(t *testing.T) {
 	destination := t.TempDir()
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
+	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, &library, newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Empty(t, resolved.ExecPath, "a step without executables must fall back to source")
@@ -102,7 +106,8 @@ func TestActivateStep_ChoosesExecutable(t *testing.T) {
 	destination := t.TempDir()
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
+	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, &library, newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(destination, "hello-step"), resolved.ExecPath)
@@ -130,7 +135,8 @@ func TestActivateStep_ExecutableDownloadFails_FallsBackToSource(t *testing.T) {
 
 	fetcher := newFakeExecutableFetcher(t)
 	fetcher.downloadErr = errFakeDownload
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), fetcher)
+	library := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, true, &library, fetcher)
 	require.NoError(t, err, "a failed executable download must fall back to source, not error")
 
 	assert.Empty(t, resolved.ExecPath)

--- a/activator/steplib/activate_test.go
+++ b/activator/steplib/activate_test.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/steplibrary"
@@ -21,7 +22,6 @@ import (
 func TestActivateStep_ResolvesExactVersion(t *testing.T) {
 	srv := serveHelloStepInventory(t)
 	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "false")
 
 	destination := t.TempDir()
 	workDir := t.TempDir()
@@ -29,7 +29,7 @@ func TestActivateStep_ResolvesExactVersion(t *testing.T) {
 
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, stepYML, log, false, steplibrary.New(log, srv.URL), newFakeExecutableFetcher(t))
+	resolved, err := ActivateStep(id, destination, stepYML, log, sourceOnlyOpts(), steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Equal(t, "hello-step", resolved.StepInfo.ID)
@@ -45,11 +45,10 @@ func TestActivateStep_ResolvesExactVersion(t *testing.T) {
 func TestActivateStep_ResolvesMajorLock(t *testing.T) {
 	srv := serveHelloStepInventory(t)
 	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "false")
 
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "1"}
 
-	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), newFakeExecutableFetcher(t))
+	resolved, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.1.0", resolved.StepInfo.Version, "major lock 1 resolves to the highest 1.x")
@@ -60,11 +59,10 @@ func TestActivateStep_ResolvesMajorLock(t *testing.T) {
 func TestActivateStep_NonexistentVersionFails(t *testing.T) {
 	srv := serveHelloStepInventory(t)
 	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "false")
 
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "99.99.99"}
 
-	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), newFakeExecutableFetcher(t))
+	_, err := ActivateStep(id, t.TempDir(), filepath.Join(t.TempDir(), "current_step.yml"), log, sourceOnlyOpts(), steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
 	require.Error(t, err, "a version not in the inventory must fail resolution")
 }
 
@@ -73,12 +71,12 @@ func TestActivateStep_NonexistentVersionFails(t *testing.T) {
 func TestActivateStep_NoExecutable_ActivatesSource(t *testing.T) {
 	srv := serveHelloStepInventory(t)
 	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "true")
+	useBinary := precompiledOpts()
 
 	destination := t.TempDir()
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), newFakeExecutableFetcher(t))
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Empty(t, resolved.ExecPath, "a step without executables must fall back to source")
@@ -99,12 +97,12 @@ func TestActivateStep_ChoosesExecutable(t *testing.T) {
 	})
 
 	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "true")
+	useBinary := precompiledOpts()
 
 	destination := t.TempDir()
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), newFakeExecutableFetcher(t))
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), newFakeExecutableFetcher(t))
 	require.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(destination, "hello-step"), resolved.ExecPath)
@@ -125,14 +123,14 @@ func TestActivateStep_ExecutableDownloadFails_FallsBackToSource(t *testing.T) {
 	})
 
 	log := apiTestLogger{t}
-	t.Setenv(precompiledStepsEnv, "true")
+	useBinary := precompiledOpts()
 
 	destination := t.TempDir()
 	id := stepid.CanonicalID{SteplibSource: testSteplibURL, IDorURI: "hello-step", Version: "2.0.0"}
 
 	fetcher := newFakeExecutableFetcher(t)
 	fetcher.downloadErr = errFakeDownload
-	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, false, steplibrary.New(log, srv.URL), fetcher)
+	resolved, err := ActivateStep(id, destination, filepath.Join(t.TempDir(), "current_step.yml"), log, useBinary, steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client())), fetcher)
 	require.NoError(t, err, "a failed executable download must fall back to source, not error")
 
 	assert.Empty(t, resolved.ExecPath)

--- a/activator/steplib/helpers_test.go
+++ b/activator/steplib/helpers_test.go
@@ -172,3 +172,14 @@ func (f *fakeExecutableFetcher) DownloadWithHash(_ context.Context, destPath, ur
 	}
 	return os.WriteFile(destPath, []byte("stub binary"), 0o644)
 }
+
+// sourceOnlyOpts configures activation to skip precompiled executables, so the
+// tests that assert source activation are not steered by a prebuilt binary.
+func sourceOnlyOpts() Options {
+	return Options{UsePrecompiled: false, StorageURLs: nil, IsOfflineMode: false}
+}
+
+// precompiledOpts configures activation to prefer a prebuilt executable.
+func precompiledOpts() Options {
+	return Options{UsePrecompiled: true, StorageURLs: DefaultPrecompiledStorageURLs, IsOfflineMode: false}
+}

--- a/activator/steplib/helpers_test.go
+++ b/activator/steplib/helpers_test.go
@@ -176,10 +176,10 @@ func (f *fakeExecutableFetcher) DownloadWithHash(_ context.Context, destPath, ur
 // sourceOnlyOpts configures activation to skip precompiled executables, so the
 // tests that assert source activation are not steered by a prebuilt binary.
 func sourceOnlyOpts() Options {
-	return Options{UsePrecompiled: false, StorageURLs: nil, IsOfflineMode: false}
+	return Options{DisablePrecompiled: true, StorageURLs: nil, IsOfflineMode: false}
 }
 
 // precompiledOpts configures activation to prefer a prebuilt executable.
 func precompiledOpts() Options {
-	return Options{UsePrecompiled: true, StorageURLs: DefaultPrecompiledStorageURLs, IsOfflineMode: false}
+	return Options{DisablePrecompiled: false, StorageURLs: DefaultPrecompiledStorageURLs, IsOfflineMode: false}
 }

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -13,7 +13,7 @@ import (
 
 // activateStepSourceWithAPI materializes id@version's source into destDir
 // without cloning a git steplib.
-func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool, fetcher httpfetch.Client) error {
+func activateStepSourceWithAPI(library *steplibrary.Client, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool, fetcher httpfetch.Client) error {
 	if isOfflineMode {
 		return errors.New("offline mode is not supported with the Steplib API, set BITRISE_STEPLIB_USE_API=false to activate steps from the local StepLib cache")
 	}
@@ -22,7 +22,7 @@ func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, id, version strin
 		return fmt.Errorf("step %s@%s has no source git URL to download from", id, version)
 	}
 
-	locations, err := libraryAPI.StepSourceDownloadLocations(context.Background(), id, version, source.Git)
+	locations, err := library.StepSourceDownloadLocations(context.Background(), id, version, source.Git)
 	if err != nil {
 		return fmt.Errorf("resolve download locations for %s@%s: %s", id, version, err)
 	}

--- a/activator/steplib/source.go
+++ b/activator/steplib/source.go
@@ -13,7 +13,7 @@ import (
 
 // activateStepSourceWithAPI materializes id@version's source into destDir
 // without cloning a git steplib.
-func activateStepSourceWithAPI(library *steplibrary.Client, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool, fetcher httpfetch.Client) error {
+func activateStepSourceWithAPI(library steplibrary.Client, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool, fetcher httpfetch.Client) error {
 	if isOfflineMode {
 		return errors.New("offline mode is not supported with the Steplib API, set BITRISE_STEPLIB_USE_API=false to activate steps from the local StepLib cache")
 	}

--- a/activator/steplib/source_test.go
+++ b/activator/steplib/source_test.go
@@ -21,7 +21,7 @@ func TestActivateStepSourceWithAPI_OfflineFails(t *testing.T) {
 	log := apiTestLogger{t}
 	client := steplibrary.New(log, "http://unused.invalid", httpfetch.NewClient(log))
 
-	err := activateStepSourceWithAPI(&client, "hello-step", "2.0.0",
+	err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
 		&models.StepSourceModel{Git: "https://github.com/example/hello-step.git"}, t.TempDir(), log, true, httpfetch.NewClient(log))
 
 	require.Error(t, err)
@@ -33,13 +33,13 @@ func TestActivateStepSourceWithAPI_MissingSourceGitFails(t *testing.T) {
 	client := steplibrary.New(log, "http://unused.invalid", httpfetch.NewClient(log))
 
 	t.Run("nil source", func(t *testing.T) {
-		err := activateStepSourceWithAPI(&client, "hello-step", "2.0.0", nil, t.TempDir(), log, false, httpfetch.NewClient(log))
+		err := activateStepSourceWithAPI(client, "hello-step", "2.0.0", nil, t.TempDir(), log, false, httpfetch.NewClient(log))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "source git")
 	})
 
 	t.Run("empty git URL", func(t *testing.T) {
-		err := activateStepSourceWithAPI(&client, "hello-step", "2.0.0",
+		err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
 			&models.StepSourceModel{Git: ""}, t.TempDir(), log, false, httpfetch.NewClient(log))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "source git")
@@ -60,7 +60,7 @@ func TestActivateStepSourceWithAPI_NoDownloadLocationFails(t *testing.T) {
 	log := apiTestLogger{t}
 	client := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
 
-	err := activateStepSourceWithAPI(&client, "hello-step", "2.0.0",
+	err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
 		&models.StepSourceModel{Git: "https://github.com/example/hello-step.git"}, t.TempDir(), log, false, httpfetch.NewClient(log))
 
 	require.Error(t, err)

--- a/activator/steplib/source_test.go
+++ b/activator/steplib/source_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestActivateStepSourceWithAPI_OfflineFails(t *testing.T) {
 	log := apiTestLogger{t}
-	client := steplibrary.New(log, "http://unused.invalid")
+	client := steplibrary.New(log, "http://unused.invalid", httpfetch.NewClient(log))
 
 	err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
 		&models.StepSourceModel{Git: "https://github.com/example/hello-step.git"}, t.TempDir(), log, true, httpfetch.NewClient(log))
@@ -30,7 +30,7 @@ func TestActivateStepSourceWithAPI_OfflineFails(t *testing.T) {
 
 func TestActivateStepSourceWithAPI_MissingSourceGitFails(t *testing.T) {
 	log := apiTestLogger{t}
-	client := steplibrary.New(log, "http://unused.invalid")
+	client := steplibrary.New(log, "http://unused.invalid", httpfetch.NewClient(log))
 
 	t.Run("nil source", func(t *testing.T) {
 		err := activateStepSourceWithAPI(client, "hello-step", "2.0.0", nil, t.TempDir(), log, false, httpfetch.NewClient(log))
@@ -58,7 +58,7 @@ func TestActivateStepSourceWithAPI_NoDownloadLocationFails(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	log := apiTestLogger{t}
-	client := steplibrary.New(log, srv.URL)
+	client := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
 
 	err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
 		&models.StepSourceModel{Git: "https://github.com/example/hello-step.git"}, t.TempDir(), log, false, httpfetch.NewClient(log))

--- a/activator/steplib/source_test.go
+++ b/activator/steplib/source_test.go
@@ -21,7 +21,7 @@ func TestActivateStepSourceWithAPI_OfflineFails(t *testing.T) {
 	log := apiTestLogger{t}
 	client := steplibrary.New(log, "http://unused.invalid", httpfetch.NewClient(log))
 
-	err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
+	err := activateStepSourceWithAPI(&client, "hello-step", "2.0.0",
 		&models.StepSourceModel{Git: "https://github.com/example/hello-step.git"}, t.TempDir(), log, true, httpfetch.NewClient(log))
 
 	require.Error(t, err)
@@ -33,13 +33,13 @@ func TestActivateStepSourceWithAPI_MissingSourceGitFails(t *testing.T) {
 	client := steplibrary.New(log, "http://unused.invalid", httpfetch.NewClient(log))
 
 	t.Run("nil source", func(t *testing.T) {
-		err := activateStepSourceWithAPI(client, "hello-step", "2.0.0", nil, t.TempDir(), log, false, httpfetch.NewClient(log))
+		err := activateStepSourceWithAPI(&client, "hello-step", "2.0.0", nil, t.TempDir(), log, false, httpfetch.NewClient(log))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "source git")
 	})
 
 	t.Run("empty git URL", func(t *testing.T) {
-		err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
+		err := activateStepSourceWithAPI(&client, "hello-step", "2.0.0",
 			&models.StepSourceModel{Git: ""}, t.TempDir(), log, false, httpfetch.NewClient(log))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "source git")
@@ -60,7 +60,7 @@ func TestActivateStepSourceWithAPI_NoDownloadLocationFails(t *testing.T) {
 	log := apiTestLogger{t}
 	client := steplibrary.New(log, srv.URL, httpfetch.NewWithClient(srv.Client()))
 
-	err := activateStepSourceWithAPI(client, "hello-step", "2.0.0",
+	err := activateStepSourceWithAPI(&client, "hello-step", "2.0.0",
 		&models.StepSourceModel{Git: "https://github.com/example/hello-step.git"}, t.TempDir(), log, false, httpfetch.NewClient(log))
 
 	require.Error(t, err)

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
-	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
 )
 
@@ -27,15 +26,12 @@ func (a *Activator) ActivateSteplibRefStep(
 		DidStepLibUpdate: false,
 	}
 
-	var libraryAPI *steplibrary.Client
-	if a.useSteplibAPIFor(id.SteplibSource) {
-		libraryAPI = a.library
-	}
+	useSteplibAPI := a.useSteplibAPIFor(id.SteplibSource)
 
 	// The inventory source is set here, on the same branch that dispatches, and before
 	// any return: the caller keeps the partial result on error, so a failed activation
 	// is still attributable to the inventory that served it.
-	if libraryAPI == nil {
+	if !useSteplibAPI {
 		activationResult.ActivationInventorySource = ActivationInventorySourceSteplib
 
 		// Old stepman preparation codepath
@@ -55,7 +51,7 @@ func (a *Activator) ActivateSteplibRefStep(
 		StorageURLs:    a.opts.PrecompiledStorageURLs,
 		IsOfflineMode:  isOfflineMode,
 	}
-	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, activateOpts, libraryAPI, a.fetcher)
+	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, activateOpts, useSteplibAPI, &a.library, a.fetcher)
 	activationResult.StepInfo = resolvedStep.StepInfo
 	activationResult.ExecutablePath = resolvedStep.ExecPath
 	if resolvedStep.ExecPath != "" {

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -2,31 +2,24 @@ package activator
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/bitrise-io/stepman/activator/steplib"
-	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
 )
 
-const (
-	bitriseSteplibURL    = "https://github.com/bitrise-io/bitrise-steplib.git"
-	bitriseSteplibAPIURL = "https://steplib.bitrise.io/api"
-	useSteplibAPIEnv     = "BITRISE_STEPLIB_USE_API"
-)
-
-func ActivateSteplibRefStep(
-	log stepman.Logger,
+// ActivateSteplibRefStep activates a step referenced through a StepLib.
+func (a *Activator) ActivateSteplibRefStep(
 	id stepid.CanonicalID,
 	activatedStepDir string,
 	workDir string,
 	didStepLibUpdateInWorkflow bool,
-	isOfflineMode bool,
 ) (ActivatedStep, error) {
+	log := a.log
+	isOfflineMode := a.opts.IsOfflineMode
 	stepYMLPath := filepath.Join(workDir, "current_step.yml")
 	//nolint:exhaustruct // missing fields are added down below based on activation result
 	activationResult := ActivatedStep{
@@ -35,8 +28,8 @@ func ActivateSteplibRefStep(
 	}
 
 	var libraryAPI *steplibrary.Client
-	if shouldUseSteplibAPI(id.SteplibSource) {
-		libraryAPI = steplibrary.New(log, bitriseSteplibAPIURL)
+	if a.useSteplibAPIFor(id.SteplibSource) {
+		libraryAPI = a.library
 	}
 
 	// The inventory source is set here, on the same branch that dispatches, and before
@@ -57,7 +50,12 @@ func ActivateSteplibRefStep(
 	}
 
 	// ActivateStep dispatches to the v2 or legacy codepath.
-	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, isOfflineMode, libraryAPI, httpfetch.NewClient(log))
+	activateOpts := steplib.Options{
+		UsePrecompiled: a.opts.UsePrecompiled,
+		StorageURLs:    a.opts.PrecompiledStorageURLs,
+		IsOfflineMode:  isOfflineMode,
+	}
+	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, activateOpts, libraryAPI, a.fetcher)
 	activationResult.StepInfo = resolvedStep.StepInfo
 	activationResult.ExecutablePath = resolvedStep.ExecPath
 	if resolvedStep.ExecPath != "" {
@@ -70,15 +68,6 @@ func ActivateSteplibRefStep(
 	}
 
 	return activationResult, nil
-}
-
-func shouldUseSteplibAPI(steplibURI string) bool {
-	if steplibURI != bitriseSteplibURL {
-		return false
-	}
-
-	apiDisabled := os.Getenv(useSteplibAPIEnv) == "false" || os.Getenv(useSteplibAPIEnv) == "0"
-	return !apiDisabled
 }
 
 func prepareStepLibForActivation(

--- a/activator/steplib_ref.go
+++ b/activator/steplib_ref.go
@@ -47,11 +47,11 @@ func (a *Activator) ActivateSteplibRefStep(
 
 	// ActivateStep dispatches to the v2 or legacy codepath.
 	activateOpts := steplib.Options{
-		UsePrecompiled: a.opts.UsePrecompiled,
-		StorageURLs:    a.opts.PrecompiledStorageURLs,
-		IsOfflineMode:  isOfflineMode,
+		DisablePrecompiled: a.opts.DisablePrecompiled,
+		StorageURLs:        a.opts.PrecompiledStorageURLs,
+		IsOfflineMode:      isOfflineMode,
 	}
-	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, activateOpts, useSteplibAPI, &a.library, a.fetcher)
+	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, activateOpts, useSteplibAPI, a.library, a.fetcher)
 	activationResult.StepInfo = resolvedStep.StepInfo
 	activationResult.ExecutablePath = resolvedStep.ExecPath
 	if resolvedStep.ExecPath != "" {

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/stepman"
 	"github.com/stretchr/testify/require"
@@ -153,14 +154,15 @@ func TestActivateSteplibRefStep(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("BITRISE_STEPLIB_USE_API", "false")
-
 			activatedStepDir := t.TempDir()
 			workDir := t.TempDir()
 
+			//nolint:exhaustruct // the remaining options are irrelevant on the legacy path
+			a := New(logger, Options{UseSteplibAPI: false})
+
 			// didStepLibUpdateInWorkflow=true keeps the StepLib update path off, so
 			// resolution is served from the local cache and DidStepLibUpdate is false.
-			got, err := ActivateSteplibRefStep(logger, tt.id, activatedStepDir, workDir, true, false)
+			got, err := a.ActivateSteplibRefStep(tt.id, activatedStepDir, workDir, true)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -216,13 +218,14 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("HOME", t.TempDir()) // fresh: the git cloned steplib is not set up
-			t.Setenv("BITRISE_STEPLIB_USE_API", "true")
-			t.Setenv("BITRISE_STEPLIB_USE_BINARY", "false")
 
 			activatedStepDir := t.TempDir()
 			workDir := t.TempDir()
 
-			got, err := ActivateSteplibRefStep(TestLogger[*testing.T]{t}, tt.id, activatedStepDir, workDir, false, false)
+			//nolint:exhaustruct // storage URLs and the API URL fall back to their defaults
+			a := New(TestLogger[*testing.T]{t}, Options{UseSteplibAPI: true, UsePrecompiled: false})
+
+			got, err := a.ActivateSteplibRefStep(tt.id, activatedStepDir, workDir, false)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -255,37 +258,80 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 	}
 }
 
-func TestShouldUseSteplibAPI(t *testing.T) {
+func TestUseSteplibAPIFor(t *testing.T) {
 	const customSteplib = "https://github.com/acme/custom-steplib.git"
 
 	tests := []struct {
-		name     string
-		envValue string // empty means the env var is unset
-		steplib  string
-		want     bool
+		name          string
+		useSteplibAPI bool
+		steplib       string
+		want          bool
 	}{
-		{name: "Unset env enables the API for the Bitrise steplib", steplib: bitriseSteplibURL, want: true},
-		{name: "Explicit true keeps the API enabled", envValue: "true", steplib: bitriseSteplibURL, want: true},
-		{name: "Explicit 1 keeps the API enabled", envValue: "1", steplib: bitriseSteplibURL, want: true},
-		{name: "Unrecognized value keeps the API enabled", envValue: "maybe", steplib: bitriseSteplibURL, want: true},
-		{name: "false opts out", envValue: "false", steplib: bitriseSteplibURL, want: false},
-		{name: "0 opts out", envValue: "0", steplib: bitriseSteplibURL, want: false},
-		{name: "Custom steplib never uses the API", steplib: customSteplib, want: false},
-		{name: "Custom steplib is not enabled by an explicit true", envValue: "true", steplib: customSteplib, want: false},
+		{name: "Enabled for the Bitrise steplib", useSteplibAPI: true, steplib: bitriseSteplibURL, want: true},
+		{name: "Disabled for the Bitrise steplib", useSteplibAPI: false, steplib: bitriseSteplibURL, want: false},
+		{name: "Custom steplib never uses the API", useSteplibAPI: true, steplib: customSteplib, want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// t.Setenv registers the restore even when the value is then removed,
-			// so an unset case cannot leak into the rest of the suite.
-			t.Setenv(useSteplibAPIEnv, tt.envValue)
-			if tt.envValue == "" {
-				require.NoError(t, os.Unsetenv(useSteplibAPIEnv))
-			}
-
-			require.Equal(t, tt.want, shouldUseSteplibAPI(tt.steplib))
+			//nolint:exhaustruct // only the API flag decides this
+			a := New(TestLogger[*testing.T]{t}, Options{UseSteplibAPI: tt.useSteplibAPI})
+			require.Equal(t, tt.want, a.useSteplibAPIFor(tt.steplib))
 		})
 	}
+}
+
+// TestOptionsFromEnv covers the env-var reads that used to sit deep in the
+// activation call stack: both flags default to on and only "false"/"0" opt out.
+func TestOptionsFromEnv(t *testing.T) {
+	tests := []struct {
+		name               string
+		envValue           string // empty means the env var is unset
+		wantAPI, wantBinar bool
+	}{
+		{name: "Unset enables both", wantAPI: true, wantBinar: true},
+		{name: "true enables both", envValue: "true", wantAPI: true, wantBinar: true},
+		{name: "1 enables both", envValue: "1", wantAPI: true, wantBinar: true},
+		{name: "Unrecognized value enables both", envValue: "maybe", wantAPI: true, wantBinar: true},
+		{name: "false opts out of both", envValue: "false"},
+		{name: "0 opts out of both", envValue: "0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range []string{"BITRISE_STEPLIB_USE_API", "BITRISE_STEPLIB_USE_BINARY"} {
+				// t.Setenv registers the restore even when the value is then
+				// removed, so an unset case cannot leak into the rest of the suite.
+				t.Setenv(key, tt.envValue)
+				if tt.envValue == "" {
+					require.NoError(t, os.Unsetenv(key))
+				}
+			}
+
+			opts := OptionsFromEnv()
+			require.Equal(t, tt.wantAPI, opts.UseSteplibAPI)
+			require.Equal(t, tt.wantBinar, opts.UsePrecompiled)
+			require.False(t, opts.IsOfflineMode, "offline mode is never inferred from the environment here")
+		})
+	}
+}
+
+func TestOptionsFromEnv_StorageURLOverride(t *testing.T) {
+	t.Setenv("BITRISE_STEPLIB_STORAGE_URLS", "https://a.example.com,https://b.example.com")
+	require.Equal(t, []string{"https://a.example.com", "https://b.example.com"},
+		OptionsFromEnv().PrecompiledStorageURLs)
+
+	require.NoError(t, os.Unsetenv("BITRISE_STEPLIB_STORAGE_URLS"))
+	require.Nil(t, OptionsFromEnv().PrecompiledStorageURLs,
+		"no override leaves the defaults to be filled in by the constructor")
+}
+
+// TestWithDefaults pins the values New fills in for a zero-value Options.
+func TestWithDefaults(t *testing.T) {
+	//nolint:exhaustruct // exercising exactly the unset fields
+	got := withDefaults(Options{})
+	require.Equal(t, bitriseSteplibAPIURL, got.SteplibAPIURL)
+	require.Equal(t, steplib.DefaultPrecompiledStorageURLs, got.PrecompiledStorageURLs)
 }
 
 type genericLogger interface {
@@ -368,7 +414,9 @@ func BenchmarkActivateSteplibRefStep(b *testing.B) {
 					b.Errorf("failed to create dir for step.yml: %s", err)
 				}
 
-				got, gotErr := ActivateSteplibRefStep(logger, tt.id, stepYMLCopyPth, tmpDir, tt.didStepLibUpdateInWorkflow, tt.isOfflineMode)
+				//nolint:exhaustruct // the benchmark drives the legacy git-clone path
+				a := New(logger, Options{UseSteplibAPI: false, IsOfflineMode: tt.isOfflineMode})
+				got, gotErr := a.ActivateSteplibRefStep(tt.id, stepYMLCopyPth, tmpDir, tt.didStepLibUpdateInWorkflow)
 				if gotErr != nil {
 					if !tt.wantErr {
 						b.Errorf("ActivateSteplibRefStep() failed: %v", gotErr)

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -281,51 +281,6 @@ func TestUseSteplibAPIFor(t *testing.T) {
 	}
 }
 
-// TestOptionsFromEnv covers the env-var reads that used to sit deep in the
-// activation call stack: both flags default to on and only "false"/"0" opt out.
-func TestOptionsFromEnv(t *testing.T) {
-	tests := []struct {
-		name               string
-		envValue           string // empty means the env var is unset
-		wantAPI, wantBinar bool
-	}{
-		{name: "Unset enables both", wantAPI: true, wantBinar: true},
-		{name: "true enables both", envValue: "true", wantAPI: true, wantBinar: true},
-		{name: "1 enables both", envValue: "1", wantAPI: true, wantBinar: true},
-		{name: "Unrecognized value enables both", envValue: "maybe", wantAPI: true, wantBinar: true},
-		{name: "false opts out of both", envValue: "false"},
-		{name: "0 opts out of both", envValue: "0"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			for _, key := range []string{"BITRISE_STEPLIB_USE_API", "BITRISE_STEPLIB_USE_BINARY"} {
-				// t.Setenv registers the restore even when the value is then
-				// removed, so an unset case cannot leak into the rest of the suite.
-				t.Setenv(key, tt.envValue)
-				if tt.envValue == "" {
-					require.NoError(t, os.Unsetenv(key))
-				}
-			}
-
-			opts := OptionsFromEnv()
-			require.Equal(t, tt.wantAPI, opts.UseSteplibAPI)
-			require.Equal(t, tt.wantBinar, opts.UsePrecompiled)
-			require.False(t, opts.IsOfflineMode, "offline mode is never inferred from the environment here")
-		})
-	}
-}
-
-func TestOptionsFromEnv_StorageURLOverride(t *testing.T) {
-	t.Setenv("BITRISE_STEPLIB_STORAGE_URLS", "https://a.example.com,https://b.example.com")
-	require.Equal(t, []string{"https://a.example.com", "https://b.example.com"},
-		OptionsFromEnv().PrecompiledStorageURLs)
-
-	require.NoError(t, os.Unsetenv("BITRISE_STEPLIB_STORAGE_URLS"))
-	require.Nil(t, OptionsFromEnv().PrecompiledStorageURLs,
-		"no override leaves the defaults to be filled in by the constructor")
-}
-
 // TestWithDefaults pins the values New fills in for a zero-value Options.
 func TestWithDefaults(t *testing.T) {
 	//nolint:exhaustruct // exercising exactly the unset fields

--- a/activator/steplib_ref_test.go
+++ b/activator/steplib_ref_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/stepman"
 	"github.com/stretchr/testify/require"
@@ -158,7 +157,7 @@ func TestActivateSteplibRefStep(t *testing.T) {
 			workDir := t.TempDir()
 
 			//nolint:exhaustruct // the remaining options are irrelevant on the legacy path
-			a := New(logger, Options{UseSteplibAPI: false})
+			a := New(logger, Options{DisableSteplibAPI: true})
 
 			// didStepLibUpdateInWorkflow=true keeps the StepLib update path off, so
 			// resolution is served from the local cache and DidStepLibUpdate is false.
@@ -223,7 +222,7 @@ func TestActivateSteplibRefStep_APIEnabled(t *testing.T) {
 			workDir := t.TempDir()
 
 			//nolint:exhaustruct // storage URLs and the API URL fall back to their defaults
-			a := New(TestLogger[*testing.T]{t}, Options{UseSteplibAPI: true, UsePrecompiled: false})
+			a := New(TestLogger[*testing.T]{t}, Options{DisableSteplibAPI: false, DisablePrecompiled: true})
 
 			got, err := a.ActivateSteplibRefStep(tt.id, activatedStepDir, workDir, false)
 			if tt.wantErr {
@@ -275,18 +274,29 @@ func TestUseSteplibAPIFor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			//nolint:exhaustruct // only the API flag decides this
-			a := New(TestLogger[*testing.T]{t}, Options{UseSteplibAPI: tt.useSteplibAPI})
+			a := New(TestLogger[*testing.T]{t}, Options{DisableSteplibAPI: !tt.useSteplibAPI})
 			require.Equal(t, tt.want, a.useSteplibAPIFor(tt.steplib))
 		})
 	}
 }
 
-// TestWithDefaults pins the values New fills in for a zero-value Options.
+// TestWithDefaults pins the values New fills in for a zero-value Options. The
+// storage URLs are deliberately absent: steplib owns that list and defaults it
+// itself, so a caller reaching steplib directly gets them too.
 func TestWithDefaults(t *testing.T) {
 	//nolint:exhaustruct // exercising exactly the unset fields
 	got := withDefaults(Options{})
 	require.Equal(t, bitriseSteplibAPIURL, got.SteplibAPIURL)
-	require.Equal(t, steplib.DefaultPrecompiledStorageURLs, got.PrecompiledStorageURLs)
+	require.Nil(t, got.PrecompiledStorageURLs)
+}
+
+// TestZeroOptionsKeepProductionDefaults guards the opt-out shape of the flags:
+// a caller that sets neither must still get the API and prebuilt executables.
+func TestZeroOptionsKeepProductionDefaults(t *testing.T) {
+	//nolint:exhaustruct // the point is that the rest stays unset
+	a := New(TestLogger[*testing.T]{t}, Options{})
+	require.True(t, a.useSteplibAPIFor(bitriseSteplibURL))
+	require.False(t, a.opts.DisablePrecompiled)
 }
 
 type genericLogger interface {
@@ -370,7 +380,7 @@ func BenchmarkActivateSteplibRefStep(b *testing.B) {
 				}
 
 				//nolint:exhaustruct // the benchmark drives the legacy git-clone path
-				a := New(logger, Options{UseSteplibAPI: false, IsOfflineMode: tt.isOfflineMode})
+				a := New(logger, Options{DisableSteplibAPI: true, IsOfflineMode: tt.isOfflineMode})
 				got, gotErr := a.ActivateSteplibRefStep(tt.id, stepYMLCopyPth, tmpDir, tt.didStepLibUpdateInWorkflow)
 				if gotErr != nil {
 					if !tt.wantErr {

--- a/steplibrary/resolve_version.go
+++ b/steplibrary/resolve_version.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
 )
 
-func (c *Client) getStepVersionInfo(ctx context.Context, stepID, version string) (models.StepInfoModel, ResolvedStepVersion, error) {
+func (c Client) getStepVersionInfo(ctx context.Context, stepID, version string) (models.StepInfoModel, ResolvedStepVersion, error) {
 	if stepID == "" {
 		return models.StepInfoModel{}, ResolvedStepVersion{}, errors.New("missing required input: step id")
 	}
@@ -61,7 +61,7 @@ func (c *Client) getStepVersionInfo(ctx context.Context, stepID, version string)
 
 // resolveVersion turns a parsed version constraint into a concrete version
 // string, fetching the step's version list when the constraint needs it.
-func (c *Client) resolveVersion(ctx context.Context, stepID, version string, constraint models.VersionConstraint, latestVersions steplibindex.LatestPointer) (string, error) {
+func (c Client) resolveVersion(ctx context.Context, stepID, version string, constraint models.VersionConstraint, latestVersions steplibindex.LatestPointer) (string, error) {
 	switch constraint.VersionLockType {
 	case models.Latest:
 		return latestVersions.Latest, nil

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -18,11 +18,14 @@ type Client struct {
 
 // New builds a stepman.Client.
 // inventoryURL: the base URL of the API where metadata is fetched from.
-func New(log stepman.Logger, inventoryURL string) *Client {
+// fetcher: the HTTP client used for every inventory request. Callers pass one
+// in so that a single client, and therefore a single connection pool, can be
+// shared across everything a run fetches.
+func New(log stepman.Logger, inventoryURL string, fetcher httpfetch.Client) *Client {
 	return &Client{
 		log:          log,
 		inventoryURL: inventoryURL,
-		api:          NewHTTPAPI(inventoryURL, httpfetch.NewClient(log)),
+		api:          NewHTTPAPI(inventoryURL, fetcher),
 	}
 }
 

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -10,6 +10,11 @@ import (
 	"github.com/bitrise-io/stepman/stepman"
 )
 
+// Client reads a StepLib V2 inventory. It is a handle, not a resource: copying
+// one is cheap and safe, and every copy talks to the same inventory over the
+// same HTTP client. Any state added later (a response cache, say) must sit
+// behind a pointer or an interface so copies keep sharing it - a mutex or a
+// bare map field would break that, and go vet only catches the mutex.
 type Client struct {
 	log          stepman.Logger
 	inventoryURL string
@@ -29,7 +34,7 @@ func New(log stepman.Logger, inventoryURL string, fetcher httpfetch.Client) Clie
 	}
 }
 
-func (c *Client) FetchStepMetadata(ctx context.Context, stepRef stepid.CanonicalID) (models.StepInfoModel, error) {
+func (c Client) FetchStepMetadata(ctx context.Context, stepRef stepid.CanonicalID) (models.StepInfoModel, error) {
 	stepInfo, resolved, err := c.getStepVersionInfo(ctx, stepRef.IDorURI, stepRef.Version)
 	if err != nil {
 		return models.StepInfoModel{}, fmt.Errorf("resolve step version: %w", err)
@@ -45,7 +50,7 @@ func (c *Client) FetchStepMetadata(ctx context.Context, stepRef stepid.Canonical
 }
 
 // StepSourceDownloadLocations returns a priority order of step source zip download locations
-func (c *Client) StepSourceDownloadLocations(ctx context.Context, id, version, sourceGit string) ([]models.DownloadLocationModel, error) {
+func (c Client) StepSourceDownloadLocations(ctx context.Context, id, version, sourceGit string) ([]models.DownloadLocationModel, error) {
 	bases, err := c.api.GetStepSourceDownloadLocations(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fetch download locations: %w", err)

--- a/steplibrary/steplibrary.go
+++ b/steplibrary/steplibrary.go
@@ -21,8 +21,8 @@ type Client struct {
 // fetcher: the HTTP client used for every inventory request. Callers pass one
 // in so that a single client, and therefore a single connection pool, can be
 // shared across everything a run fetches.
-func New(log stepman.Logger, inventoryURL string, fetcher httpfetch.Client) *Client {
-	return &Client{
+func New(log stepman.Logger, inventoryURL string, fetcher httpfetch.Client) Client {
+	return Client{
 		log:          log,
 		inventoryURL: inventoryURL,
 		api:          NewHTTPAPI(inventoryURL, fetcher),

--- a/toolkits/golang_test.go
+++ b/toolkits/golang_test.go
@@ -227,7 +227,7 @@ func Benchmark_goBuildStep(b *testing.B) {
 		IDorURI:       "xcode-test",
 		Version:       "5.1.1",
 	}
-	_, err = steplib.ActivateStep(id, stepDir, "", logger, false, nil, httpfetch.NewClient(logger))
+	_, err = steplib.ActivateStep(id, stepDir, "", logger, steplib.Options{UsePrecompiled: false, StorageURLs: nil, IsOfflineMode: false}, nil, httpfetch.NewClient(logger))
 	require.NoError(b, err)
 
 	packageName := "github.com/bitrise-steplib/steps-xcode-test"

--- a/toolkits/golang_test.go
+++ b/toolkits/golang_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
+	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -227,7 +228,8 @@ func Benchmark_goBuildStep(b *testing.B) {
 		IDorURI:       "xcode-test",
 		Version:       "5.1.1",
 	}
-	_, err = steplib.ActivateStep(id, stepDir, "", logger, steplib.Options{UsePrecompiled: false, StorageURLs: nil, IsOfflineMode: false}, nil, httpfetch.NewClient(logger))
+	library := steplibrary.New(logger, "http://unused.invalid", httpfetch.NewClient(logger))
+	_, err = steplib.ActivateStep(id, stepDir, "", logger, steplib.Options{UsePrecompiled: false, StorageURLs: nil, IsOfflineMode: false}, false, &library, httpfetch.NewClient(logger))
 	require.NoError(b, err)
 
 	packageName := "github.com/bitrise-steplib/steps-xcode-test"

--- a/toolkits/golang_test.go
+++ b/toolkits/golang_test.go
@@ -228,8 +228,7 @@ func Benchmark_goBuildStep(b *testing.B) {
 		IDorURI:       "xcode-test",
 		Version:       "5.1.1",
 	}
-	library := steplibrary.New(logger, "http://unused.invalid", httpfetch.NewClient(logger))
-	_, err = steplib.ActivateStep(id, stepDir, "", logger, steplib.Options{UsePrecompiled: false, StorageURLs: nil, IsOfflineMode: false}, false, &library, httpfetch.NewClient(logger))
+	_, err = steplib.ActivateStep(id, stepDir, "", logger, steplib.Options{DisablePrecompiled: true, StorageURLs: nil, IsOfflineMode: false}, false, steplibrary.Client{}, httpfetch.NewClient(logger))
 	require.NoError(b, err)
 
 	packageName := "github.com/bitrise-steplib/steps-xcode-test"


### PR DESCRIPTION
[STEP-2520](https://bitrise.atlassian.net/browse/STEP-2520) · CLI side (also drops offline mode): https://github.com/bitrise-io/bitrise/pull/1357

Adds `activator.Activator`, built once per workflow run with `activator.New`, and makes `ActivateSteplibRefStep` a method on it. `ActivatePathRefStep` and `ActivateGitRefStep` stay package-level — they do no HTTP.

### One HTTP client per run

Every activation used to build **two** independent clients, each with its own transport and pool: one hard-wired inside `steplibrary.New`, one at the call site. No step reused a connection from the step before it, and the two clients in a single activation didn't share one either, despite both talking to `steplib.bitrise.io`.

The `Activator` now owns one `httpfetch.Client` and hands it to both. Measured against a local server, 10 sequential fetches:

| | connections |
|---|---|
| fresh client per call (before) | 10 |
| one shared client (after) | 1 |

`steplibrary.New` takes the fetcher as an argument instead of hard-wiring one — that's what makes the sharing possible.

### Config is supplied, not discovered

Stepman no longer reads any environment. Config is resolved once by the caller into `activator.Options`; the CLI does the mapping in `cli/step_activator.go`:

| env var (CLI-owned) | option |
|---|---|
| `BITRISE_STEPLIB_USE_API` | `Options.DisableSteplibAPI` |
| `BITRISE_STEPLIB_USE_BINARY` | `Options.DisablePrecompiled` |
| `BITRISE_STEPLIB_STORAGE_URLS` | `Options.PrecompiledStorageURLs` |

The flags are **opt-outs**, so the zero-value `Options` is what production wants (API + prebuilt executables on). Semantics are unchanged: unset leaves a feature on, `false`/`0` turns it off.

`steplib.ActivateStep` takes `steplib.Options` plus an explicit `useSteplibAPI bool`, instead of reading nil-ness of the `*steplibrary.Client` as "use the git-cloned steplib". The client is passed by value, so the flag and the client can't disagree; `steplibrary.Client` is now a documented copyable handle with value receivers.

### Why, beyond connection reuse

It gives the inventory client somewhere to hold state that outlives one activation — what an in-memory cache for the per-run-identical `step_ids.json` and `meta.json` needs. Today `step_ids.json` is the whole steplib's ID list, refetched per step to answer a `slices.Contains`. That cache is a follow-up ticket.

### Deliberately not here

- **`didStepLibUpdateInWorkflow` stays a parameter.** The CLI derives it per-steplib-source from `buildRunResults` and reads the result back; internalizing it needs a matching change there.
- **No `ctx` parameter.** `ActivateStep` still creates `context.Background()` internally. Natural follow-up, serves neither goal here.

### Breaking

Package-level `activator.ActivateSteplibRefStep` is gone, as is `OptionsFromEnv`. The Bitrise CLI is the only consumer and is migrated in #1357.

### Testing

`go build`, `go vet`, `golangci-lint` clean; `go test ./...` green, including new coverage for `useSteplibAPIFor`, `withDefaults`, the zero-value defaults and `steplib.Options.storageURLs()`. `_tests/activation` passes under `-tags integration`. Verified end to end through the CLI against the real steplib: unset takes the API path with no git clone and fetches the prebuilt binary; `USE_API=false` clones and makes zero API calls; `USE_BINARY=false` downloads no executable; `STORAGE_URLS` redirects the binary fetch at the given host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STEP-2520]: https://bitrise.atlassian.net/browse/STEP-2520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ