### PR TITLE
STEP-2404: cache inventory reads in memory for the run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,16 +16,12 @@ Key entry point is `main.go` → `cli.Run()` which sets up the CLI application w
 
 ### Step activation paths
 
-Activation goes through `activator.Activator`, built once per run with `activator.New` (see `activator/activator.go`), so every step of a run shares one HTTP client. `Options` carries the config that used to be read from env vars deep in the call stack: stepman reads no environment of its own, and the caller — the Bitrise CLI — resolves those settings and passes them in. `activator/` has two ways to resolve and download a step:
+Activation goes through `activator.Activator`, built once per run with, so every step of a run shares one HTTP client.
 
 - **Legacy git-clone path**: clones the steplib repo locally and reads spec.json. This is the codepath used for custom/self-hosted steplibs.
-- **StepLib V2 API path** (default): fetches static JSON over HTTPS (no git clone), implemented in `activator/steplib/` (`activate.go`, `source.go`) and `steplibrary/`. Used for the canonical Bitrise steplib source when `Options.UseSteplibAPI` is set — see `Activator.useSteplibAPIFor` in `activator/activator.go`. The API base URL and the shared HTTP client are passed to `steplibrary.New`. Offline mode is not supported on this path and fails explicitly: an offline run against the canonical steplib has to opt out via `Options.UseSteplibAPI` to fall back to the git-clone path.
+- **StepLib API path** (default): fetches static JSON over HTTPS (no git clone).
 
-Precompiled step executables (skip building from source) are controlled by `Options.UsePrecompiled`, with the storage URLs to try in `Options.PrecompiledStorageURLs` (defaults in `activator/steplib/activate.go`).
-
-Inventory reads go through an in-memory HTTP cache (`github.com/bartventer/httpcache`) that honours the API's `Cache-Control` and revalidates with ETags, built in `httpfetch.NewClients` and living only for the run. Step archives and precompiled executables use the second, uncached client from the same pair; both share one connection pool.
-
-The Bitrise CLI maps `BITRISE_STEPLIB_USE_API`, `BITRISE_STEPLIB_USE_BINARY` and `BITRISE_STEPLIB_STORAGE_URLS` onto those options in `cli/step_activator.go`; both feature flags default to on there and are disabled with `false`/`0`.
+Precompiled step executables (skip building from source) are controlled by `Options.UsePrecompiled`, with the storage URLs to try in `Options.PrecompiledStorageURLs`.
 
 ## Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ Activation goes through `activator.Activator`, built once per run with `activato
 
 Precompiled step executables (skip building from source) are controlled by `Options.UsePrecompiled`, with the storage URLs to try in `Options.PrecompiledStorageURLs` (defaults in `activator/steplib/activate.go`).
 
+Inventory reads go through an in-memory HTTP cache (`github.com/bartventer/httpcache`) that honours the API's `Cache-Control` and revalidates with ETags, built in `httpfetch.NewClients` and living only for the run. Step archives and precompiled executables use the second, uncached client from the same pair; both share one connection pool.
+
 The Bitrise CLI maps `BITRISE_STEPLIB_USE_API`, `BITRISE_STEPLIB_USE_BINARY` and `BITRISE_STEPLIB_STORAGE_URLS` onto those options in `cli/step_activator.go`; both feature flags default to on there and are disabled with `false`/`0`.
 
 ## Development Commands

--- a/activator/activator.go
+++ b/activator/activator.go
@@ -67,13 +67,24 @@ type Activator struct {
 // building one per step is what this constructor exists to avoid.
 func New(log stepman.Logger, opts Options) *Activator {
 	opts = withDefaults(opts)
-	fetcher := httpfetch.NewClient(log)
+
+	// The inventory client caches responses in memory; the download client
+	// does not. Both share one connection pool. The cache is an optimisation,
+	// so if it cannot be built the run continues without it rather than
+	// failing - but it says so, because a run silently paying full price for
+	// every inventory read is worth knowing about.
+	clients, err := httpfetch.NewClients(log)
+	if err != nil {
+		log.Warnf("Continuing without the in-memory inventory cache: %s", err)
+		plain := httpfetch.NewClient(log)
+		clients = httpfetch.Clients{Inventory: plain, Downloads: plain}
+	}
 
 	return &Activator{
 		log:     log,
 		opts:    opts,
-		fetcher: fetcher,
-		library: steplibrary.New(log, opts.SteplibAPIURL, fetcher),
+		fetcher: clients.Downloads,
+		library: steplibrary.New(log, opts.SteplibAPIURL, clients.Inventory),
 	}
 }
 

--- a/activator/activator.go
+++ b/activator/activator.go
@@ -67,24 +67,18 @@ type Activator struct {
 // building one per step is what this constructor exists to avoid.
 func New(log stepman.Logger, opts Options) *Activator {
 	opts = withDefaults(opts)
-
-	// The inventory client caches responses in memory; the download client
-	// does not. Both share one connection pool. The cache is an optimisation,
-	// so if it cannot be built the run continues without it rather than
-	// failing - but it says so, because a run silently paying full price for
-	// every inventory read is worth knowing about.
-	clients, err := httpfetch.NewClients(log)
+	clients, err := httpfetch.NewCachingClient(log)
 	if err != nil {
 		log.Warnf("Continuing without the in-memory inventory cache: %s", err)
 		plain := httpfetch.NewClient(log)
-		clients = httpfetch.Clients{Inventory: plain, Downloads: plain}
+		clients = httpfetch.Clients{Caching: plain, Passthrough: plain}
 	}
 
 	return &Activator{
 		log:     log,
 		opts:    opts,
-		fetcher: clients.Downloads,
-		library: steplibrary.New(log, opts.SteplibAPIURL, clients.Inventory),
+		fetcher: clients.Passthrough,
+		library: steplibrary.New(log, opts.SteplibAPIURL, clients.Caching),
 	}
 }
 

--- a/activator/activator.go
+++ b/activator/activator.go
@@ -11,18 +11,14 @@ const (
 	bitriseSteplibAPIURL = "https://steplib.bitrise.io/api"
 )
 
-// Options is the configuration of an Activator. It is resolved once, when the
-// Activator is built, rather than re-read on every step activation.
-//
-// The flags are opt-outs, so the zero value is what production wants: the
-// StepLib V2 API and prebuilt executables both on.
+// Options is the configuration of an Activator.
 type Options struct {
 	// DisableSteplibAPI routes canonical Bitrise StepLib steps through a local
-	// git clone instead of the StepLib V2 API. Custom/self-hosted StepLibs use
+	// git clone instead of the StepLib API. Custom/self-hosted StepLibs use
 	// the git-clone path either way.
 	DisableSteplibAPI bool
 
-	// SteplibAPIURL is the base URL of the StepLib V2 API. Empty means the
+	// SteplibAPIURL is the base URL of the StepLib API. Empty means the
 	// canonical Bitrise inventory.
 	SteplibAPIURL string
 
@@ -36,13 +32,11 @@ type Options struct {
 
 	// IsOfflineMode forbids network access, restricting activation to what is
 	// already in the local StepLib cache. It is not supported together with
-	// the StepLib V2 API, which has no local inventory to read from.
+	// the StepLib API, which has no local inventory to read from.
 	IsOfflineMode bool
 }
 
-// withDefaults fills in the values that Options leaves optional, so the rest of
-// the package can rely on them being set. PrecompiledStorageURLs is not among
-// them: steplib owns that list and defaults it itself.
+// withDefaults fills in the values that Options leaves optional
 func withDefaults(opts Options) Options {
 	if opts.SteplibAPIURL == "" {
 		opts.SteplibAPIURL = bitriseSteplibAPIURL
@@ -56,10 +50,7 @@ type Activator struct {
 	opts    Options
 	fetcher httpfetch.Client
 
-	// library serves the StepLib V2 inventory. Always present, including when
-	// UseSteplibAPI is off: whether a given step may use it depends on that
-	// step's StepLib source too, so the choice is made per activation rather
-	// than here. See useSteplibAPIFor.
+	// library serves the StepLib inventory
 	library steplibrary.Client
 }
 
@@ -82,9 +73,7 @@ func New(log stepman.Logger, opts Options) *Activator {
 	}
 }
 
-// useSteplibAPIFor reports whether steplibURI's steps are served by the StepLib
-// V2 API. The API only hosts the canonical Bitrise StepLib, so custom StepLibs
-// stay on the git-clone path regardless of configuration.
+// useSteplibAPIFor reports whether steplibURI's steps are served by the StepLib API.
 func (a *Activator) useSteplibAPIFor(steplibURI string) bool {
 	return !a.opts.DisableSteplibAPI && steplibURI == bitriseSteplibURL
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bitrise-io/stepman
 go 1.25.0
 
 require (
+	github.com/bartventer/httpcache v0.14.0
 	github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
 	github.com/bitrise-io/envman/v2 v2.5.2
 	github.com/bitrise-io/go-utils v1.0.13

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/bartventer/httpcache v0.14.0 h1:+gePKEpVIhJpMZmEDkd2bZYT9erVXslAbYVoc/o5H4M=
+github.com/bartventer/httpcache v0.14.0/go.mod h1:AXVAaiITDQ83wjpI8TzzLior8A9VFq0cl3chDtQRpgU=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
 github.com/bitrise-io/envman/v2 v2.5.2 h1:NRB5oq4MiYCTIE/73ui+Jnb9xM0A0aIRISIxAasdxMk=
@@ -55,8 +57,6 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/urfave/cli v1.22.14 h1:ebbhrRiGK2i4naQJr+1Xj92HXZCrK7MsyTS/ob3HnAk=
 github.com/urfave/cli v1.22.14/go.mod h1:X0eDS6pD6Exaclxm99NJ3FiCDRED7vIHpx2mDOHLvkA=
 golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
-golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -64,14 +64,10 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
-golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
-golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/httpfetch/cache.go
+++ b/internal/httpfetch/cache.go
@@ -1,0 +1,70 @@
+package httpfetch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/bartventer/httpcache"
+	_ "github.com/bartventer/httpcache/store/memcache"
+)
+
+// slogAdapter is an adapter for httpcache's logger.
+type slogAdapter struct{ l Logger }
+
+func (h slogAdapter) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h slogAdapter) Handle(_ context.Context, r slog.Record) error {
+	msg := r.Message
+	r.Attrs(func(a slog.Attr) bool {
+		msg += " " + a.String()
+		return true
+	})
+	h.l.Debugf("httpcache: %s", msg)
+	return nil
+}
+
+func (h slogAdapter) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h slogAdapter) WithGroup(string) slog.Handler      { return h }
+
+// newCachingTransport wraps upstream with the in-memory response cache.
+func newCachingTransport(logger Logger, upstream http.RoundTripper) (rt http.RoundTripper, err error) {
+	defer func() {
+		// httpcache.NewTransport panics with ErrOpenCache rather than returning an
+		// error when the store cannot be opened, so turn that one back into an error.
+		r := recover()
+		if r == nil {
+			return
+		}
+		if rerr, ok := r.(error); ok && errors.Is(rerr, httpcache.ErrOpenCache) {
+			rt, err = nil, fmt.Errorf("open in-memory HTTP cache: %w", rerr)
+			return
+		}
+		panic(r)
+	}()
+	return httpcache.NewTransport(
+		"memcache://",
+		httpcache.WithUpstream(cacheSuccessesOnly{upstream: upstream}),
+		httpcache.WithLogger(slog.New(slogAdapter{l: logger})),
+	), nil
+}
+
+// cacheSuccessesOnly stops the cache storing anything but a 2xx, like a temporary status 502
+type cacheSuccessesOnly struct{ upstream http.RoundTripper }
+
+func (c cacheSuccessesOnly) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := c.upstream.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	// 304 is how revalidation succeeds, forward it
+	if resp.StatusCode == http.StatusNotModified {
+		return resp, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		resp.Header.Set("Cache-Control", "no-store")
+	}
+	return resp, nil
+}

--- a/internal/httpfetch/cache_test.go
+++ b/internal/httpfetch/cache_test.go
@@ -185,14 +185,14 @@ func TestCacheKeyedPerURL(t *testing.T) {
 // asserting against a separately built client would pass even if NewClients
 // wired the cache to the wrong half.
 func TestNewClientsCachesInventoryOnly(t *testing.T) {
-	clients, err := NewClients(testLogger{t})
+	clients, err := NewCachingClient(testLogger{t})
 	require.NoError(t, err)
 
 	t.Run("inventory caches", func(t *testing.T) {
 		origin := &inventoryServer{cacheControl: "public, max-age=60, must-revalidate", etag: `"v1"`, body: `{"step_ids":["script"]}`}
 		srv := origin.start(t)
 		for range 3 {
-			require.Equal(t, `{"step_ids":["script"]}`, getBody(t, clients.Inventory, srv.URL))
+			require.Equal(t, `{"step_ids":["script"]}`, getBody(t, clients.Caching, srv.URL))
 		}
 		require.EqualValues(t, 1, origin.hits.Load(), "the inventory client must serve repeats from cache")
 	})
@@ -203,7 +203,7 @@ func TestNewClientsCachesInventoryOnly(t *testing.T) {
 		origin := &inventoryServer{cacheControl: "public, max-age=60, must-revalidate", etag: `"v1"`, body: "binary-ish"}
 		srv := origin.start(t)
 		for range 3 {
-			require.Equal(t, "binary-ish", getBody(t, clients.Downloads, srv.URL))
+			require.Equal(t, "binary-ish", getBody(t, clients.Passthrough, srv.URL))
 		}
 		require.EqualValues(t, 3, origin.hits.Load(), "step archives and executables must never be held in memory")
 	})

--- a/internal/httpfetch/cache_test.go
+++ b/internal/httpfetch/cache_test.go
@@ -53,7 +53,7 @@ func (s *inventoryServer) start(t *testing.T) *httptest.Server {
 // mirroring NewClients' wiring: the cache sits above the server's transport.
 func cachingClientFor(t *testing.T, srv *httptest.Server) Client {
 	t.Helper()
-	rt, err := newCachingTransport(srv.Client().Transport)
+	rt, err := newCachingTransport(testLogger{t}, srv.Client().Transport)
 	require.NoError(t, err)
 	return NewWithClient(&http.Client{Transport: rt})
 }

--- a/internal/httpfetch/cache_test.go
+++ b/internal/httpfetch/cache_test.go
@@ -1,0 +1,163 @@
+package httpfetch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bartventer/httpcache"
+	"github.com/stretchr/testify/require"
+)
+
+// inventoryServer serves body under the given Cache-Control with a fixed ETag,
+// counting how many requests actually reach it and answering 304 to a matching
+// If-None-Match. It stands in for the StepLib V2 API, whose real headers are
+// max-age=60/300 with must-revalidate on the index files and immutable on
+// step.json.
+type inventoryServer struct {
+	hits         atomic.Int32
+	conditionals atomic.Int32
+	cacheControl string
+	etag         string
+	body         string
+}
+
+func (s *inventoryServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.hits.Add(1)
+		w.Header().Set("Cache-Control", s.cacheControl)
+		w.Header().Set("ETag", s.etag)
+		if r.Header.Get("If-None-Match") == s.etag {
+			s.conditionals.Add(1)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		if _, err := fmt.Fprint(w, s.body); err != nil {
+			t.Errorf("write test response: %s", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// cachingClientFor builds the Inventory client but pointed at a test server,
+// mirroring NewClients' wiring: the cache sits above the server's transport.
+func cachingClientFor(t *testing.T, srv *httptest.Server) (Client, func(*http.Response) string) {
+	t.Helper()
+	rt, err := newCachingTransport(srv.Client().Transport)
+	require.NoError(t, err)
+	status := func(resp *http.Response) string { return resp.Header.Get(httpcache.CacheStatusHeader) }
+	return NewWithClient(&http.Client{Transport: rt}), status
+}
+
+func getBody(t *testing.T, c Client, url string) string {
+	t.Helper()
+	body, err := c.Get(context.Background(), url)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, body.Close()) }()
+	b, err := io.ReadAll(body)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// A fresh entry is served without touching the origin at all: this is the case
+// that removes most of a run's inventory requests.
+func TestCacheServesFreshWithoutOrigin(t *testing.T) {
+	origin := &inventoryServer{cacheControl: "public, max-age=60, must-revalidate", etag: `"v1"`, body: `{"step_ids":["script"]}`}
+	srv := origin.start(t)
+	c, _ := cachingClientFor(t, srv)
+
+	for range 5 {
+		require.Equal(t, `{"step_ids":["script"]}`, getBody(t, c, srv.URL))
+	}
+	require.EqualValues(t, 1, origin.hits.Load(), "five reads of a fresh object must hit the origin once")
+	require.EqualValues(t, 0, origin.conditionals.Load(), "a fresh entry must not be revalidated")
+}
+
+// An expired entry revalidates with If-None-Match and takes the 304, which the
+// transport turns back into a usable 200 - httpfetch.Get rejects any non-2xx,
+// so a 304 reaching it would surface as a StatusError.
+func TestCacheRevalidatesWithETagAnd304(t *testing.T) {
+	origin := &inventoryServer{cacheControl: "public, max-age=0, must-revalidate", etag: `"v1"`, body: `{"step_ids":["script"]}`}
+	srv := origin.start(t)
+	c, _ := cachingClientFor(t, srv)
+
+	require.Equal(t, `{"step_ids":["script"]}`, getBody(t, c, srv.URL))
+	// Immediately stale (max-age=0), so the next read must revalidate and
+	// still return the body from cache rather than erroring on the 304.
+	require.Equal(t, `{"step_ids":["script"]}`, getBody(t, c, srv.URL))
+
+	require.EqualValues(t, 1, origin.conditionals.Load(), "the second read must send If-None-Match")
+	require.EqualValues(t, 2, origin.hits.Load())
+}
+
+// step.json is published immutable, so it must never be revalidated.
+func TestCacheNeverRevalidatesImmutable(t *testing.T) {
+	origin := &inventoryServer{cacheControl: "public, max-age=86400, immutable", etag: `"v1"`, body: `{"title":"Script"}`}
+	srv := origin.start(t)
+	c, _ := cachingClientFor(t, srv)
+
+	for range 3 {
+		require.Equal(t, `{"title":"Script"}`, getBody(t, c, srv.URL))
+	}
+	require.EqualValues(t, 1, origin.hits.Load())
+	require.EqualValues(t, 0, origin.conditionals.Load())
+}
+
+// Distinct URLs are distinct entries - a cache that collapsed them would serve
+// one step's metadata for another.
+func TestCacheKeyedPerURL(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		if _, err := fmt.Fprintf(w, `{"path":%q}`, r.URL.Path); err != nil {
+			t.Errorf("write test response: %s", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, _ := cachingClientFor(t, srv)
+
+	require.Equal(t, `{"path":"/a.json"}`, getBody(t, c, srv.URL+"/a.json"))
+	require.Equal(t, `{"path":"/b.json"}`, getBody(t, c, srv.URL+"/b.json"))
+	require.Equal(t, `{"path":"/a.json"}`, getBody(t, c, srv.URL+"/a.json"))
+	require.EqualValues(t, 2, hits.Load(), "two distinct URLs, and the repeat served from cache")
+}
+
+// The two clients NewClients actually returns must differ: the inventory one
+// caches, the downloads one does not. Exercising the real pair matters here -
+// asserting against a separately built client would pass even if NewClients
+// wired the cache to the wrong half.
+func TestNewClientsCachesInventoryOnly(t *testing.T) {
+	clients, err := NewClients(testLogger{t})
+	require.NoError(t, err)
+
+	t.Run("inventory caches", func(t *testing.T) {
+		origin := &inventoryServer{cacheControl: "public, max-age=60, must-revalidate", etag: `"v1"`, body: `{"step_ids":["script"]}`}
+		srv := origin.start(t)
+		for range 3 {
+			require.Equal(t, `{"step_ids":["script"]}`, getBody(t, clients.Inventory, srv.URL))
+		}
+		require.EqualValues(t, 1, origin.hits.Load(), "the inventory client must serve repeats from cache")
+	})
+
+	t.Run("downloads do not cache", func(t *testing.T) {
+		// Same headers the inventory server sends, so the only thing that can
+		// account for a difference is which client is used.
+		origin := &inventoryServer{cacheControl: "public, max-age=60, must-revalidate", etag: `"v1"`, body: "binary-ish"}
+		srv := origin.start(t)
+		for range 3 {
+			require.Equal(t, "binary-ish", getBody(t, clients.Downloads, srv.URL))
+		}
+		require.EqualValues(t, 3, origin.hits.Load(), "step archives and executables must never be held in memory")
+	})
+}
+
+type testLogger struct{ t *testing.T }
+
+func (l testLogger) Debugf(format string, v ...any) { l.t.Logf(format, v...) }

--- a/internal/httpfetch/cache_test.go
+++ b/internal/httpfetch/cache_test.go
@@ -15,14 +15,11 @@ import (
 
 // inventoryServer serves body under the given Cache-Control with a fixed ETag,
 // counting how many requests actually reach it and answering 304 to a matching
-// If-None-Match. It stands in for the StepLib V2 API, whose real headers are
-// max-age=60/300 with must-revalidate on the index files and immutable on
-// step.json.
+// If-None-Match.
 type inventoryServer struct {
 	hits         atomic.Int32
 	conditionals atomic.Int32
 	cacheControl string
-	age          string // optional Age header, as the CDN sends for edge-resident objects
 	etag         string
 	body         string
 }
@@ -32,9 +29,6 @@ func (s *inventoryServer) start(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.hits.Add(1)
 		w.Header().Set("Cache-Control", s.cacheControl)
-		if s.age != "" {
-			w.Header().Set("Age", s.age)
-		}
 		w.Header().Set("ETag", s.etag)
 		if r.Header.Get("If-None-Match") == s.etag {
 			s.conditionals.Add(1)
@@ -49,13 +43,13 @@ func (s *inventoryServer) start(t *testing.T) *httptest.Server {
 	return srv
 }
 
-// cachingClientFor builds the Inventory client but pointed at a test server,
-// mirroring NewClients' wiring: the cache sits above the server's transport.
+// cachingClientFor builds the caching client but pointed at a test server, so
+// the cache sits above the server's transport instead of the retrying one.
 func cachingClientFor(t *testing.T, srv *httptest.Server) Client {
 	t.Helper()
-	rt, err := newCachingTransport(testLogger{t}, srv.Client().Transport)
+	c, err := NewCachingWithClient(testLogger{t}, srv.Client())
 	require.NoError(t, err)
-	return NewWithClient(&http.Client{Transport: rt})
+	return c
 }
 
 // getStatus reads the body and the cache's own verdict on the request, so a
@@ -83,6 +77,10 @@ func getBody(t *testing.T, c Client, url string) string {
 	require.NoError(t, err)
 	return string(b)
 }
+
+type testLogger struct{ t *testing.T }
+
+func (l testLogger) Debugf(format string, v ...any) { l.t.Logf(format, v...) }
 
 // A fresh entry is served without touching the origin at all: this is the case
 // that removes most of a run's inventory requests.
@@ -136,139 +134,69 @@ func TestCacheNeverRevalidatesFreshImmutable(t *testing.T) {
 	require.EqualValues(t, 0, origin.conditionals.Load())
 }
 
-// ...but that is not what production looks like. step.json is published
-// "max-age=86400, s-maxage=31536000, immutable", and the CDN holds it at the
-// edge for up to a year, so it arrives with an Age of several days - already
-// stale, and immutable cannot apply to a response that was never fresh. Pin
-// the behaviour we actually get, so this test does not quietly claim a win we
-// do not have. See STEP-2527.
-func TestImmutableIsStaleOnArrivalWithLargeAge(t *testing.T) {
-	origin := &inventoryServer{
-		cacheControl: "public, max-age=86400, s-maxage=31536000, immutable",
-		age:          "342124", // ~4 days, measured on v2/steps/script/1.2.1/step.json
-		etag:         `"v1"`,
-		body:         `{"title":"Script"}`,
-	}
-	srv := origin.start(t)
-	c := cachingClientFor(t, srv)
-
-	require.Equal(t, `{"title":"Script"}`, getBody(t, c, srv.URL))
-	body, status := getStatus(t, c, srv.URL)
-	require.Equal(t, `{"title":"Script"}`, body, "the body is still correct")
-	require.Equal(t, "REVALIDATED", status,
-		"Age exceeds max-age, so every read revalidates - immutable never takes effect")
-	require.EqualValues(t, 1, origin.conditionals.Load())
-}
-
-// Distinct URLs are distinct entries - a cache that collapsed them would serve
-// one step's metadata for another.
-func TestCacheKeyedPerURL(t *testing.T) {
-	var hits atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hits.Add(1)
-		w.Header().Set("Cache-Control", "public, max-age=60")
-		if _, err := fmt.Fprintf(w, `{"path":%q}`, r.URL.Path); err != nil {
-			t.Errorf("write test response: %s", err)
-		}
-	}))
-	t.Cleanup(srv.Close)
-	c := cachingClientFor(t, srv)
-
-	require.Equal(t, `{"path":"/a.json"}`, getBody(t, c, srv.URL+"/a.json"))
-	require.Equal(t, `{"path":"/b.json"}`, getBody(t, c, srv.URL+"/b.json"))
-	require.Equal(t, `{"path":"/a.json"}`, getBody(t, c, srv.URL+"/a.json"))
-	require.EqualValues(t, 2, hits.Load(), "two distinct URLs, and the repeat served from cache")
-}
-
-// The two clients NewClients actually returns must differ: the inventory one
-// caches, the downloads one does not. Exercising the real pair matters here -
-// asserting against a separately built client would pass even if NewClients
-// wired the cache to the wrong half.
-func TestNewClientsCachesInventoryOnly(t *testing.T) {
+// NewCachingClient must wire the cache to the right half of the pair: inventory
+// reads are cached, step archives and executables never are.
+func TestNewCachingClientCachesInventoryOnly(t *testing.T) {
 	clients, err := NewCachingClient(testLogger{t})
 	require.NoError(t, err)
 
-	t.Run("inventory caches", func(t *testing.T) {
-		origin := &inventoryServer{cacheControl: "public, max-age=60, must-revalidate", etag: `"v1"`, body: `{"step_ids":["script"]}`}
-		srv := origin.start(t)
-		for range 3 {
-			require.Equal(t, `{"step_ids":["script"]}`, getBody(t, clients.Caching, srv.URL))
-		}
-		require.EqualValues(t, 1, origin.hits.Load(), "the inventory client must serve repeats from cache")
-	})
+	for _, tt := range []struct {
+		name     string
+		client   Client
+		wantHits int
+	}{
+		{"inventory caches", clients.Caching, 1},
+		{"downloads do not cache", clients.Passthrough, 3},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			origin := &inventoryServer{cacheControl: "public, max-age=60, must-revalidate", etag: `"v1"`, body: `{"step_ids":["script"]}`}
+			srv := origin.start(t)
 
-	t.Run("downloads do not cache", func(t *testing.T) {
-		// Same headers the inventory server sends, so the only thing that can
-		// account for a difference is which client is used.
-		origin := &inventoryServer{cacheControl: "public, max-age=60, must-revalidate", etag: `"v1"`, body: "binary-ish"}
-		srv := origin.start(t)
-		for range 3 {
-			require.Equal(t, "binary-ish", getBody(t, clients.Passthrough, srv.URL))
-		}
-		require.EqualValues(t, 3, origin.hits.Load(), "step archives and executables must never be held in memory")
-	})
-}
-
-type testLogger struct{ t *testing.T }
-
-func (l testLogger) Debugf(format string, v ...any) { l.t.Logf(format, v...) }
-
-// A failing origin must not be cached. retryablehttp is configured with
-// PassthroughErrorHandler, so a 5xx that outlives the retries arrives as a
-// normal response; if the origin's error page carries a freshness directive,
-// an unguarded cache would store it and replay it for the whole run.
-func TestCacheDoesNotStoreErrorResponses(t *testing.T) {
-	var hits atomic.Int32
-	var failing atomic.Bool
-	failing.Store(true)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hits.Add(1)
-		// The same freshness the real inventory paths advertise.
-		w.Header().Set("Cache-Control", "public, max-age=60, must-revalidate")
-		if failing.Load() {
-			w.WriteHeader(http.StatusBadGateway)
-			if _, err := fmt.Fprint(w, "<html>502</html>"); err != nil {
-				t.Errorf("write test response: %s", err)
+			for range 3 {
+				require.Equal(t, `{"step_ids":["script"]}`, getBody(t, tt.client, srv.URL))
 			}
-			return
-		}
-		if _, err := fmt.Fprint(w, `{"step_ids":["script"]}`); err != nil {
-			t.Errorf("write test response: %s", err)
-		}
-	}))
-	t.Cleanup(srv.Close)
-	c := cachingClientFor(t, srv)
-
-	// Two failing reads: the second must reach the origin, not be served the
-	// stored 502.
-	for range 2 {
-		_, err := c.Get(context.Background(), srv.URL)
-		require.Error(t, err)
+			require.EqualValues(t, tt.wantHits, origin.hits.Load(), "three reads through %s", tt.name)
+		})
 	}
-	require.EqualValues(t, 2, hits.Load(), "a 502 must not be cached and replayed")
-
-	// Once the origin recovers, the very next read must succeed - a pinned
-	// error would keep failing here for the rest of its freshness window.
-	failing.Store(false)
-	require.Equal(t, `{"step_ids":["script"]}`, getBody(t, c, srv.URL))
-	require.EqualValues(t, 3, hits.Load())
 }
 
-// A 404 is a real answer from the inventory (an unknown step or version) but
-// still must not be stored, for the same reason.
-func TestCacheDoesNotStoreNotFound(t *testing.T) {
-	var hits atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hits.Add(1)
-		w.Header().Set("Cache-Control", "public, max-age=60")
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	t.Cleanup(srv.Close)
-	c := cachingClientFor(t, srv)
+// A failing origin must not be cached. retryablehttp uses PassthroughErrorHandler,
+// so a 5xx that outlives the retries arrives as a normal response, and a 404 is a
+// legitimate inventory answer (unknown step or version). Either one carries the
+// inventory's freshness directive, so an unguarded cache would store it and replay
+// it for the rest of the run.
+func TestCacheDoesNotStoreFailures(t *testing.T) {
+	for _, status := range []int{http.StatusBadGateway, http.StatusNotFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var hits atomic.Int32
+			var failing atomic.Bool
+			failing.Store(true)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				hits.Add(1)
+				w.Header().Set("Cache-Control", "public, max-age=60, must-revalidate")
+				if failing.Load() {
+					w.WriteHeader(status)
+					return
+				}
+				if _, err := fmt.Fprint(w, `{"step_ids":["script"]}`); err != nil {
+					t.Errorf("write test response: %s", err)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			c := cachingClientFor(t, srv)
 
-	for range 2 {
-		_, err := c.Get(context.Background(), srv.URL)
-		require.Error(t, err)
+			// The second read must reach the origin rather than be served the stored failure.
+			for range 2 {
+				_, err := c.Get(context.Background(), srv.URL)
+				require.Error(t, err)
+			}
+			require.EqualValues(t, 2, hits.Load(), "a failure must not be cached and replayed")
+
+			// Once the origin recovers the very next read must succeed - a pinned
+			// failure would keep failing for the rest of its freshness window.
+			failing.Store(false)
+			require.Equal(t, `{"step_ids":["script"]}`, getBody(t, c, srv.URL))
+			require.EqualValues(t, 3, hits.Load())
+		})
 	}
-	require.EqualValues(t, 2, hits.Load(), "a 404 must not be cached and replayed")
 }

--- a/internal/httpfetch/cache_test.go
+++ b/internal/httpfetch/cache_test.go
@@ -22,6 +22,7 @@ type inventoryServer struct {
 	hits         atomic.Int32
 	conditionals atomic.Int32
 	cacheControl string
+	age          string // optional Age header, as the CDN sends for edge-resident objects
 	etag         string
 	body         string
 }
@@ -31,6 +32,9 @@ func (s *inventoryServer) start(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.hits.Add(1)
 		w.Header().Set("Cache-Control", s.cacheControl)
+		if s.age != "" {
+			w.Header().Set("Age", s.age)
+		}
 		w.Header().Set("ETag", s.etag)
 		if r.Header.Get("If-None-Match") == s.etag {
 			s.conditionals.Add(1)
@@ -47,12 +51,27 @@ func (s *inventoryServer) start(t *testing.T) *httptest.Server {
 
 // cachingClientFor builds the Inventory client but pointed at a test server,
 // mirroring NewClients' wiring: the cache sits above the server's transport.
-func cachingClientFor(t *testing.T, srv *httptest.Server) (Client, func(*http.Response) string) {
+func cachingClientFor(t *testing.T, srv *httptest.Server) Client {
 	t.Helper()
 	rt, err := newCachingTransport(srv.Client().Transport)
 	require.NoError(t, err)
-	status := func(resp *http.Response) string { return resp.Header.Get(httpcache.CacheStatusHeader) }
-	return NewWithClient(&http.Client{Transport: rt}), status
+	return NewWithClient(&http.Client{Transport: rt})
+}
+
+// getStatus reads the body and the cache's own verdict on the request, so a
+// test can assert HIT/MISS directly rather than inferring it from how many
+// requests reached the origin.
+func getStatus(t *testing.T, c Client, url string) (string, string) {
+	t.Helper()
+	rt := c.(*client).httpClient.Transport
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(b), resp.Header.Get(httpcache.CacheStatusHeader)
 }
 
 func getBody(t *testing.T, c Client, url string) string {
@@ -70,10 +89,16 @@ func getBody(t *testing.T, c Client, url string) string {
 func TestCacheServesFreshWithoutOrigin(t *testing.T) {
 	origin := &inventoryServer{cacheControl: "public, max-age=60, must-revalidate", etag: `"v1"`, body: `{"step_ids":["script"]}`}
 	srv := origin.start(t)
-	c, _ := cachingClientFor(t, srv)
+	c := cachingClientFor(t, srv)
 
-	for range 5 {
-		require.Equal(t, `{"step_ids":["script"]}`, getBody(t, c, srv.URL))
+	body, status := getStatus(t, c, srv.URL)
+	require.Equal(t, `{"step_ids":["script"]}`, body)
+	require.Equal(t, "MISS", status, "the first read has nothing to serve")
+
+	for range 4 {
+		body, status = getStatus(t, c, srv.URL)
+		require.Equal(t, `{"step_ids":["script"]}`, body)
+		require.Equal(t, "HIT", status)
 	}
 	require.EqualValues(t, 1, origin.hits.Load(), "five reads of a fresh object must hit the origin once")
 	require.EqualValues(t, 0, origin.conditionals.Load(), "a fresh entry must not be revalidated")
@@ -85,28 +110,54 @@ func TestCacheServesFreshWithoutOrigin(t *testing.T) {
 func TestCacheRevalidatesWithETagAnd304(t *testing.T) {
 	origin := &inventoryServer{cacheControl: "public, max-age=0, must-revalidate", etag: `"v1"`, body: `{"step_ids":["script"]}`}
 	srv := origin.start(t)
-	c, _ := cachingClientFor(t, srv)
+	c := cachingClientFor(t, srv)
 
 	require.Equal(t, `{"step_ids":["script"]}`, getBody(t, c, srv.URL))
 	// Immediately stale (max-age=0), so the next read must revalidate and
 	// still return the body from cache rather than erroring on the 304.
-	require.Equal(t, `{"step_ids":["script"]}`, getBody(t, c, srv.URL))
+	body, status := getStatus(t, c, srv.URL)
+	require.Equal(t, `{"step_ids":["script"]}`, body)
+	require.Equal(t, "REVALIDATED", status)
 
 	require.EqualValues(t, 1, origin.conditionals.Load(), "the second read must send If-None-Match")
 	require.EqualValues(t, 2, origin.hits.Load())
 }
 
-// step.json is published immutable, so it must never be revalidated.
-func TestCacheNeverRevalidatesImmutable(t *testing.T) {
+// An immutable response that is still fresh is served without revalidating.
+func TestCacheNeverRevalidatesFreshImmutable(t *testing.T) {
 	origin := &inventoryServer{cacheControl: "public, max-age=86400, immutable", etag: `"v1"`, body: `{"title":"Script"}`}
 	srv := origin.start(t)
-	c, _ := cachingClientFor(t, srv)
+	c := cachingClientFor(t, srv)
 
 	for range 3 {
 		require.Equal(t, `{"title":"Script"}`, getBody(t, c, srv.URL))
 	}
 	require.EqualValues(t, 1, origin.hits.Load())
 	require.EqualValues(t, 0, origin.conditionals.Load())
+}
+
+// ...but that is not what production looks like. step.json is published
+// "max-age=86400, s-maxage=31536000, immutable", and the CDN holds it at the
+// edge for up to a year, so it arrives with an Age of several days - already
+// stale, and immutable cannot apply to a response that was never fresh. Pin
+// the behaviour we actually get, so this test does not quietly claim a win we
+// do not have. See STEP-2527.
+func TestImmutableIsStaleOnArrivalWithLargeAge(t *testing.T) {
+	origin := &inventoryServer{
+		cacheControl: "public, max-age=86400, s-maxage=31536000, immutable",
+		age:          "342124", // ~4 days, measured on v2/steps/script/1.2.1/step.json
+		etag:         `"v1"`,
+		body:         `{"title":"Script"}`,
+	}
+	srv := origin.start(t)
+	c := cachingClientFor(t, srv)
+
+	require.Equal(t, `{"title":"Script"}`, getBody(t, c, srv.URL))
+	body, status := getStatus(t, c, srv.URL)
+	require.Equal(t, `{"title":"Script"}`, body, "the body is still correct")
+	require.Equal(t, "REVALIDATED", status,
+		"Age exceeds max-age, so every read revalidates - immutable never takes effect")
+	require.EqualValues(t, 1, origin.conditionals.Load())
 }
 
 // Distinct URLs are distinct entries - a cache that collapsed them would serve
@@ -121,7 +172,7 @@ func TestCacheKeyedPerURL(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	c, _ := cachingClientFor(t, srv)
+	c := cachingClientFor(t, srv)
 
 	require.Equal(t, `{"path":"/a.json"}`, getBody(t, c, srv.URL+"/a.json"))
 	require.Equal(t, `{"path":"/b.json"}`, getBody(t, c, srv.URL+"/b.json"))
@@ -161,3 +212,63 @@ func TestNewClientsCachesInventoryOnly(t *testing.T) {
 type testLogger struct{ t *testing.T }
 
 func (l testLogger) Debugf(format string, v ...any) { l.t.Logf(format, v...) }
+
+// A failing origin must not be cached. retryablehttp is configured with
+// PassthroughErrorHandler, so a 5xx that outlives the retries arrives as a
+// normal response; if the origin's error page carries a freshness directive,
+// an unguarded cache would store it and replay it for the whole run.
+func TestCacheDoesNotStoreErrorResponses(t *testing.T) {
+	var hits atomic.Int32
+	var failing atomic.Bool
+	failing.Store(true)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		// The same freshness the real inventory paths advertise.
+		w.Header().Set("Cache-Control", "public, max-age=60, must-revalidate")
+		if failing.Load() {
+			w.WriteHeader(http.StatusBadGateway)
+			if _, err := fmt.Fprint(w, "<html>502</html>"); err != nil {
+				t.Errorf("write test response: %s", err)
+			}
+			return
+		}
+		if _, err := fmt.Fprint(w, `{"step_ids":["script"]}`); err != nil {
+			t.Errorf("write test response: %s", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c := cachingClientFor(t, srv)
+
+	// Two failing reads: the second must reach the origin, not be served the
+	// stored 502.
+	for range 2 {
+		_, err := c.Get(context.Background(), srv.URL)
+		require.Error(t, err)
+	}
+	require.EqualValues(t, 2, hits.Load(), "a 502 must not be cached and replayed")
+
+	// Once the origin recovers, the very next read must succeed - a pinned
+	// error would keep failing here for the rest of its freshness window.
+	failing.Store(false)
+	require.Equal(t, `{"step_ids":["script"]}`, getBody(t, c, srv.URL))
+	require.EqualValues(t, 3, hits.Load())
+}
+
+// A 404 is a real answer from the inventory (an unknown step or version) but
+// still must not be stored, for the same reason.
+func TestCacheDoesNotStoreNotFound(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	c := cachingClientFor(t, srv)
+
+	for range 2 {
+		_, err := c.Get(context.Background(), srv.URL)
+		require.Error(t, err)
+	}
+	require.EqualValues(t, 2, hits.Load(), "a 404 must not be cached and replayed")
+}

--- a/internal/httpfetch/httpfetch.go
+++ b/internal/httpfetch/httpfetch.go
@@ -16,17 +16,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"log/slog"
-
-	"github.com/bartventer/httpcache"
-	// Registers the "memcache" store scheme used by inventoryCacheDSN.
 	_ "github.com/bartventer/httpcache/store/memcache"
 	"github.com/hashicorp/go-retryablehttp"
 )
-
-// inventoryCacheDSN selects the library's in-memory store. Nothing is written
-// to disk: the cache lives and dies with the process.
-const inventoryCacheDSN = "memcache://"
 
 // Client streams or atomically downloads HTTP resources. Implementations
 // returned by NewClient retry transient failures on both Get and Download.
@@ -46,35 +38,20 @@ type Client interface {
 	DownloadWithHash(ctx context.Context, destPath, url, expectedHash string) error
 }
 
+// Clients are a pair of caching and passthrough clients.
+// They share one connection pool, for performance.
+type Clients struct {
+	// Caching reads through a HTTP cache that honours Cache-Control and revalidates with ETags.
+	Caching Client
+	// Passthrough fetches step archives and precompiled executables, uncached.
+	Passthrough Client
+}
+
 // Logger is the minimal logging interface Client needs; the retry adapter only
 // emits debug lines.
 type Logger interface {
 	Debugf(format string, v ...any)
 }
-
-// slogHandler routes the cache library's slog output to our Logger, so cache
-// hits, misses and revalidations show up under --debug alongside everything
-// else. Without it the library defaults to a discard handler and the cache is
-// invisible in exactly the situation someone would be debugging.
-type slogHandler struct{ l Logger }
-
-func (h slogHandler) Enabled(context.Context, slog.Level) bool { return true }
-
-func (h slogHandler) Handle(_ context.Context, r slog.Record) error {
-	msg := r.Message
-	r.Attrs(func(a slog.Attr) bool {
-		msg += " " + a.String()
-		return true
-	})
-	h.l.Debugf("httpcache: %s", msg)
-	return nil
-}
-
-// WithAttrs and WithGroup are required by slog.Handler. The cache's output is
-// flat debug lines, so grouping buys nothing and the receiver is returned
-// unchanged rather than building a tree we would only flatten again.
-func (h slogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
-func (h slogHandler) WithGroup(string) slog.Handler      { return h }
 
 // retryhttpLogger adapts Logger to the retryablehttp.Logger interface (Printf only).
 type retryhttpLogger struct{ l Logger }
@@ -85,9 +62,7 @@ type client struct {
 	httpClient *http.Client
 }
 
-// NewClient returns a Client backed by a retryablehttp client, so callers get
-// transient-failure retries by default. Use NewWithClient to supply a specific
-// *http.Client (e.g. a test server's client).
+// NewClient returns a Client backed by a retryablehttp client.
 func NewClient(logger Logger) Client {
 	rc := retryablehttp.NewClient()
 	rc.Logger = &retryhttpLogger{l: logger}
@@ -95,106 +70,31 @@ func NewClient(logger Logger) Client {
 	return &client{httpClient: rc.StandardClient()}
 }
 
-// Clients are the two HTTP clients a stepman run needs. They share one
-// retryablehttp client, and therefore one connection pool, so every request a
-// run makes can reuse the same connections.
-//
-// They are a struct rather than two return values because both have the same
-// type: a transposed pair would compile and then quietly cache the wrong half.
-type Clients struct {
-	// Inventory reads StepLib V2 inventory JSON through an in-memory HTTP
-	// cache that honours Cache-Control and revalidates with ETags. The
-	// inventory is small and every step re-reads it, so this is where the
-	// caching pays.
-	Inventory Client
-
-	// Downloads fetches step archives and precompiled executables, uncached.
-	// They are large, immutable, already hash-verified, and land at their own
-	// paths, so holding them in memory would cost a lot and save nothing.
-	Downloads Client
-}
-
-// NewClients builds the pair over a single shared connection pool.
-func NewClients(logger Logger) (Clients, error) {
+// NewCachingClient returns both a caching and passthrough client sharing a connection pool
+func NewCachingClient(logger Logger) (Clients, error) {
 	rc := retryablehttp.NewClient()
 	rc.Logger = &retryhttpLogger{l: logger}
 	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
 
-	// StandardClient returns a fresh *http.Client each call, both backed by
-	// this one retryablehttp client - which is where the connection pool
-	// lives, so the two share it.
-	downloads := rc.StandardClient()
-	inventory := rc.StandardClient()
+	// StandardClient returns a fresh *http.Client each call
+	caching := rc.StandardClient()
+	passthrough := rc.StandardClient()
 
-	// The cache sits above the retries: a hit returns without entering the
-	// retry machinery, while a revalidation still gets retried on 5xx.
-	cached, err := newCachingTransport(logger, downloads.Transport)
+	// The cache sits above the retryablehttp (so 500 status is retried)
+	cached, err := newCachingTransport(logger, caching.Transport)
 	if err != nil {
 		return Clients{}, err
 	}
-	inventory.Transport = cached
+	passthrough.Transport = cached
 
 	return Clients{
-		Inventory: &client{httpClient: inventory},
-		Downloads: &client{httpClient: downloads},
+		Caching:     &client{httpClient: passthrough},
+		Passthrough: &client{httpClient: caching},
 	}, nil
 }
 
-// newCachingTransport wraps upstream with the in-memory response cache.
-// httpcache.NewTransport panics with ErrOpenCache rather than returning an
-// error when the store cannot be opened, so turn that one back into an error:
-// a cache that is only an optimisation must not take down a build. Anything
-// else is a genuine bug and keeps its stack.
-func newCachingTransport(logger Logger, upstream http.RoundTripper) (rt http.RoundTripper, err error) {
-	defer func() {
-		r := recover()
-		if r == nil {
-			return
-		}
-		if rerr, ok := r.(error); ok && errors.Is(rerr, httpcache.ErrOpenCache) {
-			rt, err = nil, fmt.Errorf("open in-memory HTTP cache: %w", rerr)
-			return
-		}
-		panic(r)
-	}()
-	return httpcache.NewTransport(
-		inventoryCacheDSN,
-		httpcache.WithUpstream(cacheSuccessesOnly{upstream: upstream}),
-		httpcache.WithLogger(slog.New(slogHandler{l: logger})),
-	), nil
-}
-
-// cacheSuccessesOnly stops the cache storing anything but a 2xx.
-//
-// The cache stores any final status carrying a freshness indicator, and
-// retryablehttp is configured with PassthroughErrorHandler, so a 502 that
-// survives the retries is handed back as a normal response. If the origin's
-// error page carries the same "max-age=60" the inventory paths use, that 502
-// gets stored and served as fresh for the next minute - with no request and no
-// retries - so one blip fails every remaining step of the run instead of one.
-//
-// Marking non-2xx responses no-store keeps them out. It does not change what
-// the caller sees: httpfetch.Get rejects every non-2xx anyway.
-type cacheSuccessesOnly struct{ upstream http.RoundTripper }
-
-func (c cacheSuccessesOnly) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err := c.upstream.RoundTrip(req)
-	if err != nil || resp == nil {
-		return resp, err
-	}
-	// 304 is how revalidation succeeds; the cache consumes it and must not be
-	// told to discard the entry it belongs to.
-	if resp.StatusCode == http.StatusNotModified {
-		return resp, nil
-	}
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		resp.Header.Set("Cache-Control", "no-store")
-	}
-	return resp, nil
-}
-
-// NewWithClient returns a Client backed by the given httpClient, which must be
-// non-nil. Prefer NewClient unless you need a specific transport.
+// NewWithClient returns a Client backed by the given httpClient.
+// Prefer NewClient unless you need a specific transport.
 func NewWithClient(httpClient *http.Client) Client {
 	return &client{httpClient: httpClient}
 }
@@ -221,8 +121,7 @@ func (c *client) Get(ctx context.Context, url string) (io.ReadCloser, error) {
 
 // StatusError is returned by Get when the server responds with a non-2xx
 // status, so callers can branch on the code (e.g. treat 404 as "not found")
-// via errors.As. Body holds a bounded snippet of the response body, which
-// usually explains the failure (a 404 page, S3's XML error, …).
+// via errors.As.
 type StatusError struct {
 	URL  string
 	Code int

--- a/internal/httpfetch/httpfetch.go
+++ b/internal/httpfetch/httpfetch.go
@@ -64,33 +64,34 @@ type client struct {
 
 // NewClient returns a Client backed by a retryablehttp client.
 func NewClient(logger Logger) Client {
-	rc := retryablehttp.NewClient()
-	rc.Logger = &retryhttpLogger{l: logger}
-	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
-	return &client{httpClient: rc.StandardClient()}
+	return &client{httpClient: newRetryingClient(logger)}
 }
 
-// NewCachingClient returns both a caching and passthrough client sharing a connection pool
+// NewCachingClient returns a caching and a passthrough Client. Both run over the
+// same retrying transport, so they share one connection pool.
 func NewCachingClient(logger Logger) (Clients, error) {
-	rc := retryablehttp.NewClient()
-	rc.Logger = &retryhttpLogger{l: logger}
-	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	passthrough := newRetryingClient(logger)
 
-	// StandardClient returns a fresh *http.Client each call
-	caching := rc.StandardClient()
-	passthrough := rc.StandardClient()
-
-	// The cache sits above the retryablehttp (so 500 status is retried)
-	cached, err := newCachingTransport(logger, caching.Transport)
+	// The cache sits above the retries, so a 500 is retried before it is stored.
+	cached, err := newCachingTransport(logger, passthrough.Transport)
 	if err != nil {
 		return Clients{}, err
 	}
-	passthrough.Transport = cached
+	caching := *passthrough
+	caching.Transport = cached
 
 	return Clients{
-		Caching:     &client{httpClient: passthrough},
-		Passthrough: &client{httpClient: caching},
+		Caching:     &client{httpClient: &caching},
+		Passthrough: &client{httpClient: passthrough},
 	}, nil
+}
+
+// newRetryingClient returns an *http.Client that retries transient failures.
+func newRetryingClient(logger Logger) *http.Client {
+	rc := retryablehttp.NewClient()
+	rc.Logger = &retryhttpLogger{l: logger}
+	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	return rc.StandardClient()
 }
 
 // NewWithClient returns a Client backed by the given httpClient.

--- a/internal/httpfetch/httpfetch.go
+++ b/internal/httpfetch/httpfetch.go
@@ -115,16 +115,55 @@ func NewClients(logger Logger) (Clients, error) {
 }
 
 // newCachingTransport wraps upstream with the in-memory response cache.
-// httpcache.NewTransport panics rather than returning an error when the store
-// cannot be opened, so contain it here: a library panic must not take down a
-// build over a cache that is only an optimisation.
+// httpcache.NewTransport panics with ErrOpenCache rather than returning an
+// error when the store cannot be opened, so turn that one back into an error:
+// a cache that is only an optimisation must not take down a build. Anything
+// else is a genuine bug and keeps its stack.
 func newCachingTransport(upstream http.RoundTripper) (rt http.RoundTripper, err error) {
 	defer func() {
-		if r := recover(); r != nil {
-			rt, err = nil, fmt.Errorf("open in-memory HTTP cache: %v", r)
+		r := recover()
+		if r == nil {
+			return
 		}
+		if rerr, ok := r.(error); ok && errors.Is(rerr, httpcache.ErrOpenCache) {
+			rt, err = nil, fmt.Errorf("open in-memory HTTP cache: %w", rerr)
+			return
+		}
+		panic(r)
 	}()
-	return httpcache.NewTransport(inventoryCacheDSN, httpcache.WithUpstream(upstream)), nil
+	return httpcache.NewTransport(
+		inventoryCacheDSN,
+		httpcache.WithUpstream(cacheSuccessesOnly{upstream: upstream}),
+	), nil
+}
+
+// cacheSuccessesOnly stops the cache storing anything but a 2xx.
+//
+// The cache stores any final status carrying a freshness indicator, and
+// retryablehttp is configured with PassthroughErrorHandler, so a 502 that
+// survives the retries is handed back as a normal response. If the origin's
+// error page carries the same "max-age=60" the inventory paths use, that 502
+// gets stored and served as fresh for the next minute - with no request and no
+// retries - so one blip fails every remaining step of the run instead of one.
+//
+// Marking non-2xx responses no-store keeps them out. It does not change what
+// the caller sees: httpfetch.Get rejects every non-2xx anyway.
+type cacheSuccessesOnly struct{ upstream http.RoundTripper }
+
+func (c cacheSuccessesOnly) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := c.upstream.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	// 304 is how revalidation succeeds; the cache consumes it and must not be
+	// told to discard the entry it belongs to.
+	if resp.StatusCode == http.StatusNotModified {
+		return resp, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		resp.Header.Set("Cache-Control", "no-store")
+	}
+	return resp, nil
 }
 
 // NewWithClient returns a Client backed by the given httpClient, which must be

--- a/internal/httpfetch/httpfetch.go
+++ b/internal/httpfetch/httpfetch.go
@@ -62,6 +62,14 @@ type client struct {
 	httpClient *http.Client
 }
 
+// newRetryingClient returns an *http.Client that retries transient failures.
+func newRetryingClient(logger Logger) *http.Client {
+	rc := retryablehttp.NewClient()
+	rc.Logger = &retryhttpLogger{l: logger}
+	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	return rc.StandardClient()
+}
+
 // NewClient returns a Client backed by a retryablehttp client.
 func NewClient(logger Logger) Client {
 	return &client{httpClient: newRetryingClient(logger)}
@@ -70,28 +78,35 @@ func NewClient(logger Logger) Client {
 // NewCachingClient returns a caching and a passthrough Client. Both run over the
 // same retrying transport, so they share one connection pool.
 func NewCachingClient(logger Logger) (Clients, error) {
+	// The cache is layered above the retries, so a 500 is retried before it is stored.
 	passthrough := newRetryingClient(logger)
-
-	// The cache sits above the retries, so a 500 is retried before it is stored.
-	cached, err := newCachingTransport(logger, passthrough.Transport)
+	caching, err := NewCachingWithClient(logger, passthrough)
 	if err != nil {
 		return Clients{}, err
 	}
-	caching := *passthrough
-	caching.Transport = cached
 
 	return Clients{
-		Caching:     &client{httpClient: &caching},
+		Caching:     caching,
 		Passthrough: &client{httpClient: passthrough},
 	}, nil
 }
 
-// newRetryingClient returns an *http.Client that retries transient failures.
-func newRetryingClient(logger Logger) *http.Client {
-	rc := retryablehttp.NewClient()
-	rc.Logger = &retryhttpLogger{l: logger}
-	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
-	return rc.StandardClient()
+// NewCachingWithClient returns a caching Client.
+// Prefer NewCachingClient unless you need a specific transport.
+func NewCachingWithClient(logger Logger, httpClient *http.Client) (Client, error) {
+	upstream := httpClient.Transport
+	if upstream == nil {
+		upstream = http.DefaultTransport // what net/http itself uses for a nil Transport
+	}
+
+	cached, err := newCachingTransport(logger, upstream)
+	if err != nil {
+		return nil, err
+	}
+
+	caching := *httpClient
+	caching.Transport = cached
+	return &client{httpClient: &caching}, nil
 }
 
 // NewWithClient returns a Client backed by the given httpClient.

--- a/internal/httpfetch/httpfetch.go
+++ b/internal/httpfetch/httpfetch.go
@@ -16,8 +16,15 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/bartventer/httpcache"
+	// Registers the "memcache" store scheme used by inventoryCacheDSN.
+	_ "github.com/bartventer/httpcache/store/memcache"
 	"github.com/hashicorp/go-retryablehttp"
 )
+
+// inventoryCacheDSN selects the library's in-memory store. Nothing is written
+// to disk: the cache lives and dies with the process.
+const inventoryCacheDSN = "memcache://"
 
 // Client streams or atomically downloads HTTP resources. Implementations
 // returned by NewClient retry transient failures on both Get and Download.
@@ -60,6 +67,64 @@ func NewClient(logger Logger) Client {
 	rc.Logger = &retryhttpLogger{l: logger}
 	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
 	return &client{httpClient: rc.StandardClient()}
+}
+
+// Clients are the two HTTP clients a stepman run needs. They share one
+// retryablehttp client, and therefore one connection pool, so every request a
+// run makes can reuse the same connections.
+//
+// They are a struct rather than two return values because both have the same
+// type: a transposed pair would compile and then quietly cache the wrong half.
+type Clients struct {
+	// Inventory reads StepLib V2 inventory JSON through an in-memory HTTP
+	// cache that honours Cache-Control and revalidates with ETags. The
+	// inventory is small and every step re-reads it, so this is where the
+	// caching pays.
+	Inventory Client
+
+	// Downloads fetches step archives and precompiled executables, uncached.
+	// They are large, immutable, already hash-verified, and land at their own
+	// paths, so holding them in memory would cost a lot and save nothing.
+	Downloads Client
+}
+
+// NewClients builds the pair over a single shared connection pool.
+func NewClients(logger Logger) (Clients, error) {
+	rc := retryablehttp.NewClient()
+	rc.Logger = &retryhttpLogger{l: logger}
+	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+
+	// StandardClient returns a fresh *http.Client each call, both backed by
+	// this one retryablehttp client - which is where the connection pool
+	// lives, so the two share it.
+	downloads := rc.StandardClient()
+	inventory := rc.StandardClient()
+
+	// The cache sits above the retries: a hit returns without entering the
+	// retry machinery, while a revalidation still gets retried on 5xx.
+	cached, err := newCachingTransport(downloads.Transport)
+	if err != nil {
+		return Clients{}, err
+	}
+	inventory.Transport = cached
+
+	return Clients{
+		Inventory: &client{httpClient: inventory},
+		Downloads: &client{httpClient: downloads},
+	}, nil
+}
+
+// newCachingTransport wraps upstream with the in-memory response cache.
+// httpcache.NewTransport panics rather than returning an error when the store
+// cannot be opened, so contain it here: a library panic must not take down a
+// build over a cache that is only an optimisation.
+func newCachingTransport(upstream http.RoundTripper) (rt http.RoundTripper, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			rt, err = nil, fmt.Errorf("open in-memory HTTP cache: %v", r)
+		}
+	}()
+	return httpcache.NewTransport(inventoryCacheDSN, httpcache.WithUpstream(upstream)), nil
 }
 
 // NewWithClient returns a Client backed by the given httpClient, which must be

--- a/internal/httpfetch/httpfetch.go
+++ b/internal/httpfetch/httpfetch.go
@@ -16,6 +16,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"log/slog"
+
 	"github.com/bartventer/httpcache"
 	// Registers the "memcache" store scheme used by inventoryCacheDSN.
 	_ "github.com/bartventer/httpcache/store/memcache"
@@ -49,6 +51,30 @@ type Client interface {
 type Logger interface {
 	Debugf(format string, v ...any)
 }
+
+// slogHandler routes the cache library's slog output to our Logger, so cache
+// hits, misses and revalidations show up under --debug alongside everything
+// else. Without it the library defaults to a discard handler and the cache is
+// invisible in exactly the situation someone would be debugging.
+type slogHandler struct{ l Logger }
+
+func (h slogHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h slogHandler) Handle(_ context.Context, r slog.Record) error {
+	msg := r.Message
+	r.Attrs(func(a slog.Attr) bool {
+		msg += " " + a.String()
+		return true
+	})
+	h.l.Debugf("httpcache: %s", msg)
+	return nil
+}
+
+// WithAttrs and WithGroup are required by slog.Handler. The cache's output is
+// flat debug lines, so grouping buys nothing and the receiver is returned
+// unchanged rather than building a tree we would only flatten again.
+func (h slogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h slogHandler) WithGroup(string) slog.Handler      { return h }
 
 // retryhttpLogger adapts Logger to the retryablehttp.Logger interface (Printf only).
 type retryhttpLogger struct{ l Logger }
@@ -102,7 +128,7 @@ func NewClients(logger Logger) (Clients, error) {
 
 	// The cache sits above the retries: a hit returns without entering the
 	// retry machinery, while a revalidation still gets retried on 5xx.
-	cached, err := newCachingTransport(downloads.Transport)
+	cached, err := newCachingTransport(logger, downloads.Transport)
 	if err != nil {
 		return Clients{}, err
 	}
@@ -119,7 +145,7 @@ func NewClients(logger Logger) (Clients, error) {
 // error when the store cannot be opened, so turn that one back into an error:
 // a cache that is only an optimisation must not take down a build. Anything
 // else is a genuine bug and keeps its stack.
-func newCachingTransport(upstream http.RoundTripper) (rt http.RoundTripper, err error) {
+func newCachingTransport(logger Logger, upstream http.RoundTripper) (rt http.RoundTripper, err error) {
 	defer func() {
 		r := recover()
 		if r == nil {
@@ -134,6 +160,7 @@ func newCachingTransport(upstream http.RoundTripper) (rt http.RoundTripper, err 
 	return httpcache.NewTransport(
 		inventoryCacheDSN,
 		httpcache.WithUpstream(cacheSuccessesOnly{upstream: upstream}),
+		httpcache.WithLogger(slog.New(slogHandler{l: logger})),
 	), nil
 }
 

--- a/vendor/github.com/bartventer/httpcache/.codecov.yml
+++ b/vendor/github.com/bartventer/httpcache/.codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0
+        threshold: "0%"
+        base: auto
+    patch:
+      default:
+        target: 0
+        threshold: "0%"
+        base: auto

--- a/vendor/github.com/bartventer/httpcache/.editorconfig
+++ b/vendor/github.com/bartventer/httpcache/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[Makefile]
+indent_style = tab
+indent_size = 8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/vendor/github.com/bartventer/httpcache/.gitignore
+++ b/vendor/github.com/bartventer/httpcache/.gitignore
@@ -1,0 +1,42 @@
+# Go
+
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+# Custom
+*.bak
+.dump
+bin/
+coverage/
+dist/
+docs.txt
+logs/
+output/
+share/
+tmp/
+_examples/app/app
+_examples/app/app.gif
+_examples/app/gif.log

--- a/vendor/github.com/bartventer/httpcache/.golangci.yaml
+++ b/vendor/github.com/bartventer/httpcache/.golangci.yaml
@@ -1,0 +1,260 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - cyclop
+    - dupl
+    - durationcheck
+    - errname
+    - exhaustive
+    - funlen
+    - gocheckcompilerdirectives
+    - gochecknoinits
+    - gochecksumtype
+    - goconst
+    - gocyclo
+    - godot
+    - goheader
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - iface
+    - loggercheck
+    - makezero
+    - mirror
+    - musttag
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - perfsprint
+    - prealloc
+    - predeclared
+    - promlinter
+    - protogetter
+    - reassign
+    - revive
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - tagalign
+    - testableexamples
+    - testifylint
+    - tparallel
+    - unconvert
+    - unused
+    - usestdlibvars
+    - wastedassign
+    - whitespace
+  settings:
+    cyclop:
+      max-complexity: 15
+      package-average: 10
+    errcheck:
+      check-type-assertions: true
+    exhaustive:
+      check:
+        - switch
+        - map
+    exhaustruct:
+      exclude:
+        - ^net/http.Client$
+        - ^net/http.Cookie$
+        - ^net/http.Request$
+        - ^net/http.Response$
+        - ^net/http.Server$
+        - ^net/http.Transport$
+        - ^net/url.URL$
+        - ^os/exec.Cmd$
+        - ^reflect.StructField$
+        - ^github.com/Shopify/sarama.Config$
+        - ^github.com/Shopify/sarama.ProducerMessage$
+        - ^github.com/mitchellh/mapstructure.DecoderConfig$
+        - ^github.com/prometheus/client_golang/.+Opts$
+        - ^github.com/spf13/cobra.Command$
+        - ^github.com/spf13/cobra.CompletionOptions$
+        - ^github.com/stretchr/testify/mock.Mock$
+        - ^github.com/testcontainers/testcontainers-go.+Request$
+        - ^github.com/testcontainers/testcontainers-go.FromDockerfile$
+        - ^golang.org/x/tools/go/analysis.Analyzer$
+        - ^google.golang.org/protobuf/.+Options$
+        - ^gopkg.in/yaml.v3.Node$
+    funlen:
+      lines: 100
+      statements: 50
+      ignore-comments: true
+    gocognit:
+      min-complexity: 20
+    gocritic:
+      settings:
+        captLocal:
+          paramsOnly: false
+        underef:
+          skipRecvDeref: false
+    godot:
+      capital: false
+      period: true
+    goheader:
+      values:
+        const:
+          AUTHOR: "Bart Venter <72999113+bartventer@users.noreply.github.com>"
+      template: |-
+        Copyright (c) {{ YEAR }} {{ AUTHOR }}
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/golang/protobuf:
+              recommendations:
+                - google.golang.org/protobuf
+              reason: see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
+          - github.com/satori/go.uuid:
+              recommendations:
+                - github.com/google/uuid
+              reason: satori's package is not maintained
+          - github.com/gofrs/uuid:
+              recommendations:
+                - github.com/gofrs/uuid/v5
+              reason: gofrs' package was not go module before v5
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+      settings:
+        shadow:
+          strict: false
+    inamedparam:
+      skip-single-param: true
+    mnd:
+      ignored-functions:
+        - flag.Arg
+        - flag.Duration.*
+        - flag.Float.*
+        - flag.Int.*
+        - flag.Uint.*
+        - os.Chmod
+        - os.Mkdir.*
+        - os.OpenFile
+        - os.WriteFile
+        - prometheus.ExponentialBuckets.*
+        - prometheus.LinearBuckets
+    nakedret:
+      max-func-lines: 30
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-no-explanation:
+        - funlen
+        - gocognit
+        - lll
+    perfsprint:
+      strconcat: false
+    revive:
+      rules:
+        - name: unused-parameter
+          disabled: true
+    rowserrcheck:
+      packages:
+        - github.com/jmoiron/sqlx
+    sloglint:
+      static-msg: true
+      attr-only: true
+      args-on-sep-lines: true
+      no-global: all
+      context: all
+      msg-style: capitalized
+      key-naming-case: snake
+    staticcheck:
+      checks:
+        - -ST1003
+        - all
+    tagalign:
+      align: true
+      sort: true
+      order:
+        - json
+        - yaml
+        - xml
+        - toml
+        - hcl
+        - mapstructure
+        - env
+        - docstore
+        - gorm
+        - validate
+        - bson
+        - form
+        - query
+        - db
+        - sql
+      strict: true
+  exclusions:
+    generated: strict
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gochecknoinits
+        path: (^|/)(cmd|internal/pipeline)($|/)
+      - linters:
+          - godot
+        source: (noinspection|TODO)
+      - linters:
+          - gocritic
+        source: //noinspection
+      - linters:
+          - bodyclose
+          - dupl
+          - funlen
+          - goconst
+          - gosec
+          - musttag
+          - noctx
+          - wrapcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-same-issues: 50
+formatters:
+  enable:
+    - goimports
+    - golines
+  exclusions:
+    generated: strict
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/go-viper/mapstructure/v2

--- a/vendor/github.com/bartventer/httpcache/LICENSE
+++ b/vendor/github.com/bartventer/httpcache/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/bartventer/httpcache/Makefile
+++ b/vendor/github.com/bartventer/httpcache/Makefile
@@ -1,0 +1,108 @@
+SHELL = /usr/bin/env bash
+.SHELLFLAGS = -ecuo pipefail
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables
+.DEFAULT_GOAL := help
+
+# ==============================================================================
+# Variables
+# ==============================================================================
+CI ?=
+OUTPUTDIR ?= output
+$(shell mkdir -p $(OUTPUTDIR))
+COVERPROFILE ?= coverage.out
+COVERHTML ?= coverage.html
+GOFILES := $(shell go list -f '{{ range $$file := .GoFiles }}{{ printf "%s/%s\n" $$.Dir $$file }} {{- end }}' ./... | sort)
+GOTESTFILES := $(shell go list -f '{{ range $$file := .TestGoFiles }}{{ printf "%s/%s\n" $$.Dir $$file }} {{- end }}' ./... | sort)
+FMTSTAMP := .fmt.stamp
+LINTSTAMP := .lint.stamp
+
+# ==============================================================================
+# Functions
+# ==============================================================================
+define open_browser
+	@case $$(uname -s) in \
+		Linux) xdg-open $(1) ;; \
+		Darwin) open $(1) ;; \
+		*) echo "Unsupported platform" ;; \
+	esac
+endef
+
+# ==============================================================================
+# Targets
+# ==============================================================================
+
+## Dependencies:
+.PHONY: deps/get
+deps/get: ## Get dependencies
+	go get -v ./...
+	go mod tidy -v
+
+.PHONY: deps/update
+deps/update: ## Update dependencies
+	go get -v -u ./...
+	go mod tidy -v
+
+## Generators:
+.PHONY: gif
+gif: ## Generate GIF for example application
+	./scripts/gif.sh
+
+## Code Quality:
+fmt: $(FMTSTAMP) ## Format code
+
+$(FMTSTAMP): $(GOFILES) $(GOTESTFILES)
+	golangci-lint run --fix --verbose
+
+lint: $(LINTSTAMP) ## Run linters
+
+$(LINTSTAMP): $(GOFILES) $(GOTESTFILES)
+	golangci-lint run --disable goheader --verbose
+	touch $@
+
+## Testing:
+test: $(OUTPUTDIR)/$(COVERHTML) ## Run tests
+
+$(OUTPUTDIR)/$(COVERPROFILE): $(GOFILES) $(GOTESTFILES) go.mod ## Run tests with coverage
+	mkdir -pv $(dir $@)
+	go test -v \
+		-outputdir=$(dir $@) \
+		-coverprofile=$(notdir $@) \
+		-coverpkg=./... \
+		-run= ./... | \
+		tee $(OUTPUTDIR)/test.log
+
+$(OUTPUTDIR)/$(COVERHTML): $(OUTPUTDIR)/$(COVERPROFILE) ## Generate HTML coverage report
+ifeq ($(CI),)
+	mkdir -pv $(dir $@)
+	go tool cover -html=$(OUTPUTDIR)/$(COVERPROFILE) -o $(OUTPUTDIR)/$(COVERHTML)
+	@echo "🌐 Run 'make browser/cover' to open coverage report in browser"
+else
+	@echo "CI detected, skipping HTML coverage report generation"
+endif
+
+.PHONY: browser/cover
+browser/cover: ## Open coverage report in browser
+	$(call open_browser,$(OUTPUTDIR)/$(COVERHTML))
+
+.PHONY: clean
+clean: ## Clean up build artifacts
+	rm -rfv $(OUTPUTDIR) || true
+
+## Help:
+.PHONY: help
+help: GREEN  := $(shell tput -Txterm setaf 2)
+help: YELLOW := $(shell tput -Txterm setaf 3)
+help: CYAN   := $(shell tput -Txterm setaf 6)
+help: RESET  := $(shell tput -Txterm sgr0)
+help: ## Show this help
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@awk 'BEGIN {FS = ":.*?## "} { \
+		if (/^[a-zA-Z0-9_\/-]+:.*?##.*$$/) {printf "    ${YELLOW}%-20s${GREEN}%s${RESET}\n", $$1, $$2} \
+		else if (/^## .*$$/) {printf "  ${CYAN}%s${RESET}\n", substr($$1,4)} \
+		}' $(MAKEFILE_LIST)

--- a/vendor/github.com/bartventer/httpcache/README.md
+++ b/vendor/github.com/bartventer/httpcache/README.md
@@ -1,0 +1,335 @@
+# httpcache
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/bartventer/httpcache.svg)](https://pkg.go.dev/github.com/bartventer/httpcache)
+[![Go Report Card](https://goreportcard.com/badge/github.com/bartventer/httpcache)](https://goreportcard.com/report/github.com/bartventer/httpcache)
+[![Test](https://github.com/bartventer/httpcache/actions/workflows/default.yml/badge.svg)](https://github.com/bartventer/httpcache/actions/workflows/default.yml)
+[![codecov](https://codecov.io/github/bartventer/httpcache/graph/badge.svg?token=pnpoA3t4EE)](https://codecov.io/github/bartventer/httpcache)
+
+**httpcache** is a Go package that provides a standards-compliant [http.RoundTripper](https://pkg.go.dev/net/http#RoundTripper) for transparent HTTP response caching, following [RFC 9111 (HTTP Caching)](https://www.rfc-editor.org/rfc/rfc9111).
+
+> **Note:** This package is intended for use as a **private (client-side) cache**. It is **not** a shared or proxy cache. It is designed to be used with an HTTP client to cache responses from origin servers, improving performance and reducing load on those servers.
+
+## Features
+
+- **Plug-and-Play**: Just swap in as your HTTP client's transport; no extra configuration needed. [^1]
+- **RFC 9111 Compliance**: Handles validation, expiration, and revalidation (see [details](#rfc-9111-compliance-matrix)).
+- **Cache Control**: Supports all required HTTP cache control directives, as well as extensions like `stale-while-revalidate`, `stale-if-error`, and `immutable` (see [details](#field-definitions-details)).
+- **Cache Backends**: Built-in support for file system and memory caches, with the ability to implement custom backends (see [Cache Backends](#cache-backends)).
+- **Cache Maintenance API**: Optional REST endpoints for listing, retrieving, and deleting cache entries (see [Cache Maintenance API](#cache-maintenance-api-debug-only)).
+- **Extensible**: Options for logging, transport and timeouts (see [Options](#options)).
+- **Debuggable**: Adds a cache status header to every response (see [Cache Status Headers](#cache-status-headers)).
+- **Zero Dependencies**: No external dependencies, pure Go implementation.
+
+![Made with VHS](https://vhs.charm.sh/vhs-3WOBtYTZzzXggFGYRudHTV.gif)
+
+*Demonstration of HTTP caching in action. See [_examples/app](_examples/app/app.go) for code.*
+
+## Installation
+
+To install the package, run:
+
+```bash
+go get github.com/bartventer/httpcache
+```
+
+## Quick Start
+
+To get started, create a new HTTP client with the `httpcache` transport, specifying a cache backend DSN. You'll need to register the desired cache backend before using it. Here's an example using the built-in file system cache:
+
+```go
+package main
+
+import (
+    "log/slog"
+    "net/http"
+    "time"
+
+    "github.com/bartventer/httpcache"
+    // Register the file system cache backend
+    _ "github.com/bartventer/httpcache/store/fscache"
+)
+
+func main() {
+    // Example DSN for the file system cache backend
+    dsn := "fscache://?appname=myapp"
+    client := &http.Client{
+        Transport: httpcache.NewTransport(
+            dsn,
+            httpcache.WithSWRTimeout(10*time.Second),
+            httpcache.WithLogger(slog.Default()),
+        ),
+    }
+    // ... Use the client as usual
+}
+```
+
+> **Note:** The DSN format and options depend on the cache backend you choose. Refer to the [Cache Backends](#cache-backends) section for details on available backends and their DSN formats.
+
+## Cache Backends
+
+The following built-in cache backends are available:
+
+| Backend                                                                         | DSN Example                | Description                                                                                                                                                            |
+| ------------------------------------------------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`fscache`](https://pkg.go.dev/github.com/bartventer/httpcache/store/fscache)   | `fscache://?appname=myapp` | File system cache, stores responses on disk. Suitable for persistent caching across restarts. Supports context cancellation, as well as optional `AES-GCM` encryption. |
+| [`memcache`](https://pkg.go.dev/github.com/bartventer/httpcache/store/memcache) | `memcache://`              | In-memory cache, suitable for ephemeral caching. Does not persist across restarts.                                                                                     |
+
+Consult the documentation for each backend for specific configuration options and usage details.
+
+### Custom Cache Backends
+
+To implement a custom cache backend, create a type that satisfies the [`store/driver.Conn`](https://pkg.go.dev/github.com/bartventer/httpcache/store/driver#Conn) interface, then register it using the [`store.Register`](https://pkg.go.dev/github.com/bartventer/httpcache/store#Register) function. Refer to the built-in backends for examples of how to implement this interface.
+
+### Cache Maintenance API (Debug Only)
+
+A REST API is available for cache inspection and maintenance, intended for debugging and development use only. **Do not expose these endpoints in production.**
+
+**Endpoints:**
+- `GET    /debug/httpcache`           — List cache keys (if supported)
+- `GET    /debug/httpcache/{key}`     — Retrieve a cache entry
+- `DELETE /debug/httpcache/{key}`     — Delete a cache entry
+
+All endpoints require a `dsn` query parameter to select the cache backend.
+
+**Usage Example:**
+```go
+import (
+    "net/http"
+    "github.com/bartventer/httpcache/store/expapi"
+)
+
+func main() {
+    expapi.Register()
+    http.ListenAndServe(":8080", nil)
+}
+```
+
+To use a custom [ServeMux](https://pkg.go.dev/net/http#ServeMux), pass `expapi.WithServeMux(mux)` to `expapi.Register()`.
+
+## Options
+
+| Option                            | Description                                         | Default Value                   |
+| --------------------------------- | --------------------------------------------------- | ------------------------------- |
+| `WithUpstream(http.RoundTripper)` | Set a custom transport for upstream/origin requests | `http.DefaultTransport`         |
+| `WithSWRTimeout(time.Duration)`   | Set the stale-while-revalidate timeout              | `5 * time.Second`               |
+| `WithLogger(*slog.Logger)`        | Set a logger for debug output                       | `slog.New(slog.DiscardHandler)` |
+
+## Cache Status Headers
+
+This package sets a cache status header on every response:
+
+- `X-Httpcache-Status`: The primary, detailed cache status header (always set).
+- `X-From-Cache`: (Legacy) Provided for compatibility with [`gregjones/httpcache`](https://github.com/gregjones/httpcache). Only set for cache hits/stale/revalidated responses.
+
+### Header Value Mapping
+
+| X-Httpcache-Status | X-From-Cache | Description                        |
+| ------------------ | ------------ | ---------------------------------- |
+| HIT                | 1            | Served from cache                  |
+| STALE              | 1            | Served from cache but stale        |
+| REVALIDATED        | 1            | Revalidated with origin            |
+| MISS               | *(not set)*  | Served from origin                 |
+| BYPASS             | *(not set)*  | Bypassed cache, served from origin |
+
+### Example: Stale cache hit
+
+```http
+HTTP/1.1 200 OK
+X-Httpcache-Status: STALE
+X-From-Cache: 1
+Content-Type: application/json
+```
+
+## Limitations
+
+- **Range Requests & Partial Content:**
+  This cache does **not** support HTTP range requests or partial/incomplete responses (e.g., status code 206, `Range`/`Content-Range` headers). All requests with a `Range` header are bypassed, and 206 responses are not cached. For example:
+
+  ```http
+  GET /example.txt HTTP/1.1
+  Host: example.com
+  Range: bytes=0-99
+  ```
+
+  The above request will bypass the cache and fetch the response directly from the origin server. See [RFC 9111 §3.3-3.4](https://www.rfc-editor.org/rfc/rfc9111#section-3.3) for details.
+
+
+## RFC 9111 Compliance Matrix
+
+[![RFC 9111](https://img.shields.io/badge/RFC%209111-Compliant-brightgreen)](https://www.rfc-editor.org/rfc/rfc9111)
+
+| §   | Title                                         | Requirement | Implemented | Notes                                      |
+| --- | --------------------------------------------- | :---------: | :---------: | ------------------------------------------ |
+| 1.  | Introduction                                  |     N/A     |     N/A     | Nothing to implement                       |
+| 2.  | Overview of Cache Operation                   |     N/A     |     N/A     | Nothing to implement                       |
+| 3.  | Storing Responses in Caches                   |  Required   |      ✔️      | [Details](#storing-responses-details)      |
+| 4.  | Constructing Responses from Caches            |  Required   |      ✔️      | [Details](#constructing-responses-details) |
+| 5.  | Field Definitions                             |  Required   |      ✔️      | [Details](#field-definitions-details)      |
+| 6.  | Relationship to Applications and Other Caches |     N/A     |     N/A     | Nothing to implement                       |
+| 7.  | Security Considerations                       |     N/A     |     N/A     | Nothing to implement                       |
+| 8.  | IANA Considerations                           |     N/A     |     N/A     | Nothing to implement                       |
+| 9.  | References                                    |     N/A     |     N/A     | Nothing to implement                       |
+
+**Legend for Requirements:**
+
+| Requirement | Description                                                             |
+| ----------- | ----------------------------------------------------------------------- |
+| Required    | *Must be implemented for RFC compliance*                                |
+| Optional    | *May be implemented, but not required for compliance*                   |
+| Obsolete    | *Directive is no longer relevant as per RFC 9111*                       |
+| Deprecated  | *Directive is deprecated as per RFC 9111, but can still be implemented* |
+| N/A         | *Nothing to implement or not applicable to private caches*              |
+
+<details id="storing-responses-details">
+<summary><strong>§3. Storing Responses in Caches (Details)</strong></summary>
+
+| §    | Title                                       | Requirement | Implemented | Notes                                        |
+| ---- | ------------------------------------------- | :---------: | :---------: | -------------------------------------------- |
+| 3.1. | Storing Header and Trailer Fields           |  Required   |      ✔️      |                                              |
+| 3.2. | Updating Stored Header Fields               |  Required   |      ✔️      |                                              |
+| 3.3. | Storing Incomplete Responses                |  Optional   |      ❌      | See [Limitations](#limitations)              |
+| 3.4. | Combining Partial Content                   |  Optional   |      ❌      | See [Limitations](#limitations)              |
+| 3.5. | Storing Responses to Authenticated Requests |     N/A     |     N/A     | Not applicable to private client-side caches |
+
+</details>
+
+<details id="constructing-responses-details">
+<summary><strong>§4. Constructing Responses from Caches (Details)</strong></summary>
+
+| §    | Title                                             | Requirement | Implemented | Notes                         |
+| ---- | ------------------------------------------------- | :---------: | :---------: | ----------------------------- |
+| 4.1. | Calculating Cache Keys with the Vary Header Field |  Required   |      ✔️      |                               |
+| 4.2. | Freshness                                         |  Required   |      ✔️      | [Details](#freshness-details) |
+
+<details id="freshness-details">
+<summary><em>§4.2. Freshness (Subsections)</em></summary>
+
+| §      | Title                           | Requirement | Implemented | Notes |
+| ------ | ------------------------------- | :---------: | :---------: | ----- |
+| 4.2.1. | Calculating Freshness Lifetime  |  Required   |      ✔️      |       |
+| 4.2.2. | Calculating Heuristic Freshness |  Required   |      ✔️      |       |
+| 4.2.3. | Calculating Age                 |  Required   |      ✔️      |       |
+| 4.2.4. | Serving Stale Responses         |  Required   |      ✔️      |       |
+
+</details>
+
+| §    | Title      | Requirement | Implemented | Notes                          |
+| ---- | ---------- | :---------: | ----------- | ------------------------------ |
+| 4.3. | Validation |  Required   | ✔️           | [Details](#validation-details) |
+
+<details id="validation-details">
+<summary><em>§4.3. Validation (Subsections)</em></summary>
+
+|   §    | Title                                       | Requirement | Implemented | Notes                                                                                                                                  |
+| :----: | ------------------------------------------- | :---------: | :---------: | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 4.3.1. | Sending a Validation Request                |  Required   |      ✔️      |                                                                                                                                        |
+| 4.3.2. | Handling Received Validation Request        |     N/A     |     N/A     | Not applicable to private client-side caches                                                                                           |
+| 4.3.3. | Handling a Validation Response              |  Required   |      ✔️      |                                                                                                                                        |
+| 4.3.4. | Freshening Stored Responses upon Validation |  Required   |      ✔️      |                                                                                                                                        |
+| 4.3.5. | Freshening Responses with HEAD              |  Optional   |      ❌      | Pointless, rather use conditional GETs; see [RFC 9110 §13.2.1 last para](https://datatracker.ietf.org/doc/html/rfc9110#section-13.2.1) |
+
+</details>
+
+| §    | Title                         | Requirement | Implemented | Notes |
+| ---- | ----------------------------- | :---------: | :---------: | ----- |
+| 4.4. | Invalidating Stored Responses |  Required   |      ✔️      |       |
+
+</details>
+
+<details id="field-definitions-details">
+<summary><strong>§5. Field Definitions (Details)</strong></summary>
+
+| §    | Title         | Requirement | Implemented | Notes                                   |
+| ---- | ------------- | :---------: | :---------: | --------------------------------------- |
+| 5.1. | Age           |  Required   |      ✔️      |                                         |
+| 5.2. | Cache-Control |  Required   |      ✔️      | [Details](#cache-control-directives)    |
+| 5.3. | Expires       |  Required   |      ✔️      |                                         |
+| 5.4. | Pragma        | Deprecated  |      ❌      | Deprecated by RFC 9111; not implemented |
+| 5.5. | Warning       |  Obsolete   |      ❌      | Obsoleted by RFC 9111; not implemented  |
+
+<details id="cache-control-directives">
+<summary><em>§5.2. Cache-Control Directives</em></summary>
+
+| §      | Title              | Requirement | Implemented | Notes                                  |
+| ------ | ------------------ | :---------: | :---------: | -------------------------------------- |
+| 5.2.1. | Request Directives |  Optional   |      ✔️      | [Details](#request-directives-details) |
+
+<details id="request-directives-details">
+<summary><em>§5.2.1. Request Directives (Details)</em></summary>
+
+| §        | Title/Directive  | Requirement | Implemented | Notes                                                          |
+| -------- | ---------------- | :---------: | :---------: | -------------------------------------------------------------- |
+| 5.2.1.1. | `max-age`        |  Optional   |      ✔️      |                                                                |
+| 5.2.1.2. | `max-stale`      |  Optional   |      ✔️      |                                                                |
+| 5.2.1.3. | `min-fresh`      |  Optional   |      ✔️      |                                                                |
+| 5.2.1.4. | `no-cache`       |  Optional   |      ✔️      |                                                                |
+| 5.2.1.5. | `no-store`       |  Optional   |      ✔️      |                                                                |
+| 5.2.1.6. | `no-transform`   |  Optional   |      ✔️      | See [Content Transformation Compliance](#content-transformation-compliance) |
+| 5.2.1.7. | `only-if-cached` |  Optional   |      ✔️      |                                                                |
+
+</details>
+
+| Section                    | Requirement | Implemented | Notes                                   |
+| -------------------------- | :---------: | :---------: | --------------------------------------- |
+| 5.2.2. Response Directives |  Required   |      ✔️      | [Details](#response-directives-details) |
+
+<details id="response-directives-details">
+<summary><em>§5.2.2. Response Directives (Details)</em></summary>
+
+| §         | Title/Directive    | Requirement | Implemented | Notes                                                          |
+| --------- | ------------------ | :---------: | :---------: | -------------------------------------------------------------- |
+| 5.2.2.1.  | `max-age`          |  Required   |      ✔️      |                                                                |
+| 5.2.2.2.  | `must-revalidate`  |  Required   |      ✔️      |                                                                |
+| 5.2.2.3.  | `must-understand`  |  Required   |      ✔️      |                                                                |
+| 5.2.2.4.  | `no-cache`         |  Required   |      ✔️      | Both qualified and unqualified forms supported                 |
+| 5.2.2.5.  | `no-store`         |  Required   |      ✔️      |                                                                |
+| 5.2.2.6.  | `no-transform`     |  Required   |      ✔️      | See [Content Transformation Compliance](#content-transformation-compliance) |
+| 5.2.2.7.  | `private`          |     N/A     |     N/A     | Intended for shared caches; not applicable to private caches   |
+| 5.2.2.8.  | `proxy-revalidate` |     N/A     |     N/A     | Intended for shared caches; not applicable to private caches   |
+| 5.2.2.9.  | `public`           |  Optional   |      ✔️      |                                                                |
+| 5.2.2.10. | `s-maxage`         |     N/A     |     N/A     | Intended for shared caches; not applicable to private caches   |
+
+</details>
+
+| §      | Title                | Requirement | Implemented | Notes                                    |
+| ------ | -------------------- | :---------: | :---------: | ---------------------------------------- |
+| 5.2.3. | Extension Directives |  Optional   | *partially* | [Details](#extension-directives-details) |
+
+<details id="extension-directives-details">
+<summary><em>§5.2.3. Extension Directives (Details)</em></summary>
+
+The following additional cache control directives are supported, as defined in various RFCs:
+
+| Reference                                                        | Directive                | Notes                                  |
+| ---------------------------------------------------------------- | ------------------------ | -------------------------------------- |
+| [RFC 5861, §3](https://www.rfc-editor.org/rfc/rfc5861#section-3) | `stale-while-revalidate` | Only applies to responses              |
+| [RFC 5861, §4](https://www.rfc-editor.org/rfc/rfc5861#section-4) | `stale-if-error`         | Applies to both requests and responses |
+| [RFC 8246, §2](https://www.rfc-editor.org/rfc/rfc8246)           | `immutable`              | Only applies to responses              |
+
+</details>
+</details>
+</details>
+
+### Content Transformation Compliance
+
+This implementation maintains RFC 9111 compliance regarding the `no-transform` directive by enforcing a **storage-only** architecture:
+
+```go
+type Conn interface {
+    Get(key string) ([]byte, error)    // Returns byte-identical data
+    Set(key string, data []byte) error // Stores byte-identical data  
+    Delete(key string) error           // Simple deletion
+}
+```
+
+**Storage optimizations** (compression, encryption, serialization) are allowed because they return **byte-identical** HTTP responses. This differs from transformations mentioned in [RFC 9110 §7.7](https://www.rfc-editor.org/rfc/rfc9110#section-7.7), like image format conversion which change actual response content.
+
+**Custom backends:** Must return byte-identical responses. Use the [`store/acceptance`](https://pkg.go.dev/github.com/bartventer/httpcache/store/acceptance) test suite to verify compliance.
+
+## License
+
+This project is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). See the [LICENSE](LICENSE) file for details.
+
+## Notes
+
+[^1]: No configuration is needed beyond the cache backend DSN. Caching is handled automatically based on HTTP headers and directives. To use a custom upstream transport, pass it with the `WithUpstream` option. This lets you add `httpcache` to your existing HTTP client with minimal changes. See [Options](#options) for details.

--- a/vendor/github.com/bartventer/httpcache/SECURITY.md
+++ b/vendor/github.com/bartventer/httpcache/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release (`v0.x.y`)[^1] is supported for security updates.
+
+[^1]: This project is in active initial development. While generally stable for most use cases, breaking changes or rapid development may still occur.
+
+## Reporting a Vulnerability
+
+Please use the **"Report a vulnerability"** button in the GitHub Security tab to confidentially disclose any security issues.
+
+## Updates
+
+Security fixes and announcements will appear on [GitHub Releases](https://github.com/bartventer/httpcache/releases) and [Issues](https://github.com/bartventer/httpcache/issues).

--- a/vendor/github.com/bartventer/httpcache/context.go
+++ b/vendor/github.com/bartventer/httpcache/context.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpcache
+
+import (
+	"context"
+
+	"github.com/bartventer/httpcache/internal"
+)
+
+// ContextWithTraceID adds a trace ID to the context, which can be used for
+// logging or tracing purposes. The trace ID can be retrieved later using
+// [TraceIDFromContext].
+func ContextWithTraceID(ctx context.Context, traceID string) context.Context {
+	return context.WithValue(ctx, internal.TraceIDKey, traceID)
+}
+
+// TraceIDFromContext retrieves the trace ID from the context, if it exists.
+func TraceIDFromContext(ctx context.Context) (string, bool) {
+	return internal.TraceIDFromContext(ctx)
+}

--- a/vendor/github.com/bartventer/httpcache/helpers.go
+++ b/vendor/github.com/bartventer/httpcache/helpers.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpcache
+
+import (
+	"bufio"
+	"bytes"
+	"net/http"
+
+	"github.com/bartventer/httpcache/internal"
+)
+
+func make504Response(req *http.Request) (*http.Response, error) {
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("HTTP/1.1 504 Gateway Timeout\r\n")
+	_, _ = buf.WriteString("Cache-Control: no-cache\r\n")
+	_, _ = buf.WriteString("Content-Length: 0\r\n")
+	_, _ = buf.WriteString(
+		internal.CacheStatusHeader + ": " + internal.CacheStatusBypass.Value + "\r\n",
+	)
+	_, _ = buf.WriteString("Connection: close\r\n")
+	_, _ = buf.WriteString("\r\n")
+	return http.ReadResponse(bufio.NewReader(&buf), req)
+}
+
+func cloneRequest(req *http.Request) *http.Request {
+	req2 := new(http.Request)
+	*req2 = *req
+	req2.Header = req.Header.Clone()
+	return req2
+}
+
+// withConditionalHeaders sets the conditional headers on the request based on the
+// stored response headers as specified in RFC 9111 §4.3.1.
+func withConditionalHeaders(req *http.Request, storedHdr http.Header) *http.Request {
+	var req2 *http.Request
+	if etag := storedHdr.Get("ETag"); etag != "" {
+		req2 = cloneRequest(req)
+		req2.Header.Set("If-None-Match", etag)
+	}
+	if lastModified := storedHdr.Get("Last-Modified"); lastModified != "" {
+		if req2 == nil {
+			req2 = cloneRequest(req)
+		}
+		req2.Header.Set("If-Modified-Since", lastModified)
+	}
+	if req2 != nil {
+		req = req2
+	}
+	return req
+}

--- a/vendor/github.com/bartventer/httpcache/internal/cacheabilityevaluator.go
+++ b/vendor/github.com/bartventer/httpcache/internal/cacheabilityevaluator.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+	"time"
+)
+
+// CacheabilityEvaluator describes the interface implemented by types that can
+// evaluate whether a response can be stored in cache, according to RFC 9111 §3.
+type CacheabilityEvaluator interface {
+	CanStoreResponse(
+		resp *http.Response,
+		reqCC CCRequestDirectives,
+		resCC CCResponseDirectives,
+	) bool
+}
+
+func canStoreResponse(
+	resp *http.Response,
+	reqCC CCRequestDirectives,
+	resCC CCResponseDirectives,
+) bool {
+	//  The response status code must be final
+	if resp.StatusCode < 200 || resp.StatusCode == http.StatusProcessing || resp.StatusCode >= 600 {
+		return false
+	}
+
+	// If status is 206 or 304 or must-understand is present, cache must understand the code.
+	if (resp.StatusCode == http.StatusPartialContent || resp.StatusCode == http.StatusNotModified || resCC.MustUnderstand()) &&
+		!isStatusUnderstood(resp.StatusCode) {
+		return false
+	}
+
+	// The no-store directive must not be present in the response/request headers.
+	if resCC.NoStore() || reqCC.NoStore() {
+		return false
+	}
+
+	// Skip the following checks:
+	// 	- For private caches, private directive is allowed (no restriction).
+	// 	- For private caches, Authorization is not a restriction.
+
+	// The response must contain at least one explicit or heuristic cacheability indicator.
+	return resCC.Public() ||
+		resp.Header.Get("Expires") != "" ||
+		resCC.MaxAgePresent() ||
+		isHeuristicallyCacheableCode(resp.StatusCode)
+}
+
+type CacheabilityEvaluatorFunc func(
+	resp *http.Response,
+	reqCC CCRequestDirectives,
+	resCC CCResponseDirectives,
+) bool
+
+func (f CacheabilityEvaluatorFunc) CanStoreResponse(
+	resp *http.Response,
+	reqCC CCRequestDirectives,
+	resCC CCResponseDirectives,
+) bool {
+	return f(resp, reqCC, resCC)
+}
+func NewCacheabilityEvaluator() CacheabilityEvaluator {
+	return CacheabilityEvaluatorFunc(canStoreResponse)
+}
+
+// StaleIfErrorPolicy describes the interface implemented by types that can
+// evaluate cache control directives for storing responses (RFC 9111 §3) and
+// determining whether a stale response can be served in case of an error (RFC 5861 §4).
+type StaleIfErrorPolicy interface {
+	CanStaleOnError(freshness *Freshness, sies ...StaleIfErrorer) bool
+}
+
+type StaleIfErrorer interface {
+	// StaleIfError returns the duration for which the cache can serve a stale response
+	// when an error occurs, according to the Stale-If-Error directive (RFC 5861 §4).
+	StaleIfError() (dur time.Duration, valid bool)
+}
+
+var _ StaleIfErrorPolicy = (*staleIfErrorPolicy)(nil)
+
+type staleIfErrorPolicy struct {
+	clock Clock
+}
+
+func NewStaleIfErrorPolicy(clock Clock) *staleIfErrorPolicy {
+	return &staleIfErrorPolicy{clock}
+}
+
+func (cce *staleIfErrorPolicy) CanStaleOnError(
+	freshness *Freshness,
+	sies ...StaleIfErrorer,
+) bool {
+	if len(sies) == 0 {
+		return false
+	}
+	for _, sie := range sies {
+		if sie == nil {
+			continue
+		}
+		dur, valid := sie.StaleIfError()
+		if !valid {
+			continue
+		}
+		age := freshness.Age.Value + cce.clock.Since(freshness.Age.Timestamp)
+		// If stale-if-error is set, allow extra staleness
+		if age <= freshness.UsefulLife+dur {
+			return true
+		}
+	}
+	return false
+}
+
+// isStatusUnderstood reports whether the status code is understood by the cache.
+func isStatusUnderstood(code int) bool {
+	switch code {
+	case http.StatusOK,
+		http.StatusNonAuthoritativeInfo,
+		// Range requests are not cacheable, so we don't consider 206 here.
+		// http.StatusPartialContent,
+		http.StatusMovedPermanently,
+		http.StatusNotModified,
+		http.StatusNotFound,
+		http.StatusMethodNotAllowed,
+		http.StatusGone,
+		http.StatusRequestURITooLong,
+		http.StatusNotImplemented,
+		http.StatusPermanentRedirect:
+		return true
+	default:
+		return false
+	}
+}
+
+// isHeuristicallyCacheableCode reports whether the status code is heuristically cacheable
+// per RFC9111 §4.2.2.
+func isHeuristicallyCacheableCode(code int) bool {
+	switch code {
+	case http.StatusOK,
+		http.StatusNonAuthoritativeInfo,
+		http.StatusPartialContent,
+		http.StatusMovedPermanently,
+		http.StatusNotModified,
+		http.StatusNotFound,
+		http.StatusMethodNotAllowed,
+		http.StatusGone,
+		http.StatusRequestURITooLong,
+		http.StatusNotImplemented,
+		http.StatusPermanentRedirect:
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/bartventer/httpcache/internal/cacheinvalidator.go
+++ b/vendor/github.com/bartventer/httpcache/internal/cacheinvalidator.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// CacheInvalidator describes the interface implemented by types that can
+// invalidate cache entries for a target URI when an unsafe request receives a
+// non-error response, as required by RFC 9111 §4.4. It may also invalidate
+// entries for URIs in Location or Content-Location headers, but only if they
+// share the same origin as the target URI.
+type CacheInvalidator interface {
+	InvalidateCache(reqURL *url.URL, respHeader http.Header, refs ResponseRefs, key string)
+}
+
+type cacheInvalidator struct {
+	cache ResponseCache
+	cke   URLKeyer
+}
+
+func NewCacheInvalidator(cache ResponseCache, cke URLKeyer) *cacheInvalidator {
+	return &cacheInvalidator{cache, cke}
+}
+
+func (r *cacheInvalidator) InvalidateCache(
+	reqURL *url.URL,
+	respHeader http.Header,
+	refs ResponseRefs,
+	key string,
+) {
+	deleted := map[string]struct{}{}
+	del := func(k string) {
+		if _, ok := deleted[k]; !ok {
+			_ = r.cache.Delete(k)
+			deleted[k] = struct{}{}
+		}
+	}
+	for h := range refs.ResponseIDs() {
+		del(h)
+	}
+	r.invalidateLocationHeaders(reqURL, respHeader, del)
+	del(key)
+}
+
+var locationHeaders = [...]string{"Location", "Content-Location"}
+
+func (r *cacheInvalidator) invalidateLocationHeaders(
+	reqURL *url.URL,
+	respHeader http.Header,
+	deleteFn func(string),
+) {
+	for _, hdr := range locationHeaders {
+		loc := respHeader.Get(hdr)
+		if loc == "" {
+			continue
+		}
+		locURL, err := url.Parse(loc)
+		if err != nil {
+			continue
+		}
+		locURL = reqURL.ResolveReference(locURL)
+		if sameOrigin(reqURL, locURL) {
+			urlKey := r.cke.URLKey(locURL)
+			refs, _ := r.cache.GetRefs(urlKey)
+			for h := range refs.ResponseIDs() {
+				deleteFn(h)
+			}
+			deleteFn(urlKey)
+		}
+	}
+}

--- a/vendor/github.com/bartventer/httpcache/internal/ccdirectives.go
+++ b/vendor/github.com/bartventer/httpcache/internal/ccdirectives.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"iter"
+	"maps"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RawTime is a string that represents a time in HTTP date format.
+type RawTime string
+
+// Value returns the time and a boolean indicating whether the result is valid.
+func (r RawTime) Value() (t time.Time, valid bool) {
+	if r == "" {
+		return
+	}
+	parsedTime, err := http.ParseTime(string(r))
+	if err != nil {
+		return
+	}
+	return parsedTime, true
+}
+
+// RawDeltaSeconds is a string that represents a delta time in seconds,
+// as defined in §1.2.2 of RFC 9111.
+//
+// This implementation supports values up to the maximum range of int64
+// (9223372036854775807 seconds). Values exceeding 2147483648 (2^31) are
+// valid and will not be capped, as allowed by the RFC, which permits
+// using the greatest positive integer the implementation can represent.
+type RawDeltaSeconds string
+
+func (r RawDeltaSeconds) Value() (dur time.Duration, valid bool) {
+	if len(r) == 0 || r[0] == '-' {
+		return
+	}
+	seconds, err := strconv.ParseInt(string(r), 10, 64)
+	if err != nil {
+		return
+	}
+
+	return time.Duration(seconds) * time.Second, true
+}
+
+// RawCSV is a string that represents a sequence of comma-separated values.
+type RawCSV string
+
+// Value returns an iterator over the raw comma-separated string and a boolean indicating
+// whether the result is valid.
+func (s RawCSV) Value() (seq iter.Seq[string], valid bool) {
+	if len(s) == 0 {
+		return
+	}
+	return TrimmedCSV(string(s)), true
+}
+
+// directives returns an iterator over all key-value pairs in a string of
+// cache directives (as specified in 9111, §5.2.1 and 5.2.2). The
+// iterator yields the key (token) and value (argument) of each directive.
+//
+// It guarantees that the key is always non-empty, and if a value is not
+// present, it yields an empty string as the value.
+func directives(s string) iter.Seq2[string, string] {
+	return func(yield func(string, string) bool) {
+		for part := range TrimmedCSV(s) {
+			key, value, found := strings.Cut(part, "=")
+			if !found {
+				key = textproto.TrimString(part)
+				value = ""
+			} else {
+				value = textproto.TrimString(value)
+			}
+			if len(key) == 0 {
+				continue
+			}
+			if !yield(key, value) {
+				return
+			}
+		}
+	}
+}
+
+// parseDirectives parses a string of cache directives and returns a map
+// where the keys are the directive names and the values are the arguments.
+func parseDirectives(s string) map[string]string {
+	return maps.Collect(directives(s))
+}
+
+func getDurationDirective(d map[string]string, token string) (dur time.Duration, valid bool) {
+	if v, ok := d[token]; ok {
+		return RawDeltaSeconds(v).Value()
+	}
+	return
+}
+
+// CCRequestDirectives is a map of request directives from the Cache-Control
+// header field as defined in RFC 9111, §5.2.1. The keys are the directive tokens,
+// and the values are the arguments (if any) as strings.
+//
+// This implementation does not perform any transformations on the request,
+// hence we ignore the "no-transform" directive.
+type CCRequestDirectives map[string]string
+
+func ParseCCRequestDirectives(header http.Header) CCRequestDirectives {
+	value := header.Get("Cache-Control")
+	if value == "" {
+		return nil
+	}
+	return parseDirectives(value)
+}
+
+// MaxAge parses the "max-age" request directive as defined in RFC 9111, §5.2.1.1.
+func (d CCRequestDirectives) MaxAge() (dur time.Duration, valid bool) {
+	return getDurationDirective(d, "max-age")
+}
+
+// MaxStale parses the "max-stale" request directive as defined in RFC 9111, §5.2.1.2.
+func (d CCRequestDirectives) MaxStale() (dur RawDeltaSeconds, valid bool) {
+	if v, ok := d["max-stale"]; ok {
+		return RawDeltaSeconds(v), true
+	}
+	return
+}
+
+// MinFresh parses the "min-fresh" request directive as defined in RFC 9111, §5.2.1.3.
+func (d CCRequestDirectives) MinFresh() (dur time.Duration, valid bool) {
+	return getDurationDirective(d, "min-fresh")
+}
+
+// NoCache reports the presence of the "no-cache" request directive as defined in RFC 9111, §5.2.1.4.
+func (d CCRequestDirectives) NoCache() bool {
+	return hasToken(d, "no-cache")
+}
+
+// NoStore reports the presence of the "no-store" request directive as defined in RFC 9111, §5.2.1.5.
+func (d CCRequestDirectives) NoStore() bool {
+	return hasToken(d, "no-store")
+}
+
+// OnlyIfCached reports the presence of the "only-if-cached" request directive as defined in RFC 9111, §5.2.1.7.
+func (d CCRequestDirectives) OnlyIfCached() bool {
+	return hasToken(d, "only-if-cached")
+}
+
+// StaleIfError parses the "stale-if-error" request directive (extension) as defined in RFC 5861, §4.
+func (d CCRequestDirectives) StaleIfError() (dur time.Duration, valid bool) {
+	return getDurationDirective(d, "stale-if-error")
+}
+
+// CCResponseDirectives is a map of response directives from the Cache-Control
+// header field. The keys are the directive tokens, and the values are the arguments (if any)
+// as strings.
+//
+// The following directives per RFC 9111, §5.2.2 are not applicable to private caches:
+//   - "private" (§5.2.2.7)
+//   - "proxy-revalidate" (§5.2.2.8)
+//   - "s-maxage" (§5.2.2.10)
+//
+// This implementation does not perform any transformations on the request,
+// hence we ignore the "no-transform" directive.
+type CCResponseDirectives map[string]string
+
+func ParseCCResponseDirectives(header http.Header) CCResponseDirectives {
+	value := header.Get("Cache-Control")
+	if value == "" {
+		return nil
+	}
+	return parseDirectives(value)
+}
+
+// MaxAge parses the "max-age" response directive as defined in RFC 9111, §5.2.2.1.
+func (d CCResponseDirectives) MaxAge() (dur time.Duration, valid bool) {
+	return getDurationDirective(d, "max-age")
+}
+
+// MaxAgePresent reports the presence of the "max-age" response directive as defined in RFC 9111, §5.2.2.1.
+func (d CCResponseDirectives) MaxAgePresent() bool {
+	return hasToken(d, "max-age")
+}
+
+// MustRevalidate reports the presence of the "must-revalidate" response directive as defined in RFC 9111, §5.2.2.2.
+func (d CCResponseDirectives) MustRevalidate() bool {
+	return hasToken(d, "must-revalidate")
+}
+
+// MustUnderstand reports the presence of the "must-understand" response directive as defined in RFC 9111, §5.2.2.3.
+func (d CCResponseDirectives) MustUnderstand() bool {
+	return hasToken(d, "must-understand")
+}
+
+// NoCache parses the "no-cache" response directive as defined in RFC 9111, §5.2.2.4.
+func (d CCResponseDirectives) NoCache() (fields RawCSV, present bool) {
+	v, ok := d["no-cache"]
+	if !ok {
+		return
+	}
+	return RawCSV(ParseQuotedString(v)), true
+}
+
+// NoStore reports the presence of the "no-store" response directive as defined in RFC 9111, §5.2.2.5.
+func (d CCResponseDirectives) NoStore() bool {
+	return hasToken(d, "no-store")
+}
+
+// Public reports the presence of the "public" response directive as defined in RFC 9111, §5.2.2.9.
+func (d CCResponseDirectives) Public() bool {
+	return hasToken(d, "public")
+}
+
+// StaleIfError parses the "stale-if-error" response directive (extension) as defined in RFC 5861, §4.
+func (d CCResponseDirectives) StaleIfError() (dur time.Duration, valid bool) {
+	return getDurationDirective(d, "stale-if-error")
+}
+
+// StaleWhileRevalidate parses the "stale-while-revalidate" response directive (extension) as defined in RFC 5861, §3.
+func (d CCResponseDirectives) StaleWhileRevalidate() (dur time.Duration, valid bool) {
+	return getDurationDirective(d, "stale-while-revalidate")
+}
+
+// Immutable reports the presence of the "immutable" response directive (extension) as defined in RFC 8246, §2.
+func (d CCResponseDirectives) Immutable() bool {
+	return hasToken(d, "immutable")
+}

--- a/vendor/github.com/bartventer/httpcache/internal/clock.go
+++ b/vendor/github.com/bartventer/httpcache/internal/clock.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+	"time"
+)
+
+type Clock interface {
+	Now() time.Time
+	Since(t time.Time) time.Duration
+}
+
+type clock struct{}
+
+func NewClock() *clock { return &clock{} }
+
+func (c clock) Since(t time.Time) time.Duration { return time.Since(t) }
+func (c clock) Now() time.Time                  { return time.Now() }
+
+// FixDateHeader sets the "Date" header to the current time in UTC if it is
+// missing or empty, as per RFC 9110 §6.6.1, and reports whether it was changed.
+//
+// NOTE: This cache forwards all requests to the client, so it MUST set the
+// "Date" header to the current time for responses that do not have it set.
+func FixDateHeader(h http.Header, receivedAt time.Time) bool {
+	if date, valid := RawTime(h.Get("Date")).Value(); !valid || date.IsZero() {
+		h.Set("Date", receivedAt.UTC().Format(http.TimeFormat))
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/bartventer/httpcache/internal/doc.go
+++ b/vendor/github.com/bartventer/httpcache/internal/doc.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package internal provides the core unexported functionality for the
+// httpcache package.
+package internal

--- a/vendor/github.com/bartventer/httpcache/internal/entry.go
+++ b/vendor/github.com/bartventer/httpcache/internal/entry.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"bufio"
+	"bytes"
+	"encoding"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"time"
+)
+
+// Response represents a cached HTTP response entry.
+type Response struct {
+	ID          string         // unique identifier for the response entry
+	Data        *http.Response // the actual HTTP response data
+	RequestedAt time.Time      // time when the request was made used for determining cache freshness
+	ReceivedAt  time.Time      // time when the response was received, used for determining cache freshness
+}
+
+var _ slog.LogValuer = (*Response)(nil)
+
+func (r Response) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("id", r.ID),
+		slog.Time("requested_at", r.RequestedAt),
+		slog.Time("received_at", r.ReceivedAt),
+		slog.String("status", r.Data.Status),
+		slog.Int("status_code", r.Data.StatusCode),
+	)
+}
+
+// DateHeader returns the parsed value of the "Date" header from the response.
+//
+// NOTE: It assumes a valid "Date" header has been set by [FixDateHeader].
+func (r *Response) DateHeader() time.Time {
+	date, _ := RawTime(r.Data.Header.Get("Date")).Value()
+	return date
+}
+
+// Deprecated: This function is a workaround for Kubernetes' handling of "UTC" Expires headers.
+func parseHTTPDateCompat(dateStr string) (t time.Time, err error) {
+	if os.Getenv("HTTPCACHE_ALLOW_UTC_DATETIMEFORMAT") == "1" {
+		// TODO(bartventer): PR Kubernetes to emit "GMT" per RFC 9110 §5.6.7.
+		// See k8s.io/kube-openapi/pkg/handler3/handler.go for "UTC" usage.
+		return time.Parse(time.RFC1123, dateStr)
+	}
+	return
+}
+
+func (r *Response) ExpiresHeader() (t time.Time, found bool, valid bool) {
+	expiresStr := r.Data.Header.Get("Expires")
+	if expiresStr == "" {
+		return
+	}
+	found = true
+	if t, valid = RawTime(expiresStr).Value(); valid {
+		return
+	}
+	expires, err := parseHTTPDateCompat(expiresStr)
+	if err != nil || expires.IsZero() {
+		return
+	}
+	return expires, true, true
+}
+
+func (r *Response) WriteTo(w io.Writer) (int64, error) {
+	n, err := fmt.Fprintf(
+		w,
+		"%s\t%s\t%s\n",
+		r.ID,
+		r.RequestedAt.Format(time.RFC3339Nano),
+		r.ReceivedAt.Format(time.RFC3339Nano),
+	)
+	return int64(n), err
+}
+
+var _ encoding.BinaryMarshaler = (*Response)(nil)
+
+func (r Response) MarshalBinary() ([]byte, error) {
+	respBytes, err := httputil.DumpResponse(r.Data, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	var buf bytes.Buffer
+	_, err = r.WriteTo(&buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write metadata: %w", err)
+	}
+	buf.Write(respBytes)
+	return buf.Bytes(), nil
+}
+
+var (
+	errReadBytes       = errors.New("failed to read bytes")
+	errInvalidMetaLine = errors.New("invalid metadata line format")
+	errInvalidResponse = errors.New("invalid response")
+)
+
+// ParseResponse parses a cached HTTP response entry from binary data and reconstructs
+// a [Response] using the provided request for context. Returns an error if parsing fails.
+func ParseResponse(data []byte, req *http.Request) (resp *Response, err error) {
+	reader := bufio.NewReader(bytes.NewReader(data))
+	metaLine, err := reader.ReadBytes('\n')
+	if err != nil {
+		return nil, errors.Join(errReadBytes, fmt.Errorf("failed to read metadata line: %w", err))
+	}
+	metaLine = bytes.TrimSpace(metaLine)
+	parts := bytes.Split(metaLine, []byte("\t"))
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("%w: expected 3 parts, got %d", errInvalidMetaLine, len(parts))
+	}
+	resp = new(Response)
+	resp.ID = string(parts[0])
+	resp.RequestedAt, _ = time.Parse(time.RFC3339Nano, string(parts[1]))
+	resp.ReceivedAt, _ = time.Parse(time.RFC3339Nano, string(parts[2]))
+	//nolint:bodyclose // The response body is not closed here, as it may be reused later.
+	r, err := http.ReadResponse(reader, req)
+	if err != nil {
+		return nil, errors.Join(errInvalidResponse, fmt.Errorf("failed to read response: %w", err))
+	}
+	resp.Data = r
+	return resp, nil
+}
+
+// ResponseRef represents a reference to a cached HTTP response.
+type ResponseRef struct {
+	ResponseID   string            `json:"id"`                   // unique identifier for the response entry.
+	Vary         string            `json:"vary"`                 // value of the Vary response header.
+	VaryResolved map[string]string `json:"vary_resolved"`        // resolved varying request headers, keys are canonicalized.
+	ReceivedAt   time.Time         `json:"received_at,omitzero"` // when the response was generated.
+}
+
+var _ slog.LogValuer = (*ResponseRef)(nil)
+
+func (r ResponseRef) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("response_id", r.ResponseID),
+		slog.String("vary", r.Vary),
+		slog.Any("vary_resolved", r.VaryResolved),
+		slog.Time("received_at", r.ReceivedAt),
+	)
+}
+
+type ResponseRefs []*ResponseRef
+
+func (he ResponseRefs) ResponseIDs() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for _, entry := range he {
+			if !yield(entry.ResponseID) {
+				return
+			}
+		}
+	}
+}

--- a/vendor/github.com/bartventer/httpcache/internal/freshness.go
+++ b/vendor/github.com/bartventer/httpcache/internal/freshness.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"cmp"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type Age struct {
+	Value     time.Duration // Age of the cached response (RFC9111 §4.2.3)
+	Timestamp time.Time     // Time when the age was calculated
+}
+
+var _ slog.LogValuer = (*Age)(nil)
+
+func (a Age) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Duration("value", a.Value),
+		slog.Time("timestamp", a.Timestamp),
+	)
+}
+
+type Freshness struct {
+	IsStale    bool          // Whether the response is stale
+	Age        *Age          // Current age (seconds) of the response (RFC9111 §4.2.3)
+	UsefulLife time.Duration // Freshness lifetime (seconds) of the response (RFC9111 §4.2.1)
+}
+
+var _ slog.LogValuer = (*Freshness)(nil)
+
+func (f Freshness) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Bool("is_stale", f.IsStale),
+		slog.Any("age", cmp.Or(f.Age, &Age{Value: 0, Timestamp: time.Time{}})),
+		slog.Duration("useful_life", f.UsefulLife),
+	)
+}
+
+// heuristicFreshness calculates freshness lifetime using heuristics (10% of (date - last-modified)),
+// per RFC9111 §4.2.2.
+func heuristicFreshness(h http.Header, date time.Time) time.Duration {
+	lastMod, ok := RawTime(h.Get("Last-Modified")).Value()
+	if !ok || !lastMod.Before(date) {
+		return 0
+	}
+	delta := date.Sub(lastMod)
+	return time.Duration(float64(delta) * 0.1).Round(time.Second)
+}
+
+// calculateCurrentAge implements RFC9111 §4.2.3 for calculating the current age of a cached response
+// based on the Age header, response time, request time, and the current clock time.
+func calculateCurrentAge(
+	clock Clock,
+	h http.Header,
+	date, requestTime, responseTime time.Time,
+) *Age {
+	ageVal := 0
+	if ageStr := h.Get("Age"); ageStr != "" {
+		ageVal, _ = strconv.Atoi(ageStr)
+	}
+	apparentAge := max(responseTime.Sub(date), 0)
+	responseDelay := max(responseTime.Sub(requestTime), 0)
+	correctedAgeValue := time.Duration(ageVal)*time.Second + responseDelay
+	correctedInitialAge := max(apparentAge, correctedAgeValue)
+	residentTime := max(clock.Since(responseTime), 0)
+	return &Age{
+		Value:     correctedInitialAge + residentTime,
+		Timestamp: clock.Now(),
+	}
+}
+
+const maxDuration = 1<<63 - 1
+
+// FreshnessCalculator describes the interface implemented by types that can
+// calculate the freshness of a cached response based on request and response
+// cache control directives according to RFC 9111 §4.2.
+type FreshnessCalculator interface {
+	// CalculateFreshness calculates the freshness of a cached response
+	// based on the request and response cache control directives.
+	CalculateFreshness(
+		resp *Response,
+		reqCC CCRequestDirectives,
+		resCC CCResponseDirectives,
+	) *Freshness
+}
+
+func NewFreshnessCalculator(clock Clock) *freshnessCalculator {
+	return &freshnessCalculator{clock}
+}
+
+type freshnessCalculator struct {
+	clock Clock // Clock interface to get current time
+}
+
+// calculateFreshnessStatus determines if a cached response is fresh or stale based on RFC9111 §4.2.
+// It considers request and response headers, cache directives, and timestamps.
+//
+//nolint:cyclop // Cyclomatic complexity is high due to multiple conditions, but it's necessary for RFC compliance.
+func (f *freshnessCalculator) CalculateFreshness(
+	entry *Response,
+	reqCC CCRequestDirectives,
+	resCC CCResponseDirectives,
+) *Freshness {
+	if reqMaxAge, ok := reqCC.MaxAge(); ok && reqMaxAge == 0 {
+		return &Freshness{
+			IsStale:    true,
+			Age:        &Age{Value: 0, Timestamp: f.clock.Now()},
+			UsefulLife: 0,
+		}
+	}
+
+	resp := entry.Data
+	date := entry.DateHeader()
+	currentAge := calculateCurrentAge(
+		f.clock,
+		resp.Header,
+		date,
+		entry.RequestedAt,
+		entry.ReceivedAt,
+	)
+
+	// Freshness lifetime (private cache: ignore s-maxage)
+	usefulLife := time.Duration(0)
+	if maxAge, ok := resCC.MaxAge(); ok && maxAge >= 0 {
+		usefulLife = maxAge // Response is fresh for max-age seconds
+	}
+
+	if usefulLife == 0 {
+		expires, found, valid := entry.ExpiresHeader()
+		switch {
+		case valid && expires.After(date):
+			// Use Expires header if available
+			usefulLife = expires.Sub(date)
+		case !found && (isHeuristicallyCacheableCode(resp.StatusCode) || resCC.Public()):
+			// Heuristic fallback if allowed by RFC9111 §4.2.2 (only if expires is not set)
+			usefulLife = heuristicFreshness(resp.Header, date)
+		}
+	}
+
+	if reqMaxAge, ok := reqCC.MaxAge(); ok && reqMaxAge > 0 {
+		usefulLife = min(usefulLife, reqMaxAge) // Client prefers a response no older than max-age
+	}
+	if reqMinFresh, ok := reqCC.MinFresh(); ok && reqMinFresh > 0 &&
+		(usefulLife-currentAge.Value) < reqMinFresh {
+		return &Freshness{IsStale: true, Age: currentAge, UsefulLife: usefulLife}
+	}
+
+	maxStale := time.Duration(0)
+	if reqMaxStaleStr, ok := reqCC.MaxStale(); ok {
+		if reqMaxStaleStr == "" {
+			maxStale = maxDuration // accept any staleness
+		} else if reqMaxStale, valid := reqMaxStaleStr.Value(); valid && reqMaxStale >= 0 {
+			maxStale = reqMaxStale
+		}
+	}
+
+	isStale := currentAge.Value >= usefulLife
+	// If max-stale present, allow extra staleness
+	if isStale && maxStale > 0 && currentAge.Value < max(usefulLife+maxStale, maxStale) {
+		isStale = false
+	}
+
+	return &Freshness{IsStale: isStale, Age: currentAge, UsefulLife: usefulLife}
+}

--- a/vendor/github.com/bartventer/httpcache/internal/header.go
+++ b/vendor/github.com/bartventer/httpcache/internal/header.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+const (
+	CacheStatusHeader = "X-Httpcache-Status"
+	FromCacheHeader   = "X-From-Cache" // Deprecated: use [CacheStatusHeader] instead
+)
+
+type CacheStatus struct {
+	Value string
+	// Value for compatibility with github.com/gregjones/httpcache:
+	// 	"1" means served from cache (less specific "HIT")
+	// 	"" means not served from cache (less specific "MISS")
+	//
+	// Deprecated: only used for compatibility with unmaintained (still widely
+	// used) github.com/gregjones/httpcache; use Value instead.
+	Legacy string
+}
+
+func (s CacheStatus) ApplyTo(header http.Header) {
+	header.Set(CacheStatusHeader, s.Value)
+	if s.Legacy != "" {
+		header.Set(FromCacheHeader, s.Legacy)
+	}
+}
+
+var _ slog.LogValuer = (*CacheStatus)(nil)
+
+func (s CacheStatus) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("value", s.Value),
+		slog.Bool("from_cache", s.Legacy == FromCache),
+	)
+}
+
+const (
+	FromCache    = "1"
+	NotFromCache = ""
+)
+
+var (
+	CacheStatusHit         = CacheStatus{"HIT", FromCache}         // served from cache
+	CacheStatusMiss        = CacheStatus{"MISS", NotFromCache}     // served from origin
+	CacheStatusStale       = CacheStatus{"STALE", FromCache}       // served from cache but stale
+	CacheStatusRevalidated = CacheStatus{"REVALIDATED", FromCache} // revalidated with origin server
+	CacheStatusBypass      = CacheStatus{"BYPASS", NotFromCache}   // cache bypassed
+)

--- a/vendor/github.com/bartventer/httpcache/internal/helpers.go
+++ b/vendor/github.com/bartventer/httpcache/internal/helpers.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"iter"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/bartventer/httpcache/internal/urlutil"
+)
+
+// sameOrigin checks if two URIs have the same origin (scheme, host, port).
+func sameOrigin(a, b *url.URL) bool {
+	aPort := a.Port()
+	if aPort == "" {
+		aPort = urlutil.DefaultPort(a.Scheme)
+	}
+	bPort := b.Port()
+	if bPort == "" {
+		bPort = urlutil.DefaultPort(b.Scheme)
+	}
+	return strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		aPort == bPort
+}
+
+// SetAgeHeader sets the Age header in the response based on the Age value.
+// It assumes a non-nil Age pointer is provided.
+func SetAgeHeader(resp *http.Response, clock Clock, age *Age) {
+	adjusted := max(age.Value+clock.Since(age.Timestamp), 0)
+	resp.Header.Set("Age", strconv.Itoa(int(adjusted.Seconds())))
+}
+
+// hopByHopHeaders returns a map of hop-by-hop headers that should be removed
+// from the response before caching or forwarding it (RFC 9111 §3.1).
+func hopByHopHeaders(respHeader http.Header) map[string]struct{} {
+	m := map[string]struct{}{
+		// As per RFC 9111 §7.6.1 (https://www.rfc-editor.org/rfc/rfc9110#section-7.6.1)
+		"Connection":        {},
+		"Proxy-Connection":  {},
+		"Keep-Alive":        {},
+		"TE":                {},
+		"Transfer-Encoding": {},
+		"Upgrade":           {},
+		// RFC 9111 §3.1 proxy headers
+		"Proxy-Authenticate":        {},
+		"Proxy-Authentication-Info": {},
+		"Proxy-Authorization":       {},
+		// Also see net/http/response.go "respExcludeHeader" for additional excluded headers.
+	}
+	// Fields listed in the Connection header field
+	for field := range TrimmedCSVCanonical(respHeader.Get("Connection")) {
+		m[field] = struct{}{}
+	}
+	return m
+}
+
+// removeHopByHopHeaders removes hop-by-hop headers so that only
+// end-to-end headers remain in the response as per RFC 9111 §3.1.
+func removeHopByHopHeaders(resp *http.Response) {
+	for hdr := range hopByHopHeaders(resp.Header) {
+		delete(resp.Header, hdr)
+	}
+}
+
+// mergeResponseHeaders merges the headers from the revalidated response into
+// the stored response, excluding hop-by-hop headers and the Content-Length
+// header, as per RFC 9111 §3.2.
+func mergeResponseHeaders(targetResp *http.Response, srcHdrs http.Header) {
+	nonCacheHdrs := hopByHopHeaders(srcHdrs)
+	nonCacheHdrs["Content-Length"] = struct{}{}
+	for hdr, val := range srcHdrs {
+		if _, ok := nonCacheHdrs[hdr]; ok {
+			continue
+		}
+		targetResp.Header[hdr] = val
+	}
+}
+
+// isStaleErrorAllowed reports whether the cache is allowed to serve a stale response
+// for the given error status code, according to RFC5861 §4.
+func isStaleErrorAllowed(code int) bool {
+	switch code {
+	case http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsUnsafeMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsNonErrorStatus(status int) bool {
+	return (status >= 200 && status < 400)
+}
+
+// TrimmedCSV returns an iterator over the raw comma-separated string.
+// It yields each part of the string, trimmed of whitespace, and does not split inside quoted strings.
+func TrimmedCSV(s string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		var part strings.Builder
+		inQuotes := false
+		escape := false
+		for i := range len(s) {
+			c := s[i]
+			switch {
+			case escape:
+				part.WriteByte(c)
+				escape = false
+			case c == '\\':
+				part.WriteByte(c)
+				escape = true
+			case c == '"':
+				part.WriteByte(c)
+				inQuotes = !inQuotes
+			case c == ',' && !inQuotes:
+				p := textproto.TrimString(part.String())
+				if len(p) > 0 {
+					if !yield(p) {
+						return
+					}
+				}
+				part.Reset()
+			default:
+				part.WriteByte(c)
+			}
+		}
+		if part.Len() > 0 {
+			p := textproto.TrimString(part.String())
+			if len(p) > 0 {
+				_ = yield(p)
+			}
+		}
+	}
+}
+
+// TrimmedCSVCanonical is the same as [TrimmedCSV], but it yields each part
+// in canonical form.
+func TrimmedCSVCanonical(s string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for part := range TrimmedCSV(s) {
+			if !yield(http.CanonicalHeaderKey(part)) {
+				return
+			}
+		}
+	}
+}
+
+func hasToken[Map ~map[K]V, K comparable, V any](m Map, token K) bool {
+	_, ok := m[token]
+	return ok
+}

--- a/vendor/github.com/bartventer/httpcache/internal/log.go
+++ b/vendor/github.com/bartventer/httpcache/internal/log.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"runtime"
+	"slices"
+	"time"
+)
+
+type contextKey struct{}
+
+func (c contextKey) String() string { return "httpcache context key" }
+
+var TraceIDKey contextKey
+
+func TraceIDFromContext(ctx context.Context) (string, bool) {
+	traceID, ok := ctx.Value(TraceIDKey).(string)
+	return traceID, ok
+}
+
+/*
+	+-------------------------------+
+	| Log Field Types   			|
+	+-------------------------------+
+*/
+
+type (
+	LogEntry struct {
+		URLKey       string
+		MiscProvider MiscProvider
+		Error        error
+	}
+
+	Misc struct {
+		CCReq     CCRequestDirectives
+		CCResp    CCResponseDirectives
+		Stored    *Response
+		Freshness *Freshness
+		Refs      ResponseRefs
+		RefIndex  int
+	}
+)
+
+func (m Misc) LogValue() slog.Value {
+	attrs := make([]slog.Attr, 0, 5)
+	if m.CCReq != nil {
+		attrs = append(attrs, slog.Any("cc_request", m.CCReq))
+	}
+	if m.CCResp != nil {
+		attrs = append(attrs, slog.Any("cc_response", m.CCResp))
+	}
+	if m.Stored != nil {
+		attrs = append(attrs, slog.Any("stored", m.Stored))
+	}
+	if m.Freshness != nil {
+		attrs = append(attrs, slog.Any("freshness", m.Freshness))
+	}
+	if m.RefIndex >= 0 && m.RefIndex < len(m.Refs) {
+		attrs = append(attrs, slog.Any("ref", m.Refs[m.RefIndex]))
+	}
+	if cap(attrs) > len(attrs) {
+		attrs = slices.Clip(attrs)
+	}
+	return slog.GroupValue(attrs...)
+}
+
+/*
+	+-------------------------------+
+	| Provider Interfaces			|
+	+-------------------------------+
+*/
+
+type (
+	LogProvider interface {
+		MakeLog() (CacheStatus, *http.Request, LogEntry)
+	}
+	MiscProvider interface {
+		MakeMisc() Misc
+	}
+)
+
+type (
+	LogFunc      func() (CacheStatus, *http.Request, LogEntry)
+	MiscFunc     func() Misc
+	LogValueFunc func() slog.Value
+)
+
+func (f LogFunc) MakeLog() (event CacheStatus, req *http.Request, cl LogEntry) {
+	return f()
+}
+
+func (f MiscFunc) MakeMisc() Misc           { return f() }
+func (f LogValueFunc) LogValue() slog.Value { return f() }
+
+/*
+	+-------------------------------+
+	| Logger Implementation			|
+	+-------------------------------+
+*/
+
+type Logger struct{ handler slog.Handler }
+
+func NewLogger(h slog.Handler) *Logger { return &Logger{handler: h} }
+
+func (l *Logger) Handler() slog.Handler { return l.handler }
+
+func (l *Logger) Enabled(ctx context.Context, level slog.Level) bool {
+	return l.handler.Enabled(ctx, level)
+}
+
+func (l *Logger) With(attrs ...slog.Attr) *Logger {
+	if len(attrs) == 0 {
+		return l
+	}
+	return &Logger{handler: l.handler.WithAttrs(attrs)}
+}
+
+func (l *Logger) WithGroup(name string) *Logger {
+	if name == "" {
+		return l
+	}
+	return &Logger{handler: l.handler.WithGroup(name)}
+}
+
+func (l *Logger) LogCacheHit(req *http.Request, urlKey string, mp MiscProvider) {
+	l.logCache(
+		req.Context(),
+		slog.LevelDebug,
+		"Hit; served from cache.",
+		LogFunc(func() (CacheStatus, *http.Request, LogEntry) {
+			return CacheStatusHit, req, LogEntry{
+				URLKey:       urlKey,
+				MiscProvider: mp,
+				Error:        nil,
+			}
+		}),
+	)
+}
+
+func (l *Logger) LogCacheMiss(req *http.Request, urlKey string, mp MiscProvider) {
+	l.logCache(
+		req.Context(),
+		slog.LevelDebug,
+		"Miss; served from origin.",
+		LogFunc(func() (CacheStatus, *http.Request, LogEntry) {
+			return CacheStatusMiss, req, LogEntry{
+				URLKey:       urlKey,
+				MiscProvider: mp,
+				Error:        nil,
+			}
+		}),
+	)
+}
+
+func (l *Logger) LogCacheStale(req *http.Request, urlKey string, mp MiscProvider) {
+	l.logCache(
+		req.Context(),
+		slog.LevelDebug,
+		"Stale; served from cache.",
+		LogFunc(func() (CacheStatus, *http.Request, LogEntry) {
+			return CacheStatusStale, req, LogEntry{
+				URLKey:       urlKey,
+				MiscProvider: mp,
+				Error:        nil,
+			}
+		}),
+	)
+}
+
+func (l *Logger) LogCacheStaleIfError(req *http.Request, urlKey string, mp MiscProvider) {
+	l.logCache(
+		req.Context(),
+		slog.LevelDebug,
+		"Stale; served from cache; stale-if-error policy applied.",
+		LogFunc(func() (CacheStatus, *http.Request, LogEntry) {
+			return CacheStatusStale, req, LogEntry{
+				URLKey:       urlKey,
+				MiscProvider: mp,
+				Error:        nil,
+			}
+		}),
+	)
+}
+
+func (l *Logger) LogCacheStaleRevalidate(req *http.Request, urlKey string, mp MiscProvider) {
+	l.logCache(
+		req.Context(),
+		slog.LevelDebug,
+		"Stale; served from cache; revalidating.",
+		LogFunc(func() (CacheStatus, *http.Request, LogEntry) {
+			return CacheStatusStale, req, LogEntry{
+				URLKey:       urlKey,
+				MiscProvider: mp,
+				Error:        nil,
+			}
+		}),
+	)
+}
+
+func (l *Logger) LogCacheRevalidated(req *http.Request, urlKey string, mp MiscProvider) {
+	l.logCache(
+		req.Context(),
+		slog.LevelDebug,
+		"Revalidated; served cached response.",
+		LogFunc(func() (CacheStatus, *http.Request, LogEntry) {
+			return CacheStatusRevalidated, req, LogEntry{
+				URLKey:       urlKey,
+				MiscProvider: mp,
+				Error:        nil,
+			}
+		}),
+	)
+}
+
+func (l *Logger) LogCacheBypass(msg string, req *http.Request, urlKey string, mp MiscProvider) {
+	l.logCache(
+		req.Context(),
+		slog.LevelDebug,
+		msg,
+		LogFunc(func() (CacheStatus, *http.Request, LogEntry) {
+			return CacheStatusBypass, req, LogEntry{
+				URLKey:       urlKey,
+				MiscProvider: mp,
+				Error:        nil,
+			}
+		}),
+	)
+}
+
+func (l *Logger) LogCacheError(
+	msg string,
+	err error,
+	req *http.Request,
+	urlKey string,
+	mp MiscProvider,
+) {
+	l.logCache(
+		req.Context(),
+		slog.LevelWarn,
+		msg,
+		LogFunc(func() (CacheStatus, *http.Request, LogEntry) {
+			return CacheStatus{Value: "error"}, req, LogEntry{
+				URLKey:       urlKey,
+				MiscProvider: mp,
+				Error:        err,
+			}
+		}),
+	)
+}
+
+func (l *Logger) logCache(ctx context.Context, level slog.Level, msg string, lp LogProvider) {
+	if !l.handler.Enabled(ctx, level) {
+		return
+	}
+	event, req, cl := lp.MakeLog()
+	attrs := make([]slog.Attr, 0, 7)
+	attrs = append(attrs,
+		slog.String("service", "httpcache"),
+		slog.String("event", event.Value),
+	)
+	if cl.Error != nil {
+		attrs = append(attrs, slog.Any("error", cl.Error))
+	}
+	if tracedID, ok := TraceIDFromContext(ctx); ok && tracedID != "" {
+		attrs = append(attrs, slog.String("trace_id", tracedID))
+	}
+	attrs = append(attrs,
+		slog.GroupAttrs("request",
+			slog.String("method", req.Method),
+			slog.String("url", req.URL.String()),
+			slog.String("host", req.Host),
+		),
+		slog.GroupAttrs("cache",
+			slog.Any("status", event),
+			slog.String("url_key", cl.URLKey),
+		),
+	)
+	if mp := cl.MiscProvider; mp != nil {
+		attrs = append(attrs, slog.Any("misc", mp.MakeMisc()))
+	}
+	if cap(attrs) > len(attrs) {
+		attrs = slices.Clip(attrs)
+	}
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:])
+	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	r.AddAttrs(attrs...)
+	_ = l.handler.Handle(ctx, r)
+}

--- a/vendor/github.com/bartventer/httpcache/internal/mocks.go
+++ b/vendor/github.com/bartventer/httpcache/internal/mocks.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+)
+
+var _ Cache = (*MockCache)(nil)
+
+type MockCache struct {
+	GetFunc    func(key string) ([]byte, error)
+	SetFunc    func(key string, entry []byte) error
+	DeleteFunc func(key string) error
+}
+
+func (m *MockCache) Get(key string) ([]byte, error) {
+	return m.GetFunc(key)
+}
+
+func (m *MockCache) Set(key string, entry []byte) error {
+	return m.SetFunc(key, entry)
+}
+
+func (m *MockCache) Delete(key string) error {
+	return m.DeleteFunc(key)
+}
+
+var _ ResponseCache = (*MockResponseCache)(nil)
+
+type MockResponseCache struct {
+	GetFunc     func(key string, req *http.Request) (*Response, error)
+	SetFunc     func(key string, entry *Response) error
+	DeleteFunc  func(key string) error
+	GetRefsFunc func(key string) (ResponseRefs, error)
+	SetRefsFunc func(key string, headers ResponseRefs) error
+}
+
+func (m *MockResponseCache) GetRefs(key string) (ResponseRefs, error) {
+	return m.GetRefsFunc(key)
+}
+
+func (m *MockResponseCache) SetRefs(key string, headers ResponseRefs) error {
+	return m.SetRefsFunc(key, headers)
+}
+
+func (m *MockResponseCache) Get(key string, req *http.Request) (*Response, error) {
+	return m.GetFunc(key, req)
+}
+func (m *MockResponseCache) Set(key string, entry *Response) error {
+	return m.SetFunc(key, entry)
+}
+func (m *MockResponseCache) Delete(key string) error {
+	return m.DeleteFunc(key)
+}
+
+var _ RequestMethodChecker = (*MockRequestMethodChecker)(nil)
+
+type MockRequestMethodChecker struct {
+	IsRequestMethodUnderstoodFunc func(req *http.Request) bool
+}
+
+func (m *MockRequestMethodChecker) IsRequestMethodUnderstood(req *http.Request) bool {
+	return m.IsRequestMethodUnderstoodFunc(req)
+}
+
+var _ VaryMatcher = (*MockVaryMatcher)(nil)
+
+type MockVaryMatcher struct {
+	VaryHeadersMatchFunc func(cachedHdrs ResponseRefs, reqHdr http.Header) (int, bool)
+}
+
+func (m *MockVaryMatcher) VaryHeadersMatch(
+	cachedHdrs ResponseRefs,
+	reqHdr http.Header,
+) (int, bool) {
+	return m.VaryHeadersMatchFunc(cachedHdrs, reqHdr)
+}
+
+var _ URLKeyer = (*MockCacheKeyer)(nil)
+
+type MockCacheKeyer struct {
+	CacheKeyFunc func(u *url.URL) string
+}
+
+func (m *MockCacheKeyer) URLKey(u *url.URL) string {
+	return m.CacheKeyFunc(u)
+}
+
+var _ StaleIfErrorPolicy = (*MockStaleIfErrorPolicy)(nil)
+
+type MockStaleIfErrorPolicy struct {
+	CanStaleOnErrorFunc func(freshness *Freshness, sies ...StaleIfErrorer) bool
+}
+
+func (m *MockStaleIfErrorPolicy) CanStaleOnError(
+	freshness *Freshness,
+	sies ...StaleIfErrorer,
+) bool {
+	return m.CanStaleOnErrorFunc(freshness, sies...)
+}
+
+var _ FreshnessCalculator = (*MockFreshnessCalculator)(nil)
+
+type MockFreshnessCalculator struct {
+	CalculateFreshnessFunc func(resp *http.Response, reqCC CCRequestDirectives, resCC CCResponseDirectives) *Freshness
+}
+
+func (m *MockFreshnessCalculator) CalculateFreshness(
+	resp *Response,
+	reqCC CCRequestDirectives,
+	resCC CCResponseDirectives,
+) *Freshness {
+	return m.CalculateFreshnessFunc(resp.Data, reqCC, resCC)
+}
+
+var _ Clock = (*MockClock)(nil)
+
+type MockClock struct {
+	NowResult   time.Time
+	SinceResult time.Duration
+}
+
+func (m *MockClock) Now() time.Time                  { return m.NowResult }
+func (m *MockClock) Since(t time.Time) time.Duration { return m.SinceResult }
+
+var _ http.RoundTripper = (*MockRoundTripper)(nil)
+
+type MockRoundTripper struct {
+	RoundTripFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.RoundTripFunc(req)
+}
+
+var _ ResponseStorer = (*MockResponseStorer)(nil)
+
+type MockResponseStorer struct {
+	StoreResponseFunc func(req *http.Request, resp *http.Response, key string, headers ResponseRefs, reqTime, respTime time.Time, refIndex int) error
+}
+
+func (m *MockResponseStorer) StoreResponse(
+	req *http.Request,
+	resp *http.Response,
+	key string,
+	headers ResponseRefs,
+	reqTime, respTime time.Time,
+	refIndex int,
+) error {
+	return m.StoreResponseFunc(req, resp, key, headers, reqTime, respTime, refIndex)
+}
+
+var _ CacheInvalidator = (*MockCacheInvalidator)(nil)
+
+type MockCacheInvalidator struct {
+	InvalidateCacheFunc func(reqURL *url.URL, respHeader http.Header, headers ResponseRefs, key string)
+}
+
+func (m *MockCacheInvalidator) InvalidateCache(
+	reqURL *url.URL,
+	respHeader http.Header,
+	headers ResponseRefs,
+	key string,
+) {
+	m.InvalidateCacheFunc(reqURL, respHeader, headers, key)
+}
+
+var _ ValidationResponseHandler = (*MockValidationResponseHandler)(nil)
+
+type MockValidationResponseHandler struct {
+	HandleValidationResponseFunc func(ctx RevalidationContext, req *http.Request, resp *http.Response) (*http.Response, error)
+}
+
+func (m *MockValidationResponseHandler) HandleValidationResponse(
+	ctx RevalidationContext,
+	req *http.Request,
+	resp *http.Response,
+) (*http.Response, error) {
+	return m.HandleValidationResponseFunc(ctx, req, resp)
+}
+
+var _ VaryMatcher = (*MockVaryMatcher)(nil)

--- a/vendor/github.com/bartventer/httpcache/internal/normalization.go
+++ b/vendor/github.com/bartventer/httpcache/internal/normalization.go
@@ -1,0 +1,350 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"cmp"
+	"hash/fnv"
+	"iter"
+	"maps"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"unique"
+)
+
+// normalizationHeader interns the sets of header fields that require specific normalization.
+var normalizationHeader struct {
+	sync.Once
+	byQValue,
+	byEncoding, byTimeInsensitive,
+	byOrderInsensitive, byCaseInsensitive map[string]struct{}
+}
+
+func initNormalizationHeader() {
+	normalizationHeader.Do(func() {
+		normalizationHeader.byQValue = make(map[string]struct{})
+		for _, field := range []string{
+			"Accept",
+			"Accept-Charset",
+			"Accept-Language",
+		} {
+			normalizationHeader.byQValue[field] = struct{}{}
+		}
+
+		normalizationHeader.byEncoding = make(map[string]struct{})
+		for _, field := range []string{
+			"Content-Encoding",
+			// The below can also accept quality values, see RFC 9110
+			"Accept-Encoding",
+			"TE",
+		} {
+			normalizationHeader.byEncoding[field] = struct{}{}
+		}
+
+		normalizationHeader.byTimeInsensitive = make(map[string]struct{})
+		for _, field := range []string{
+			"If-Modified-Since",
+			"If-Unmodified-Since",
+			"Date",
+		} {
+			normalizationHeader.byTimeInsensitive[field] = struct{}{}
+		}
+
+		normalizationHeader.byOrderInsensitive = make(map[string]struct{})
+		for _, field := range []string{
+			"Cache-Control",
+			"Connection",
+			"Content-Language",
+			"Expect",
+			"Pragma",
+			"Upgrade",
+			"Vary",
+			"Via",
+		} {
+			normalizationHeader.byOrderInsensitive[field] = struct{}{}
+		}
+
+		normalizationHeader.byCaseInsensitive = make(map[string]struct{})
+		for _, field := range []string{
+			"Content-Type",
+			"Content-Disposition",
+			"Host",
+			"Referer",
+			"User-Agent",
+			"Server",
+			"Origin",
+		} {
+			normalizationHeader.byCaseInsensitive[field] = struct{}{}
+		}
+	})
+}
+
+func hasNormalizationHeader(m map[string]struct{}, field string) bool {
+	_, ok := m[field]
+	return ok
+}
+
+// normalizeHeaderValue normalizes a header value according to the rules defined
+// in RFC 9111 §4.1. Assumes a canonicalized header field name.
+func normalizeHeaderValue(field, value string) string {
+	if value == "" {
+		return ""
+	}
+
+	initNormalizationHeader()
+	switch {
+	case hasNormalizationHeader(normalizationHeader.byEncoding, field):
+		value = normalizeEncodingHeader(value)
+		if field == "Content-Encoding" {
+			// No quality values.
+			return value
+		}
+		fallthrough
+
+	case hasNormalizationHeader(normalizationHeader.byQValue, field):
+		return normalizeOrderInsensitiveWithQValues(value)
+
+	case hasNormalizationHeader(normalizationHeader.byOrderInsensitive, field):
+		return normalizeOrderInsensitive(value)
+
+	case hasNormalizationHeader(normalizationHeader.byCaseInsensitive, field):
+		return strings.ToLower(value)
+
+	case hasNormalizationHeader(normalizationHeader.byTimeInsensitive, field):
+		return strings.TrimSpace(value)
+
+	case field == "Authorization":
+		parts := strings.SplitN(value, " ", 2)
+		if len(parts) == 2 {
+			return strings.ToLower(parts[0]) + " " + parts[1]
+		}
+		return value
+
+	default:
+		return value
+	}
+}
+
+// normalizeOrderInsensitive normalizes comma-separated values where order doesn't matter.
+func normalizeOrderInsensitive(value string) string {
+	parts := slices.Sorted(TrimmedCSV(value))
+	return strings.Join(parts, ",")
+}
+
+// Sentinel quality values for normalization.
+var (
+	maxQValue = unique.Make(1.0)
+	minQValue = unique.Make(0.001)
+)
+
+// normalizeOrderInsensitiveWithQValues handles headers with quality values.
+//
+// References:
+//   - https://www.rfc-editor.org/rfc/rfc9110.html#name-content-negotiation-field-f
+//   - https://www.rfc-editor.org/rfc/rfc9110.html#name-content-negotiation-fields
+func normalizeOrderInsensitiveWithQValues(value string) string {
+	type qualityValue struct {
+		main   string                 // the main value (e.g., "text/html")
+		q      unique.Handle[float64] // the quality value (q=0.8); default is 1.0
+		params []string               // any additional parameters (sorted)
+	}
+	parts := slices.Collect(TrimmedCSV(value))
+	qualityParts := make([]qualityValue, 0, len(parts))
+outer:
+	for i := range parts {
+		part := parts[i]
+		main, allParamsRaw, found := strings.Cut(part, ";")
+		q := maxQValue
+		params := make([]string, 0, 2)
+		if found {
+			for param := range strings.SplitSeq(allParamsRaw, ";") {
+				param = strings.TrimSpace(param)
+				switch {
+				// q is case insensitive
+				case len(param) > 2 && strings.EqualFold(param[:2], "q="):
+					qRaw := param[2:]
+					if qRaw == "0" || qRaw == "0.0" {
+						continue outer // skip this part, as it has q=0
+					}
+					if qVal, err := strconv.ParseFloat(qRaw, 64); err == nil {
+						q = unique.Make(
+							min(max(qVal, minQValue.Value()), maxQValue.Value()),
+						)
+					}
+				case param != "":
+					params = append(params, param)
+				}
+			}
+			slices.Sort(params)
+		}
+		qualityParts = append(qualityParts, qualityValue{
+			main:   main,
+			q:      q,
+			params: slices.Clip(params),
+		})
+	}
+
+	// Sort by quality value, then by number of wildcards in main,
+	// then lexicographically by main, then by number of parameters,
+	// then lexicographically by parameters.
+	slices.SortFunc(qualityParts, func(a, b qualityValue) int {
+		return cmp.Or(
+			cmp.Compare(b.q.Value(), a.q.Value()),
+			cmp.Compare(strings.Count(a.main, "*"), strings.Count(b.main, "*")),
+			cmp.Compare(a.main, b.main),
+			cmp.Compare(len(b.params), len(a.params)),
+			slices.Compare(a.params, b.params),
+		)
+	})
+
+	// Keep first (highest ranked) for each main value
+	qualityParts = slices.CompactFunc(qualityParts, func(a, b qualityValue) bool {
+		return a.main == b.main
+	})
+
+	// Reconstruct
+	var s strings.Builder
+	for i, qp := range qualityParts {
+		if i > 0 {
+			s.WriteByte(',')
+		}
+		s.WriteString(qp.main)
+		for _, p := range qp.params {
+			s.WriteByte(';')
+			s.WriteString(p)
+		}
+		if qp.q != maxQValue {
+			s.WriteString(";q=")
+			s.WriteString(formatQValue(qp.q.Value()))
+		}
+	}
+	return s.String()
+}
+
+func formatQValue(q float64) string {
+	str := strconv.FormatFloat(q, 'f', 3, 64)
+	str = strings.TrimRight(str, "0")
+	return strings.TrimSuffix(str, ".")
+}
+
+// Aliases for encoding names (see RFC 9110 §16.6.1).
+//
+// References:
+//   - https://www.rfc-editor.org/rfc/rfc9110.html#name-content-coding
+//   - https://datatracker.ietf.org/doc/html/rfc9110#name-te
+//   - https://www.rfc-editor.org/rfc/rfc9112#section-7
+var encodingReplacer = strings.NewReplacer(
+	"x-gzip", "gzip",
+	"x-compress", "compress",
+)
+
+// normalizeEncodingHeader handles special cases for encoding headers.
+func normalizeEncodingHeader(value string) string {
+	value = encodingReplacer.Replace(value)
+	return normalizeOrderInsensitive(value)
+}
+
+func normalizedVaryHeader(vary string, reqHeader http.Header) iter.Seq2[string, string] {
+	return func(yield func(string, string) bool) {
+		for name := range TrimmedCSVCanonical(vary) {
+			values := reqHeader[name]
+			value := ""
+			// an empty value is valid and means "no variation"
+			if len(values) > 0 {
+				// NOTE: The policy of this cache is to use just the first header line
+				value = normalizeHeaderValue(name, values[0])
+			}
+			if !yield(name, value) {
+				return
+			}
+		}
+	}
+}
+
+// VaryHeaderNormalizer describes the interface implemented by types that can
+// normalize request header field values given a Vary header field value, as per
+// RFC 9111 §4.1.
+type VaryHeaderNormalizer interface {
+	NormalizeVaryHeader(vary string, reqHeader http.Header) iter.Seq2[string, string]
+}
+
+type VaryHeaderNormalizerFunc func(vary string, reqHeader http.Header) iter.Seq2[string, string]
+
+func (f VaryHeaderNormalizerFunc) NormalizeVaryHeader(
+	vary string,
+	reqHeader http.Header,
+) iter.Seq2[string, string] {
+	return f(vary, reqHeader)
+}
+
+func NewVaryHeaderNormalizer() VaryHeaderNormalizer {
+	return VaryHeaderNormalizerFunc(normalizedVaryHeader)
+}
+
+// HeaderValueNormalizer describes the interface implemented by types that can normalize
+// header field values according to the rules defined in RFC 9111 §4.1.
+type HeaderValueNormalizer interface {
+	NormalizeHeaderValue(field, value string) string
+}
+
+type HeaderValueNormalizerFunc func(field, value string) string
+
+func (f HeaderValueNormalizerFunc) NormalizeHeaderValue(field, value string) string {
+	return f(field, value)
+}
+
+func NewHeaderValueNormalizer() HeaderValueNormalizer {
+	return HeaderValueNormalizerFunc(normalizeHeaderValue)
+}
+
+// VaryKeyer describes the interface implemented by types that can generate a
+// unique key for a cached response based on the URL and Vary headers, according
+// to RFC 9111 §4.1.
+type VaryKeyer interface {
+	VaryKey(urlKey string, varyHeaders map[string]string) string
+}
+
+type VaryKeyerFunc func(urlKey string, varyHeaders map[string]string) string
+
+func (f VaryKeyerFunc) VaryKey(urlKey string, varyHeaders map[string]string) string {
+	return f(urlKey, varyHeaders)
+}
+
+func NewVaryKeyer() VaryKeyer { return VaryKeyerFunc(makeVaryKey) }
+
+const noVaryHash = "0"
+
+func makeVaryKey(urlKey string, varyHeaders map[string]string) string {
+	if len(varyHeaders) == 0 {
+		return urlKey + "#" + noVaryHash // No Vary headers, so no variations
+	}
+	varyHash := makeVaryHash(varyHeaders)
+	return urlKey + "#" + strconv.FormatUint(varyHash, 10)
+}
+
+func makeVaryHash(vary map[string]string) uint64 {
+	h := fnv.New64a()
+	keys := make([]string, 0, len(vary))
+	keys = slices.AppendSeq(keys, maps.Keys(vary))
+	slices.Sort(keys)
+	for _, k := range keys {
+		_, _ = h.Write([]byte(k))
+		_, _ = h.Write([]byte(vary[k]))
+	}
+	return h.Sum64()
+}

--- a/vendor/github.com/bartventer/httpcache/internal/quotedstring.go
+++ b/vendor/github.com/bartventer/httpcache/internal/quotedstring.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ParseQuotedString parses an HTTP quoted-string (RFC 9110 §5.6.4).
+// It returns the unescaped string, or the original string if parsing fails.
+func ParseQuotedString(s string) string {
+	result, err := ParseQuotedStringE(s)
+	if err != nil {
+		return s
+	}
+	return result
+}
+
+var (
+	errInvalidQuotedString = errors.New("httpcache: invalid quoted-string")
+	errUnfinishedEscape    = errors.New("httpcache: unfinished escape (quoted-pair)")
+	errInvalidCharacter    = errors.New("httpcache: invalid character in quoted-string")
+)
+
+// ParseQuotedStringE parses an HTTP quoted-string (RFC 9110 §5.6.4).
+// It returns the unescaped string, or an error if the input is not valid.
+func ParseQuotedStringE(s string) (string, error) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return "", fmt.Errorf(
+			"%w: %q does not start and end with DQUOTE",
+			errInvalidQuotedString,
+			s,
+		)
+	}
+	in := []byte(s[1 : len(s)-1])
+	var b strings.Builder
+	for i := 0; i < len(in); {
+		c := in[i]
+		if c == '\\' {
+			i++
+			if i >= len(in) {
+				return "", errUnfinishedEscape
+			}
+			// Quoted-pair: any byte allowed after '\'
+			b.WriteByte(in[i])
+			i++
+			continue
+		}
+		if validQDTextByte(c) {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		return "", fmt.Errorf("%w: %q contains invalid character %q at position %d",
+			errInvalidCharacter,
+			s,
+			c,
+			i+1, // +1 to account for the leading quote
+		)
+	}
+	return b.String(), nil
+}
+
+// validQDTextByte reports whether b is allowed as qdtext, per RFC 9110 §5.6.4.
+func validQDTextByte(b byte) bool {
+	switch {
+	case b == '\t' || b == ' ':
+		return true
+	case b == 0x21:
+		return true
+	case 0x23 <= b && b <= 0x5B:
+		return true
+	case 0x5D <= b && b <= 0x7E:
+		return true
+	case 0x80 <= b: // obs-text
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/bartventer/httpcache/internal/requestmethodchecker.go
+++ b/vendor/github.com/bartventer/httpcache/internal/requestmethodchecker.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+)
+
+// RequestMethodChecker describes the interface implemented by types that can
+// check whether the request method is understood by the cache according to RFC 9111 §3.
+type RequestMethodChecker interface {
+	IsRequestMethodUnderstood(req *http.Request) bool
+}
+
+type RequestMethodCheckerFunc func(req *http.Request) bool
+
+func (f RequestMethodCheckerFunc) IsRequestMethodUnderstood(req *http.Request) bool {
+	return f(req)
+}
+
+func NewRequestMethodChecker() RequestMethodChecker {
+	return RequestMethodCheckerFunc(isRequestMethodUnderstood)
+}
+
+func isRequestMethodUnderstood(req *http.Request) bool {
+	return req.Method == http.MethodGet && req.Header.Get("Range") == ""
+}

--- a/vendor/github.com/bartventer/httpcache/internal/responsecache.go
+++ b/vendor/github.com/bartventer/httpcache/internal/responsecache.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/bartventer/httpcache/store/driver"
+)
+
+type Cache = driver.Conn
+
+// ResponseCache is an interface for caching HTTP responses.
+// It provides methods to delete any cached item by its key,
+// retrieve and set full cached responses, and manage references associated
+// with a given URL key.
+type ResponseCache interface {
+	Get(key string, req *http.Request) (*Response, error)
+	Set(key string, entry *Response) error
+	Delete(key string) error
+	GetRefs(key string) (ResponseRefs, error)
+	SetRefs(key string, refs ResponseRefs) error
+}
+
+type responseCache struct {
+	cache Cache
+}
+
+func NewResponseCache(cache Cache) *responseCache {
+	return &responseCache{cache}
+}
+
+var _ ResponseCache = (*responseCache)(nil)
+
+type CacheError struct {
+	Op      string
+	Message string
+	Err     error
+}
+
+func (c *CacheError) Error() string { return fmt.Sprintf("%s: %s: %v", c.Op, c.Message, c.Err) }
+func (c *CacheError) Unwrap() error { return c.Err }
+
+func (c CacheError) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("op", c.Op),
+		slog.String("message", c.Message),
+		slog.Any("error", c.Err),
+	)
+}
+
+func newCacheError(err error, op, message string) *CacheError {
+	return &CacheError{Op: op, Message: message, Err: err}
+}
+
+var _ slog.LogValuer = (*CacheError)(nil)
+
+func (r *responseCache) Get(responseKey string, req *http.Request) (*Response, error) {
+	data, err := r.cache.Get(responseKey)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := ParseResponse(data, req)
+	if err != nil {
+		return nil, newCacheError(
+			err,
+			"Get",
+			fmt.Sprintf("failed to unmarshal cached entry for key %q", responseKey),
+		)
+	}
+	return entry, nil
+}
+
+func (r *responseCache) Set(responseKey string, entry *Response) error {
+	data, err := entry.MarshalBinary()
+	if err != nil {
+		return newCacheError(
+			err,
+			"Set",
+			fmt.Sprintf("failed to marshal entry for key %q", responseKey),
+		)
+	}
+	return r.cache.Set(responseKey, data)
+}
+
+func (r *responseCache) Delete(key string) error {
+	return r.cache.Delete(key)
+}
+
+func (r *responseCache) GetRefs(urlKey string) (ResponseRefs, error) {
+	data, err := r.cache.Get(urlKey)
+	if err != nil {
+		return nil, err
+	}
+	var refs ResponseRefs
+	if unmarshalErr := json.Unmarshal(data, &refs); unmarshalErr != nil {
+		return nil, newCacheError(
+			unmarshalErr,
+			"GetRefs",
+			fmt.Sprintf("failed to unmarshal cached refs for key %q", urlKey),
+		)
+	}
+	return refs, nil
+}
+
+func (r *responseCache) SetRefs(urlKey string, refs ResponseRefs) error {
+	data, err := json.Marshal(refs)
+	if err != nil {
+		return newCacheError(
+			err,
+			"SetRefs",
+			fmt.Sprintf("failed to marshal refs for key %q", urlKey),
+		)
+	}
+	return r.cache.Set(urlKey, data)
+}

--- a/vendor/github.com/bartventer/httpcache/internal/responsestorerer.go
+++ b/vendor/github.com/bartventer/httpcache/internal/responsestorerer.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+)
+
+// ResponseStorer describes the interface implemented by types that can store HTTP responses
+// in a cache, as specified in RFC 9111 §3.1.
+//
+// If refs is nil, a new slice should be  created. If refIndex is valid, the
+// reference at that index should be updated; otherwise, a new reference should
+// be appended.
+type ResponseStorer interface {
+	StoreResponse(
+		req *http.Request,
+		resp *http.Response,
+		urlKey string,
+		refs ResponseRefs,
+		reqTime, respTime time.Time,
+		refIndex int,
+	) error
+}
+
+type responseStorer struct {
+	cache ResponseCache
+	vhn   VaryHeaderNormalizer
+	vk    VaryKeyer
+}
+
+func NewResponseStorer(cache ResponseCache, vhn VaryHeaderNormalizer, vk VaryKeyer) ResponseStorer {
+	return &responseStorer{cache, vhn, vk}
+}
+
+func (r *responseStorer) StoreResponse(
+	req *http.Request,
+	resp *http.Response,
+	urlKey string,
+	refs ResponseRefs,
+	reqTime, respTime time.Time,
+	refIndex int,
+) error {
+	// Remove hop-by-hop headers as per RFC 9111 §3.1
+	removeHopByHopHeaders(resp)
+
+	// Join multiple Vary headers into a single string
+	vary := strings.Join(resp.Header.Values("Vary"), ",")
+	varyResolved := maps.Collect(
+		r.vhn.NormalizeVaryHeader(vary, req.Header),
+	)
+	responseID := r.vk.VaryKey(urlKey, varyResolved)
+
+	respEntry := &Response{
+		Data:        resp,
+		RequestedAt: reqTime,
+		ReceivedAt:  respTime,
+		ID:          responseID,
+	}
+	_ = r.cache.Set(responseID, respEntry)
+
+	switch {
+	case refs == nil:
+		refs = make(ResponseRefs, 0, 1)
+	case cap(refs) <= len(refs)+1:
+		refs = slices.Grow(refs, 1)
+	}
+
+	refEntry := &ResponseRef{
+		Vary:         vary,
+		VaryResolved: varyResolved,
+		ReceivedAt:   respEntry.DateHeader(),
+		ResponseID:   responseID,
+	}
+
+	if refIndex < 0 || refIndex >= len(refs) {
+		refs = append(refs, refEntry) // New response reference
+	} else {
+		refs[refIndex] = refEntry // Update existing response reference
+	}
+
+	return r.cache.SetRefs(urlKey, refs)
+}

--- a/vendor/github.com/bartventer/httpcache/internal/urlkeyer.go
+++ b/vendor/github.com/bartventer/httpcache/internal/urlkeyer.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/url"
+
+	"github.com/bartventer/httpcache/pkg/urlkey"
+)
+
+// URLKeyer describes the interface implemented by types that can generate a
+// normalized cache key from a URL, following rules specified in RFC 3986 §6.
+type URLKeyer interface {
+	URLKey(u *url.URL) string
+}
+
+type URLKeyerFunc func(u *url.URL) string
+
+func (f URLKeyerFunc) URLKey(u *url.URL) string {
+	return f(u)
+}
+
+func NewURLKeyer() URLKeyer { return URLKeyerFunc(urlkey.Normalize) }

--- a/vendor/github.com/bartventer/httpcache/internal/urlutil/urlutil.go
+++ b/vendor/github.com/bartventer/httpcache/internal/urlutil/urlutil.go
@@ -1,0 +1,52 @@
+// Package urlutil provides utility functions for URL manipulation.
+package urlutil
+
+import "strings"
+
+func DefaultPort(scheme string) string {
+	switch scheme {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
+}
+
+// SplitHostPort separates host and port. If the port is not valid, it returns
+// the entire input as host, and it doesn't check the validity of the host.
+// Unlike net.SplitHostPort, but per RFC 3986, it requires ports to be numeric.
+//
+// From Go's net/url package.
+// Copyright 2009 The Go Authors. All rights reserved.
+func SplitHostPort(hostPort string) (host, port string) {
+	host = hostPort
+	colon := strings.LastIndexByte(host, ':')
+	if colon != -1 && validOptionalPort(host[colon:]) {
+		host, port = host[:colon], host[colon+1:]
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = host[1 : len(host)-1]
+	}
+	return
+}
+
+// validOptionalPort reports whether port is either an empty string or matches "/^:\d*$/".
+//
+// From Go's net/url package.
+// Copyright 2009 The Go Authors. All rights reserved.
+func validOptionalPort(port string) bool {
+	if port == "" {
+		return true
+	}
+	if port[0] != ':' {
+		return false
+	}
+	for _, b := range port[1:] {
+		if b < '0' || b > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/bartventer/httpcache/internal/validationresponsehandler.go
+++ b/vendor/github.com/bartventer/httpcache/internal/validationresponsehandler.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+	"time"
+)
+
+type ValidationResponseHandler interface {
+	HandleValidationResponse(
+		ctx RevalidationContext,
+		req *http.Request,
+		resp *http.Response,
+	) (*http.Response, error)
+}
+
+type RevalidationContext struct {
+	URLKey     string
+	Start, End time.Time
+	CCReq      CCRequestDirectives
+	Stored     *Response
+	Freshness  *Freshness
+	Refs       ResponseRefs
+	RefIndex   int
+}
+
+func (r RevalidationContext) ToMisc(ccResp CCResponseDirectives) MiscFunc {
+	return MiscFunc(func() Misc {
+		return Misc{
+			CCReq:     r.CCReq,
+			CCResp:    ccResp,
+			Stored:    r.Stored,
+			Freshness: r.Freshness,
+			Refs:      r.Refs,
+			RefIndex:  r.RefIndex,
+		}
+	})
+}
+
+type validationResponseHandler struct {
+	l     *Logger
+	clock Clock
+	ci    CacheInvalidator
+	ce    CacheabilityEvaluator
+	siep  StaleIfErrorPolicy
+	rs    ResponseStorer
+}
+
+func NewValidationResponseHandler(
+	dl *Logger,
+	clock Clock,
+	ci CacheInvalidator,
+	ce CacheabilityEvaluator,
+	siep StaleIfErrorPolicy,
+	rs ResponseStorer,
+) *validationResponseHandler {
+	return &validationResponseHandler{dl, clock, ci, ce, siep, rs}
+}
+
+func (r *validationResponseHandler) HandleValidationResponse(
+	ctx RevalidationContext,
+	req *http.Request,
+	resp *http.Response,
+) (*http.Response, error) {
+	if req.Method == http.MethodGet && resp.StatusCode == http.StatusNotModified {
+		// RFC 9111 §4.3.3 Handling Validation Responses (304 Not Modified)
+		// RFC 9111 §4.3.4 Freshening Stored Responses upon Validation
+		mergeResponseHeaders(ctx.Stored.Data, resp.Header)
+		_ = r.rs.StoreResponse(
+			req,
+			ctx.Stored.Data,
+			ctx.URLKey,
+			ctx.Refs,
+			ctx.Start,
+			ctx.End,
+			ctx.RefIndex,
+		)
+		CacheStatusRevalidated.ApplyTo(ctx.Stored.Data.Header)
+		r.l.LogCacheRevalidated(req, ctx.URLKey, ctx.ToMisc(nil))
+		return ctx.Stored.Data, nil
+	}
+
+	var (
+		ccResp     CCResponseDirectives
+		ccRespOnce bool
+	)
+	if isStaleErrorAllowed(resp.StatusCode) && req.Method == http.MethodGet {
+		ccResp = ParseCCResponseDirectives(resp.Header)
+		ccRespOnce = true
+		if r.siep.CanStaleOnError(ctx.Freshness, ccResp) {
+			// RFC 9111 §4.2.4 Serving Stale Responses
+			// RFC 9111 §4.3.3 Handling Validation Responses (5xx errors)
+			SetAgeHeader(ctx.Stored.Data, r.clock, ctx.Freshness.Age)
+			CacheStatusStale.ApplyTo(ctx.Stored.Data.Header)
+			r.l.LogCacheStaleIfError(req, ctx.URLKey, ctx.ToMisc(ccResp))
+			return ctx.Stored.Data, nil
+		}
+	}
+
+	if !ccRespOnce {
+		ccResp = ParseCCResponseDirectives(resp.Header)
+	}
+	switch {
+	case r.ce.CanStoreResponse(resp, ctx.CCReq, ccResp):
+		// RFC 9111 §4.3.3 Handling Validation Responses (full response)
+		// RFC 9111 §3.2 Storing Responses
+		_ = r.rs.StoreResponse(req, resp, ctx.URLKey, ctx.Refs, ctx.Start, ctx.End, ctx.RefIndex)
+		CacheStatusMiss.ApplyTo(resp.Header)
+		r.l.LogCacheMiss(req, ctx.URLKey, ctx.ToMisc(ccResp))
+	case IsUnsafeMethod(req.Method) && IsNonErrorStatus(resp.StatusCode):
+		// RFC 9111 §4.4 Invalidation of Cache Entries
+		r.ci.InvalidateCache(req.URL, resp.Header, ctx.Refs, ctx.URLKey)
+		fallthrough
+	default:
+		CacheStatusBypass.ApplyTo(resp.Header)
+		r.l.LogCacheBypass("Bypass; serving upstream response", req, ctx.URLKey, ctx.ToMisc(ccResp))
+	}
+	return resp, nil
+}

--- a/vendor/github.com/bartventer/httpcache/internal/varymatcher.go
+++ b/vendor/github.com/bartventer/httpcache/internal/varymatcher.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+)
+
+// VaryMatcher defines the interface implemented by types that can match
+// request headers nominated by a cached response's Vary header against
+// the headers of an incoming request.
+type VaryMatcher interface {
+	VaryHeadersMatch(cachedHdrs ResponseRefs, reqHdr http.Header) (int, bool)
+}
+
+func NewVaryMatcher(hvn HeaderValueNormalizer) *varyMatcher {
+	return &varyMatcher{hvn: hvn}
+}
+
+type varyMatcher struct {
+	hvn HeaderValueNormalizer
+}
+
+func (vm *varyMatcher) VaryHeadersMatch(entries ResponseRefs, reqHdr http.Header) (int, bool) {
+	slices.SortFunc(entries, func(a, b *ResponseRef) int {
+		aVary := strings.TrimSpace(a.Vary)
+		bVary := strings.TrimSpace(b.Vary)
+
+		// Responses with Vary: "*" are least preferred
+		switch aIsStar, bIsStar := aVary == "*", bVary == "*"; {
+		case aIsStar && !bIsStar:
+			return 1 // b preferred
+		case bIsStar && !aIsStar:
+			return -1 // a preferred
+		}
+
+		// Responses with Vary headers are preferred over those without
+		switch aHasVary, bHasVary := aVary != "", bVary != ""; {
+		case aHasVary && !bHasVary:
+			return -1 // a preferred
+		case !aHasVary && bHasVary:
+			return 1 // b preferred
+		}
+
+		// If both have Vary headers, sort by ReceivedAt (earliest first)
+		return a.ReceivedAt.Compare(b.ReceivedAt)
+	})
+
+	for i, entry := range entries {
+		if vm.varyHeadersMatchOne(entry, reqHdr) {
+			return i, true // Found a match
+		}
+	}
+
+	return -1, false // No match found
+}
+
+func (vm *varyMatcher) varyHeadersMatchOne(entry *ResponseRef, reqHeader http.Header) bool {
+	if entry.Vary == "*" {
+		return false // Vary: "*" never matches
+	}
+	for field, value := range entry.VaryResolved {
+		reqValues := reqHeader[field]
+		// an empty value is comparable and means "no variation"
+		reqValue := ""
+		if len(reqValues) > 0 {
+			// NOTE: The policy of this cache is to use just the first header line
+			reqValue = vm.hvn.NormalizeHeaderValue(field, reqValues[0])
+		}
+		if reqValue != value {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/bartventer/httpcache/options.go
+++ b/vendor/github.com/bartventer/httpcache/options.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpcache
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/bartventer/httpcache/internal"
+)
+
+type Option interface {
+	apply(*transport)
+}
+
+type optionFunc func(*transport)
+
+func (f optionFunc) apply(r *transport) {
+	f(r)
+}
+
+// WithUpstream sets the underlying [http.RoundTripper] used for upstream/origin
+// requests. Default: [http.DefaultTransport].
+//
+// Note: Headers added by the upstream roundtripper (e.g., authentication
+// headers) do not affect cache key calculation or Vary header matching
+// (RFC 9111 §4.1). The cache operates on the original client request, not the
+// mutated request seen by the upstream roundtripper.
+func WithUpstream(upstream http.RoundTripper) Option {
+	return optionFunc(func(r *transport) {
+		r.upstream = upstream
+	})
+}
+
+// WithSWRTimeout sets the timeout for Stale-While-Revalidate requests;
+// default: [DefaultSWRTimeout].
+func WithSWRTimeout(timeout time.Duration) Option {
+	return optionFunc(func(r *transport) {
+		r.swrTimeout = timeout
+	})
+}
+
+// WithLogger sets the logger for debug output; default:
+// [slog.New]([slog.DiscardHandler]).
+func WithLogger(logger *slog.Logger) Option {
+	return optionFunc(func(r *transport) {
+		if logger != nil {
+			r.logger = internal.NewLogger(logger.Handler())
+		}
+	})
+}

--- a/vendor/github.com/bartventer/httpcache/pkg/urlkey/urlkey.go
+++ b/vendor/github.com/bartventer/httpcache/pkg/urlkey/urlkey.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package urlkey derives stable cache-key strings from URLs by applying
+// pragmatic HTTP URL normalization.
+//
+// The normalization follows RFC 3986 equivalence guidance and HTTP URI rules
+// where applicable ([RFC 3986 §6.2], [RFC 7230 §2.7.3]). It is intended for cache
+// key generation, not as a full URI canonicalization framework.
+//
+// [RFC 3986 §6.2]: https://datatracker.ietf.org/doc/html/rfc3986#section-6.2
+// [RFC 7230 §2.7.3]: https://datatracker.ietf.org/doc/html/rfc7230#section-2.7.3
+package urlkey
+
+import (
+	"net/url"
+	"strings"
+	"unicode"
+
+	"github.com/bartventer/httpcache/internal/urlutil"
+)
+
+// Normalize returns a normalized URL string suitable for use as a cache key.
+//
+// It normalizes scheme/host case, default ports, dot-segments, and
+// percent-encoding (for path and query), and excludes fragments.
+//
+// For opaque URLs (u.Opaque != ""), the opaque value is returned unchanged.
+func Normalize(u *url.URL) string {
+	if u.Opaque != "" {
+		return u.Opaque
+	}
+	// RFC 3986 §6.2.2.3: Path normalization (dot-segment removal) is handled by
+	// [url.URL.ResolveReference], which uses the RFC 3986 §5.2.4 algorithm.
+	base, _ := url.Parse(u.Scheme + "://" + u.Host)
+	normalized := base.ResolveReference(u)
+
+	// RFC 3986 §6.2.2.1: Scheme is lowercased (already done by [url.Parse]).
+	scheme := normalized.Scheme
+
+	host, port := urlutil.SplitHostPort(normalized.Host)
+	defaultP := urlutil.DefaultPort(scheme)
+	if port == "" {
+		port = defaultP
+	}
+	// RFC 3986 §6.2.2.1: Host is lowercased.
+	hostPort := strings.ToLower(host)
+
+	// RFC 3986 §6.2.3: Only include port if it is non-default for the scheme.
+	if port != "" && port != defaultP {
+		hostPort = hostPort + ":" + port
+	}
+
+	// RFC 3986 §6.2.3: An empty path for http/https is normalized to "/".
+	// Also see https://datatracker.ietf.org/doc/html/rfc7230#section-2.7.3
+	path := normalized.EscapedPath()
+	if path == "" && (scheme == "http" || scheme == "https") {
+		path = "/"
+	}
+
+	// RFC 3986 §6.2.2.2: Normalize percent-encoding in path.
+	path = normalizePercentEncoding(path)
+	result := scheme + "://" + hostPort + path
+
+	// RFC 3986 §6.2.2.2: Normalize percent-encoding in query, if present.
+	if normalized.RawQuery != "" {
+		result += "?" + normalizePercentEncoding(normalized.RawQuery)
+	}
+
+	// RFC 3986 §6.1 Equivalence: "fragment components (if any) should be excluded from
+	// the comparison"
+	return result
+}
+
+// normalizePercentEncoding rewrites percent-encoded characters in a URL path or query
+// so that unreserved characters are decoded, and all hex digits are uppercase.
+// Follows RFC 3986 §6.2.2.2.
+func normalizePercentEncoding(s string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == '%' && i+2 < len(s) &&
+			isHexDigit(s[i+1]) && isHexDigit(s[i+2]) {
+			hexVal := fromHex(s[i+1])<<4 | fromHex(s[i+2])
+			r := rune(hexVal)
+			if isUnreserved(r) {
+				b.WriteRune(r)
+			} else {
+				b.WriteString(percentEncodeUpper(hexVal))
+			}
+			i += 3
+		} else {
+			b.WriteByte(s[i])
+			i++
+		}
+	}
+	return b.String()
+}
+
+func isHexDigit(c byte) bool {
+	return ('0' <= c && c <= '9') ||
+		('A' <= c && c <= 'F') ||
+		('a' <= c && c <= 'f')
+}
+
+func fromHex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
+}
+
+// isUnreserved reports whether r is an unreserved character per RFC 3986 §2.3.
+func isUnreserved(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) ||
+		r == '-' || r == '.' || r == '_' || r == '~'
+}
+
+const hex = "0123456789ABCDEF"
+
+// percentEncodeUpper returns the percent-encoded form of b using uppercase
+// hex digits as specified in RFC 3986 §2.1.
+func percentEncodeUpper(b byte) string {
+	return "%" + string(hex[b>>4]) + string(hex[b&0x0F])
+}

--- a/vendor/github.com/bartventer/httpcache/roundtripper.go
+++ b/vendor/github.com/bartventer/httpcache/roundtripper.go
@@ -1,0 +1,468 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httpcache provides an implementation of http.RoundTripper that adds
+// transparent HTTP response caching according to RFC 9111 (HTTP Caching).
+//
+// The main entry point is [NewTransport], which returns an [http.RoundTripper] for use with [http.Client].
+// httpcache supports the required standard HTTP caching directives, as well as extension directives such as
+// stale-while-revalidate, stale-if-error and immutable.
+//
+// Example usage:
+//
+//	package main
+//
+//	import (
+//		"log/slog"
+//		"net/http"
+//		"time"
+//
+//		"github.com/bartventer/httpcache"
+//
+//		// Register a cache backend by importing the package
+//		_ "github.com/bartventer/httpcache/store/fscache"
+//	)
+//
+//	func main() {
+//		dsn := "fscache://?appname=myapp" // Example DSN for the file system cache backend
+//		client := &http.Client{
+//			Transport: httpcache.NewTransport(
+//				dsn,
+//				httpcache.WithSWRTimeout(10*time.Second),
+//				httpcache.WithLogger(slog.Default()),
+//			),
+//		}
+//	}
+package httpcache
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"iter"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/bartventer/httpcache/internal"
+	"github.com/bartventer/httpcache/store"
+	"github.com/bartventer/httpcache/store/driver"
+)
+
+const (
+	DefaultSWRTimeout = 5 * time.Second
+
+	CacheStatusHeader = internal.CacheStatusHeader
+)
+
+// transport is an implementation of [http.RoundTripper] that caches HTTP responses
+// according to the HTTP caching rules defined in RFC 9111.
+type transport struct {
+	// Configurable options
+
+	cache      internal.ResponseCache // Cache for storing and retrieving responses
+	upstream   http.RoundTripper      // Underlying round tripper for upstream/origin requests
+	swrTimeout time.Duration          // Timeout for Stale-While-Revalidate requests
+	logger     *internal.Logger       // Logger for debug output, if needed
+
+	// Internal details
+
+	rmc   internal.RequestMethodChecker      // Checks if HTTP request methods are understood
+	vm    internal.VaryMatcher               // Matches Vary headers to determine cache validity
+	uk    internal.URLKeyer                  // Generates unique cache keys for requests
+	fc    internal.FreshnessCalculator       // Calculates the freshness of cached responses
+	ce    internal.CacheabilityEvaluator     // Evaluates if a response is cacheable
+	siep  internal.StaleIfErrorPolicy        // Handles stale-if-error caching policies
+	ci    internal.CacheInvalidator          // Invalidates cache entries based on conditions
+	rs    internal.ResponseStorer            // Stores HTTP responses in the cache
+	vrh   internal.ValidationResponseHandler // Processes validation responses for revalidation
+	clock internal.Clock                     // Provides time-related operations, can be mocked for testing
+}
+
+// ErrOpenCache is used as the panic value when the cache cannot be opened.
+// You may recover from this panic if you wish to handle the situation gracefully.
+//
+// Example usage:
+//
+//	defer func() {
+//		if r := recover(); r != nil {
+//			if err, ok := r.(error); ok && errors.Is(err, ErrOpenCache) {
+//				// Handle the error gracefully, e.g., log it or return a default transport
+//				log.Println("Failed to open cache:", err)
+//				client := &http.Client{
+//					Transport: http.DefaultTransport, // Fallback to default transport
+//				}
+//				// Use the fallback client as needed
+//				_ = client
+//			} else {
+//				// Re-panic if it's not the expected error
+//				panic(r)
+//			}
+//		}
+//	}()
+var ErrOpenCache = errors.New("httpcache: failed to open cache")
+
+// NewTransport returns an [http.RoundTripper] that caches HTTP responses using
+// the specified cache backend.
+//
+// The dsn parameter follows the format documented in [store.Open].
+// Configuration is done via functional options like [WithUpstream] and
+// [WithSWRTimeout].
+//
+// Panics with [ErrOpenCache] if the cache backend cannot be opened.
+func NewTransport(dsn string, options ...Option) http.RoundTripper {
+	cache, err := store.Open(dsn)
+	if err != nil {
+		panic(ErrOpenCache)
+	}
+	return newTransport(cache, options...)
+}
+
+func newTransport(conn driver.Conn, options ...Option) http.RoundTripper {
+	rt := &transport{
+		cache: internal.NewResponseCache(conn),
+		rmc:   internal.NewRequestMethodChecker(),
+		vm:    internal.NewVaryMatcher(internal.NewHeaderValueNormalizer()),
+		uk:    internal.NewURLKeyer(),
+		ce:    internal.NewCacheabilityEvaluator(),
+		clock: internal.NewClock(),
+	}
+
+	for _, opt := range options {
+		opt.apply(rt)
+	}
+	rt.upstream = cmp.Or(rt.upstream, http.DefaultTransport)
+	rt.swrTimeout = cmp.Or(max(rt.swrTimeout, 0), DefaultSWRTimeout)
+	if rt.logger == nil {
+		rt.logger = internal.NewLogger(slog.DiscardHandler)
+	}
+
+	rt.fc = internal.NewFreshnessCalculator(rt.clock)
+	rt.ci = internal.NewCacheInvalidator(rt.cache, rt.uk)
+	rt.siep = internal.NewStaleIfErrorPolicy(rt.clock)
+	rt.rs = internal.NewResponseStorer(
+		rt.cache,
+		internal.NewVaryHeaderNormalizer(),
+		internal.NewVaryKeyer(),
+	)
+	rt.vrh = internal.NewValidationResponseHandler(
+		rt.logger,
+		rt.clock,
+		rt.ci,
+		rt.ce,
+		rt.siep,
+		rt.rs,
+	)
+	return rt
+}
+
+// NewClient returns a new [http.Client], configured with a transport that
+// caches HTTP responses, using the specified cache backend DSN.
+//
+// See [NewTransport] for details on the DSN and available options.
+func NewClient(dsn string, options ...Option) *http.Client {
+	return &http.Client{Transport: NewTransport(dsn, options...)}
+}
+
+var _ http.RoundTripper = (*transport)(nil)
+
+func (r *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	urlKey := r.uk.URLKey(req.URL)
+
+	if !r.rmc.IsRequestMethodUnderstood(req) {
+		return r.handleUnrecognizedMethod(req, urlKey)
+	}
+
+	refs, err := r.cache.GetRefs(urlKey)
+	if err != nil || len(refs) == 0 {
+		return r.handleCacheMiss(req, urlKey, nil, -1)
+	}
+
+	refIndex, found := r.vm.VaryHeadersMatch(refs, req.Header)
+	if !found {
+		return r.handleCacheMiss(req, urlKey, refs, -1)
+	}
+
+	entry, err := r.cache.Get(refs[refIndex].ResponseID, req)
+	if err != nil {
+		r.logger.LogCacheError(
+			"Error retrieving cache entry; possible corruption.",
+			err,
+			req,
+			urlKey,
+			internal.MiscFunc(func() internal.Misc {
+				return internal.Misc{Refs: refs, RefIndex: refIndex}
+			}),
+		)
+		return r.handleCacheMiss(req, urlKey, refs, refIndex)
+	}
+
+	return r.handleCacheHit(req, entry, urlKey, refs, refIndex)
+}
+
+func (r *transport) handleUnrecognizedMethod(
+	req *http.Request,
+	urlKey string,
+) (*http.Response, error) {
+	if !internal.IsUnsafeMethod(req.Method) {
+		resp, err := r.upstream.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+		internal.CacheStatusBypass.ApplyTo(resp.Header)
+		r.logger.LogCacheBypass(
+			"Bypass; unrecognized (safe) method, served from upstream.",
+			req,
+			urlKey,
+			nil,
+		)
+		return resp, nil
+	}
+	resp, err := r.upstream.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if internal.IsNonErrorStatus(resp.StatusCode) {
+		refs, _ := r.cache.GetRefs(urlKey)
+		r.ci.InvalidateCache(req.URL, resp.Header, refs, urlKey)
+	}
+	internal.CacheStatusBypass.ApplyTo(resp.Header)
+	r.logger.LogCacheBypass(
+		"Bypass; unrecognized (unsafe) method, served from upstream.",
+		req,
+		urlKey,
+		nil,
+	)
+	return resp, nil
+}
+
+func (r *transport) handleCacheMiss(
+	req *http.Request,
+	urlKey string,
+	refs internal.ResponseRefs,
+	refIndex int,
+) (*http.Response, error) {
+	ccReq := internal.ParseCCRequestDirectives(req.Header)
+	if ccReq.OnlyIfCached() {
+		r.logger.LogCacheMiss(
+			req,
+			urlKey,
+			internal.MiscFunc(func() internal.Misc {
+				return internal.Misc{
+					CCReq:    ccReq,
+					Refs:     refs,
+					RefIndex: refIndex,
+				}
+			}),
+		)
+		return make504Response(req)
+	}
+	resp, start, end, err := r.roundTripTimed(req)
+	if err != nil {
+		return nil, err
+	}
+	ccResp := internal.ParseCCResponseDirectives(resp.Header)
+	if r.ce.CanStoreResponse(resp, ccReq, ccResp) {
+		_ = r.rs.StoreResponse(req, resp, urlKey, refs, start, end, refIndex)
+	}
+	internal.CacheStatusMiss.ApplyTo(resp.Header)
+	r.logger.LogCacheMiss(req, urlKey, internal.MiscFunc(func() internal.Misc {
+		return internal.Misc{
+			CCReq:    ccReq,
+			CCResp:   ccResp,
+			Refs:     refs,
+			RefIndex: refIndex,
+		}
+	}))
+	return resp, nil
+}
+
+//nolint:cyclop // The complexity of this function is justified by the need to handle multiple caching scenarios according to RFC 9111.
+func (r *transport) handleCacheHit(
+	req *http.Request,
+	stored *internal.Response,
+	urlKey string,
+	refs internal.ResponseRefs,
+	refIndex int,
+) (*http.Response, error) {
+	ccReq := internal.ParseCCRequestDirectives(req.Header)
+	ccResp := internal.ParseCCResponseDirectives(stored.Data.Header)
+	freshness := r.fc.CalculateFreshness(stored, ccReq, ccResp)
+	respNoCacheFieldsRaw, hasRespNoCache := ccResp.NoCache()
+	respNoCacheFieldsSeq, isRespNoCacheQualified := respNoCacheFieldsRaw.Value()
+
+	// RFC 8246: If response is fresh and immutable, always serve from cache unless request has no-cache
+	if !freshness.IsStale && ccResp.Immutable() && !ccReq.NoCache() {
+		return r.serveFromCache(
+			req,
+			urlKey,
+			stored,
+			freshness,
+			isRespNoCacheQualified,
+			respNoCacheFieldsSeq,
+		)
+	}
+
+	if (freshness.IsStale && ccResp.MustRevalidate()) ||
+		(hasRespNoCache && !isRespNoCacheQualified) { // Unqualified no-cache: must revalidate before serving from cache
+		goto revalidate
+	}
+
+	if ccReq.OnlyIfCached() || (!freshness.IsStale && !ccReq.NoCache()) {
+		return r.serveFromCache(
+			req,
+			urlKey,
+			stored,
+			freshness,
+			isRespNoCacheQualified,
+			respNoCacheFieldsSeq,
+		)
+	}
+
+	if swr, swrValid := ccResp.StaleWhileRevalidate(); freshness.IsStale && swrValid {
+		age := freshness.Age.Value + r.clock.Since(freshness.Age.Timestamp)
+		staleFor := age - freshness.UsefulLife
+		if staleFor >= 0 && staleFor < swr {
+			return r.handleStaleWhileRevalidate(req, stored, urlKey, freshness, ccReq)
+		}
+	}
+
+revalidate:
+	req = withConditionalHeaders(req, stored.Data.Header)
+	resp, start, end, err := r.roundTripTimed(req)
+	if err != nil {
+		return nil, err
+	}
+	ctx := internal.RevalidationContext{
+		URLKey:    urlKey,
+		Start:     start,
+		End:       end,
+		CCReq:     ccReq,
+		Stored:    stored,
+		Refs:      refs,
+		RefIndex:  refIndex,
+		Freshness: freshness,
+	}
+	return r.vrh.HandleValidationResponse(ctx, req, resp)
+}
+
+func (r *transport) serveFromCache(
+	req *http.Request,
+	urlKey string,
+	stored *internal.Response,
+	freshness *internal.Freshness,
+	noCacheQualified bool,
+	noCacheFieldsSeq iter.Seq[string],
+) (*http.Response, error) {
+	if noCacheQualified {
+		//Qualified no-cache: may serve from cache with fields stripped
+		for field := range noCacheFieldsSeq {
+			stored.Data.Header.Del(field)
+		}
+	}
+	internal.SetAgeHeader(stored.Data, r.clock, freshness.Age)
+	internal.CacheStatusHit.ApplyTo(stored.Data.Header)
+	r.logger.LogCacheHit(req, urlKey, internal.MiscFunc(func() internal.Misc {
+		return internal.Misc{
+			Stored:    stored,
+			Freshness: freshness,
+		}
+	}))
+	return stored.Data, nil
+}
+
+// handleStaleWhileRevalidate serves a stale cached response immediately and triggers
+// background revalidation in a separate goroutine (RFC 5861, §3).
+func (r *transport) handleStaleWhileRevalidate(
+	req *http.Request,
+	stored *internal.Response,
+	urlKey string,
+	freshness *internal.Freshness,
+	ccReq internal.CCRequestDirectives,
+) (*http.Response, error) {
+	req2 := req.Clone(req.Context())
+	req2 = withConditionalHeaders(req2, stored.Data.Header)
+	// Background revalidation is "best effort"; it is not guaranteed to complete
+	// if the program exits before the goroutine finishes. This design choice was
+	// made to keep the API simple and avoid requiring explicit shutdown coordination.
+	//
+	// Open a discussion at github.com/bartventer/httpcache/issues if your use case requires
+	// guaranteed completion.
+	go r.backgroundRevalidate(req2, stored, urlKey, freshness, ccReq)
+	internal.CacheStatusStale.ApplyTo(stored.Data.Header)
+	r.logger.LogCacheStaleRevalidate(req, urlKey, internal.MiscFunc(func() internal.Misc {
+		return internal.Misc{
+			CCReq:     ccReq,
+			Stored:    stored,
+			Freshness: freshness,
+		}
+	}))
+	return stored.Data, nil
+}
+
+func (r *transport) backgroundRevalidate(
+	req *http.Request,
+	stored *internal.Response,
+	urlKey string,
+	freshness *internal.Freshness,
+	ccReq internal.CCRequestDirectives,
+) {
+	ctx, cancel := context.WithTimeout(req.Context(), r.swrTimeout)
+	defer cancel()
+	req = req.WithContext(ctx)
+	errc := make(chan error, 1)
+	go func() {
+		defer close(errc)
+		//nolint:bodyclose // The response is not used, so we don't need to close it.
+		resp, start, end, err := r.roundTripTimed(req)
+		if err != nil {
+			errc <- err
+			return
+		}
+		select {
+		case <-req.Context().Done():
+			errc <- req.Context().Err()
+			return
+		default:
+		}
+		revalCtx := internal.RevalidationContext{
+			URLKey:    urlKey,
+			Start:     start,
+			End:       end,
+			CCReq:     ccReq,
+			Stored:    stored,
+			Freshness: freshness,
+		}
+		//nolint:bodyclose // The response is not used, so we don't need to close it.
+		_, err = r.vrh.HandleValidationResponse(revalCtx, req, resp)
+		errc <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-errc:
+	}
+}
+
+func (r *transport) roundTripTimed(
+	req *http.Request,
+) (resp *http.Response, start, end time.Time, err error) {
+	start = r.clock.Now()
+	resp, err = r.upstream.RoundTrip(req)
+	end = r.clock.Now()
+	if resp != nil {
+		_ = internal.FixDateHeader(resp.Header, end)
+	}
+	return
+}

--- a/vendor/github.com/bartventer/httpcache/store/cache.go
+++ b/vendor/github.com/bartventer/httpcache/store/cache.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package store provides a registry and entry point for cache backends.
+//
+// This package allows you to register cache drivers and open cache connections
+// using a DSN string. It acts as a facade over the internal registry and the
+// driver interfaces defined in the [driver] subpackage.
+//
+// Most users won't interact with this package directly, but will instead use it
+// indirectly through higher-level caching abstractions.
+// For more details on registering drivers and opening connections, see the
+// documentation for the [Register] and [Open] functions.
+package store
+
+import (
+	"github.com/bartventer/httpcache/store/driver"
+	"github.com/bartventer/httpcache/store/internal/registry"
+)
+
+// Register makes a driver implementation available by the provided name (e.g.,
+// "memcache", "fscache", etc.). The name corresponds to the scheme component of
+// a DSN string used in [Open] to identify the driver to use.
+// If Register is called twice with the same name or if driver is nil, it
+// panics.
+func Register(name string, driver driver.Driver) {
+	registry.Default().RegisterDriver(name, driver)
+}
+
+// Open establishes a connection to a registered driver, as specified in the
+// provided DSN string.
+//
+// The DSN (Data Source Name) format follows the pattern:
+//
+//	scheme://[path]?[query_parameters]
+//
+// Where:
+//   - scheme: The name of the registered driver (e.g., "memcache", "fscache",
+//     etc.).
+//   - path: An optional path component that can be used by the driver for
+//     configuration.
+//   - query_parameters: Optional key-value pairs for additional driver-
+//     specific settings.
+//
+// See [Register] for registering drivers.
+func Open(dsn string) (driver.Conn, error) {
+	return registry.Default().OpenConn(dsn)
+}
+
+// Drivers returns a sorted list of the names of the registered drivers.
+func Drivers() []string {
+	return registry.Default().Drivers()
+}

--- a/vendor/github.com/bartventer/httpcache/store/driver/driver.go
+++ b/vendor/github.com/bartventer/httpcache/store/driver/driver.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package driver defines interfaces to be implemented by cache backends
+// as used by the github.com/bartventer/httpcache/store package.
+//
+// # Implementing a Cache Backend
+//
+// To implement a custom cache backend, provide a type that implements the [Conn] interface.
+//
+// The [Driver] interface is used to create a [Conn] from a URL.
+//
+// The URL scheme determines which driver is used.
+//
+// Implementations must be safe for concurrent use by multiple goroutines.
+// Example implementations can be found in sub-packages such as store/memcache
+// and store/fscache.
+package driver
+
+import (
+	"errors"
+	"net/url"
+)
+
+// ErrNotExist is returned when a cache entry does not exist.
+//
+// Methods such as [Cache.Get] and [Cache.Delete] should return an error
+// that satisfies errors.Is(err, store.ErrNotExist) if the entry is not found.
+var ErrNotExist = errors.New("driver: entry does not exist")
+
+// Driver is the interface implemented by cache backends that can create a [Conn]
+// from a URL. The URL scheme determines which driver is used.
+type Driver interface {
+	Open(u *url.URL) (Conn, error)
+}
+
+type DriverFunc func(u *url.URL) (Conn, error)
+
+func (f DriverFunc) Open(u *url.URL) (Conn, error) {
+	return f(u)
+}
+
+// Conn describes the interface implemented by types that provide
+// a connection to a cache backend. It allows for basic operations such as
+// getting, setting, and deleting cache entries by key.
+type Conn interface {
+	// Get retrieves the cached value for the given key.
+	// If the key does not exist, it should return an error satisfying
+	// errors.Is(err, store.ErrNotExist).
+	Get(key string) ([]byte, error)
+
+	// Set stores the value for the given key.
+	// If the key already exists, it should overwrite the existing value.
+	Set(key string, value []byte) error
+
+	// Delete removes the cached value for the given key.
+	// If the key does not exist, it should return an error satisfying
+	// errors.Is(err, store.ErrNotExist).
+	Delete(key string) error
+}

--- a/vendor/github.com/bartventer/httpcache/store/internal/registry/registry.go
+++ b/vendor/github.com/bartventer/httpcache/store/internal/registry/registry.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registry provides a registry for cache drivers.
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"net/url"
+	"slices"
+	"sync"
+
+	"github.com/bartventer/httpcache/store/driver"
+)
+
+var ErrUnknownDriver = errors.New("store: unknown driver")
+
+type driverRegistry struct {
+	mu      sync.RWMutex
+	drivers map[string]driver.Driver
+}
+
+func (dr *driverRegistry) RegisterDriver(name string, driver driver.Driver) {
+	dr.mu.Lock()
+	defer dr.mu.Unlock()
+	if driver == nil {
+		panic("store: Register driver is nil")
+	}
+	if _, dup := dr.drivers[name]; dup {
+		panic("store: Register called twice for driver " + name)
+	}
+	dr.drivers[name] = driver
+}
+
+func (dr *driverRegistry) OpenConn(dsn string) (driver.Conn, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	dr.mu.RLock()
+	driver, ok := dr.drivers[u.Scheme]
+	dr.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownDriver, u.Scheme)
+	}
+
+	return driver.Open(u)
+}
+
+func (dr *driverRegistry) Drivers() []string {
+	dr.mu.RLock()
+	defer dr.mu.RUnlock()
+	return slices.Sorted(maps.Keys(dr.drivers))
+}
+
+var defaultRegistry = New()
+
+func Default() *driverRegistry {
+	return defaultRegistry
+}
+
+func New() *driverRegistry {
+	return &driverRegistry{drivers: make(map[string]driver.Driver)}
+}

--- a/vendor/github.com/bartventer/httpcache/store/memcache/memcache.go
+++ b/vendor/github.com/bartventer/httpcache/store/memcache/memcache.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Bart Venter <72999113+bartventer@users.noreply.github.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package memcache implements an in-memory cache backend.
+//
+// It is suitable for testing or ephemeral caching needs, but does not persist data
+// across process restarts.
+package memcache
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sync"
+
+	"github.com/bartventer/httpcache/store"
+	"github.com/bartventer/httpcache/store/driver"
+)
+
+const Scheme = "memcache"
+
+//nolint:gochecknoinits // We use init to register the driver.
+func init() {
+	store.Register(Scheme, driver.DriverFunc(func(u *url.URL) (driver.Conn, error) {
+		return Open(), nil
+	}))
+}
+
+type memCache struct {
+	mu    sync.RWMutex
+	store map[string][]byte
+}
+
+// Open creates a new in-memory cache.
+//
+// This cache is not persistent and will lose all data when the process exits.
+func Open() *memCache {
+	return &memCache{
+		store: make(map[string][]byte),
+	}
+}
+
+var _ driver.Conn = (*memCache)(nil)
+
+func (c *memCache) Get(key string) ([]byte, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	val, ok := c.store[key]
+	if !ok {
+		return nil, errors.Join(
+			driver.ErrNotExist,
+			fmt.Errorf("memcache: key %q does not exist", key),
+		)
+	}
+	// Return a copy to prevent mutation
+	cp := make([]byte, len(val))
+	copy(cp, val)
+	return cp, nil
+}
+
+func (c *memCache) Set(key string, value []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Store a copy to prevent external mutation
+	cp := make([]byte, len(value))
+	copy(cp, value)
+	c.store[key] = cp
+	return nil
+}
+
+func (c *memCache) Delete(key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.store[key]; !ok {
+		return errors.Join(
+			driver.ErrNotExist,
+			fmt.Errorf("memcache: key %q does not exist", key),
+		)
+	}
+	delete(c.store, key)
+	return nil
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/fileutil/copy.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/fileutil/copy.go
@@ -156,6 +156,11 @@ func (fm fileManager) lchown(path string, uid, gid int) error {
 }
 
 // copyOwner invokes lchown to copy ownership from srcInfo to dstPath.
+// Ownership is preserved best effort: only root may chown a file to another
+// user, so a non-root copier gets EPERM whenever the source is owned by
+// someone else (e.g. a build artifact written by a root container) — after the
+// content was already copied. Such a copy succeeds owned by the caller
+// instead of failing.
 func (fm fileManager) copyOwner(srcInfo os.FileInfo, dstPath string) error {
 	if runtime.GOOS == "windows" {
 		return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,13 @@
+# github.com/bartventer/httpcache v0.14.0
+## explicit; go 1.25
+github.com/bartventer/httpcache
+github.com/bartventer/httpcache/internal
+github.com/bartventer/httpcache/internal/urlutil
+github.com/bartventer/httpcache/pkg/urlkey
+github.com/bartventer/httpcache/store
+github.com/bartventer/httpcache/store/driver
+github.com/bartventer/httpcache/store/internal/registry
+github.com/bartventer/httpcache/store/memcache
 # github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
 ## explicit
 github.com/bitrise-io/colorstring


### PR DESCRIPTION
[STEP-2404](https://bitrise.atlassian.net/browse/STEP-2404)

Stepman was refetching the same StepLib inventory JSON (e.g. step_ids.json, 12.3KB) on every single step activation. This PR adds an in-memory HTTP cache for those inventory reads, cutting redundant requests.
The API publishes real cache headers, so the cache follows them instead of picking a TTL.

httpfetch.NewClients returns two clients that share one retryablehttp client, and therefore one connection pool.

```
retryablehttp.Client        (owns the pool)
  ├─ Passthrough  → uncached
  └─ Caching  → cacheSuccessesOnly → httpcache transport → same pool
```


[STEP-2404]: https://bitrise.atlassian.net/browse/STEP-2404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ